### PR TITLE
Checking credentials only when needed

### DIFF
--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
         try:
             return self.credentials.get("default")
         except KeyError:
-            logger.warning("No default credentials provided.")
+            pass
 
     @property
     def toml(self):

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -88,10 +88,11 @@ class Settings(BaseSettings):
         self._credentials = Credentials(credentials_config)
 
     def get_auth(self):
-        default_credentials = self.default_credentials
-        if default_credentials is not None:
+        if self.default_credentials is not None:
             try:
-                self._default_auth = ManagerAuth(*default_credentials, self.manager_url)
+                self._default_auth = ManagerAuth(
+                    *self.default_credentials, self.manager_url
+                )
                 logger.info(
                     f"Connecting as user '{self._default_auth.get_user().username}'."
                 )

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -97,6 +97,7 @@ class Settings(BaseSettings):
                 logger.warning(f"Invalid credentials for {self.manager_url}.")
             except ConnectError:
                 logger.warning(f"Unable to connect to {self.manager_url}.")
+                return
 
         self._default_auth = AnonymousAuth()
 
@@ -106,8 +107,11 @@ class Settings(BaseSettings):
         )
 
     def load_toml_config(self):
-        toml_user = self.default_auth.get_user()
-        if not toml_user.is_authenticated:
+        if self.default_auth is not None:
+            toml_user = self.default_auth.get_user()
+            if not toml_user.is_authenticated:
+                toml_user = local_user
+        else:  # if no connection to manager
             toml_user = local_user
 
         toml_config = self.storage_directory / "platforms.toml"

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -47,16 +47,22 @@ class Settings(BaseSettings):
         self.configure_logging(self.mode)
 
         self._credentials = None
+        self._toml = None
 
         self.get_auth()
         self.load_manager_config()
-        self.load_toml_config()
 
     @property
     def credentials(self):
         if self._credentials is None:
             self.load_credentials()
         return self._credentials
+
+    @property
+    def toml(self):
+        if self._toml is None:
+            self.load_toml_config()
+        return self._toml
 
     def load_credentials(self):
         credentials_config = self.storage_directory / "credentials.toml"
@@ -99,7 +105,7 @@ class Settings(BaseSettings):
 
         toml_config = self.storage_directory / "platforms.toml"
         toml_config.touch()
-        self.toml = TomlConfig(toml_config, toml_user)
+        self._toml = TomlConfig(toml_config, toml_user)
 
     @validator("storage_directory")
     def expand_user(cls, v):

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -46,15 +46,24 @@ class Settings(BaseSettings):
 
         self.configure_logging(self.mode)
 
-        self.load_credentials()
+        self._credentials = None
+
+        self.get_auth()
         self.load_manager_config()
         self.load_toml_config()
+
+    @property
+    def credentials(self):
+        if self._credentials is None:
+            self.load_credentials()
+        return self._credentials
 
     def load_credentials(self):
         credentials_config = self.storage_directory / "credentials.toml"
         credentials_config.touch()
-        self.credentials = Credentials(credentials_config)
+        self._credentials = Credentials(credentials_config)
 
+    def get_auth(self):
         self.default_credentials = None
         self.default_auth = None
         try:

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -92,14 +92,16 @@ class Settings(BaseSettings):
         if default_credentials is not None:
             try:
                 self._default_auth = ManagerAuth(*default_credentials, self.manager_url)
-                return
+                logger.info(
+                    f"Connecting as user '{self._default_auth.get_user().username}'."
+                )
             except InvalidCredentials:
                 logger.warning(f"Invalid credentials for {self.manager_url}.")
             except ConnectError:
                 logger.warning(f"Unable to connect to {self.manager_url}.")
-                return
 
-        self._default_auth = AnonymousAuth()
+        else:
+            self._default_auth = AnonymousAuth()
 
     def load_manager_config(self):
         self._manager = ManagerConfig(

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -94,9 +94,7 @@ class Settings(BaseSettings):
                 self._default_auth = ManagerAuth(*default_credentials, self.manager_url)
                 return
             except InvalidCredentials:
-                logger.warning(
-                    "Failure while requesting management service authentication: Invalid credentials."
-                )
+                logger.warning(f"Invalid credentials for {self.manager_url}.")
             except ConnectError:
                 logger.warning(f"Unable to connect to {self.manager_url}.")
 


### PR DESCRIPTION
Working on the ixmp4-pyam integration, I noticed that ixmp4 immediately (tries to) connect to the IIASA-ScSe-Manager, resulting in a log output like
<img width="1066" alt="image" src="https://github.com/iiasa/ixmp4/assets/16931589/3480503f-02fe-4fdc-b03b-ba639c03ed8b">

This can be confusing to pyam-only-users, so this PR changes the order so that the credentials are only loaded when needed.
