### PR TITLE
Publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,14 +12,14 @@ jobs:
       # publish to pypi
       - if: github.event_name == 'release'
         name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.16
+        uses: JRubics/poetry-publish@v1
         with:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
           plugins: "poetry-dynamic-versioning-plugin"
       # publish to testpypi
       - if: github.event_name != 'release'
         name: Build and publish to testpypi
-        uses: JRubics/poetry-publish@v1.16
+        uses: JRubics/poetry-publish@v1
         with:
           repository_name: "testpypi"
           repository_url: "https://test.pypi.org/legacy/"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,27 @@
+name: Publish ixmp4
+on:
+  push:
+    tags: ["v*"]
+  release:
+    types: ["published"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # publish to pypi
+      - if: github.event_name == 'release'
+        name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.16
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          plugins: "poetry-dynamic-versioning-plugin"
+      # publish to testpypi
+      - if: github.event_name != 'release'
+        name: Build and publish to testpypi
+        uses: JRubics/poetry-publish@v1.16
+        with:
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"
+          pypi_token: ${{ secrets.TESTPYPI_TOKEN }}
+          plugins: "poetry-dynamic-versioning-plugin"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -83,6 +83,9 @@ source ~/.bashrc
 # Activate in-project virtualenvs
 poetry config virtualenvs.in-project true
 
+# Add dynamic versioning plugin
+poetry self add "poetry-dynamic-versioning[plugin]"
+
 # Install dependencies
 # (using "--with docs" if docs dependencies should be installed as well)
 poetry install --with docs,server,dev

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -284,3 +284,37 @@ Optionally, supply POETRY_OPTS:
 ```bash
 docker build --build-arg POETRY_OPTS="--with docs,dev" -t ixmp4-docs:latest .
 ```
+
+## Version number
+
+This package uses the poetry-dynamic-versioning plugin to generate a version number
+either out of a tag or a current revision.
+
+For this reason the version number is *intentionally* set to 0.0.0 in `pyproject.toml`.
+
+It is overwritten on the fly by the poetry-dynamic-versioning plugin.
+
+## Release procedure
+
+1. Before releasing, check that the "pytest" GitHub action on the current "main" branch
+   passes. Address any failures before releasing.
+1. Test on your local machine if the build runs by running `python -m build --sdist
+  --wheel --outdir dist/`. Fix any packaging issues or errors by creating a PR.
+
+1. Tag the release candidate (RC) version on the main branch as v<release version>rc<N>
+  and push to upstream:
+
+  ```console
+  git tag v<release version>rc<N>>
+  git push upstream v<release version>rc<N>
+  ```
+
+1. Check that the GitHub action "Publish ixmp4" was executed correctly and that the
+   release candidate was successfully uploaded to TestPyPI. The address will be
+   https://test.pypi.org/project/imxp4/<release version>rc<N>. E.g.:
+   <https://test.pypi.org/project/imxp4/0.2.0rc1/>
+1. Visit https://github.com/iiasa/ixmp4/releases and mark the new release by creating
+   the tag and release simultaneously. The name of the tag is v<release version>
+   (without the rc<N>).
+1. Check that the "Publish to PyPI and TestPyPI" GitHub action passed and that the
+  distributions are published on https://pypi.org/project/ixmp4/ .

--- a/README.md
+++ b/README.md
@@ -15,11 +15,23 @@ in the domain of integrated assessment of climate change and energy systems mode
 
 The **ixmp4** package is released under the [MIT license](https://github.com/iiasa/ixmp4/blob/main/LICENSE).
 
-## Requirements
+## Install from pypi
+
+You can install ixmp4 using pip:
+
+```console
+pip install ixmp4
+```
+
+## Install from GitHub
+
+For installing the latest version directly from GitHub do the following.
+
+### Requirements
 
 This project requires Python 3.10 and poetry (>= 1.2).
 
-## Setup
+### Setup
 
 ```bash
 # Install Poetry, minimum version >=1.2 required
@@ -30,6 +42,9 @@ source ~/.bashrc
 
 # Activate in-project virtualenvs
 poetry config virtualenvs.in-project true
+
+# Add dynamic versioning plugin
+poetry self add "poetry-dynamic-versioning[plugin]"
 
 # Install dependencies
 # (using "--with dev,docs,server" if dev and docs dependencies should be installed as well)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     "Philip Hackstock <hackstock@iiasa.ac.at>",
 ]
 name = "ixmp4"
-version = "0.1.0"
+version = "0.0.0"
 description = "a data warehouse for scenario analysis"
 license = "MIT"
 readme = "README.md"
@@ -72,8 +72,8 @@ snakeviz = "^2.1.1"
 ixmp4 = "ixmp4.__main__:app"
 
 [build-system]
-build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core>=1.2.0"]
+build-backend = "poetry_dynamic_versioning.backend"
+requires = ["poetry-core>=1.2.0", "poetry-dynamic-versioning"]
 
 [tool.mypy]
 exclude = [
@@ -110,3 +110,9 @@ exclude = [
     'example.py',
     'import.py',
 ]
+
+[tool.poetry-dynamic-versioning]
+bump = true
+enable = true
+style = "pep440"
+vcs = "git"


### PR DESCRIPTION
This PR adds an automated workflow for pushing to (test)-pypi.
There are two triggers for the publish workflow:

1. Publish to pypi when a release is created on GitHub
2. Publish to test-pypi when a tag with `v*` is pushed

I've set configured it so that the two events are **mutually** exclusive. To avoid double running the workflow since the release on GitHub goes along with pushing a tag.

I have also included the poetry dynamic versioning plugin (equivalent to setuptools_scm).

Any input for changes to the README or DEVELOPING are welcome.