### PR TITLE
Include isort

### DIFF
--- a/ixmp4/__init__.py
+++ b/ixmp4/__init__.py
@@ -1,23 +1,17 @@
 # flake8: noqa
 import importlib.metadata
 
-from ixmp4.core import (
-    Platform as Platform,
-    Region as Region,
-    Unit as Unit,
-    Run as Run,
-    Variable as Variable,
-    Model as Model,
-    Scenario as Scenario,
-)
-
-from ixmp4.core.exceptions import (
-    NotFound as NotFound,
-    NotUnique as NotUnique,
-    IxmpError as IxmpError,
-    InconsistentIamcType as InconsistentIamcType,
-)
-
+from ixmp4.core import Model as Model
+from ixmp4.core import Platform as Platform
+from ixmp4.core import Region as Region
+from ixmp4.core import Run as Run
+from ixmp4.core import Scenario as Scenario
+from ixmp4.core import Unit as Unit
+from ixmp4.core import Variable as Variable
+from ixmp4.core.exceptions import InconsistentIamcType as InconsistentIamcType
+from ixmp4.core.exceptions import IxmpError as IxmpError
+from ixmp4.core.exceptions import NotFound as NotFound
+from ixmp4.core.exceptions import NotUnique as NotUnique
 from ixmp4.data.abstract import DataPoint as DataPoint
 
 __version__ = importlib.metadata.version("ixmp4")

--- a/ixmp4/cli/__init__.py
+++ b/ixmp4/cli/__init__.py
@@ -11,15 +11,15 @@ Check the CLI help command on how to use it:
 """
 
 from typing import Optional
+
 import typer
 
-
-from ixmp4.core.exceptions import InvalidCredentials
-from ixmp4.conf.auth import ManagerAuth
-from ixmp4.conf import settings
 from ixmp4.cli import platforms
-from . import utils
+from ixmp4.conf import settings
+from ixmp4.conf.auth import ManagerAuth
+from ixmp4.core.exceptions import InvalidCredentials
 
+from . import utils
 
 app = typer.Typer()
 app.add_typer(platforms.app, name="platforms")

--- a/ixmp4/cli/server.py
+++ b/ixmp4/cli/server.py
@@ -1,12 +1,12 @@
-from typing import Optional
 import json
+from typing import Optional
 
-import uvicorn  # type: ignore[import]
 import typer
-
+import uvicorn  # type: ignore[import]
 from fastapi.openapi.utils import get_openapi
-from ixmp4.server import v1
+
 from ixmp4.conf import settings
+from ixmp4.server import v1
 
 from . import utils
 

--- a/ixmp4/cli/utils.py
+++ b/ixmp4/cli/utils.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 import typer
 
 echo = typer.echo

--- a/ixmp4/conf/__init__.py
+++ b/ixmp4/conf/__init__.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+
 from ixmp4.conf.settings import Settings
 
 load_dotenv()

--- a/ixmp4/conf/auth.py
+++ b/ixmp4/conf/auth.py
@@ -1,6 +1,6 @@
 import logging
-from uuid import uuid4
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 import httpx
 import jwt

--- a/ixmp4/conf/base.py
+++ b/ixmp4/conf/base.py
@@ -1,4 +1,5 @@
 from typing import Protocol
+
 import pydantic
 
 

--- a/ixmp4/conf/credentials.py
+++ b/ixmp4/conf/credentials.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from pathlib import Path
+
 import toml
 
 

--- a/ixmp4/conf/manager.py
+++ b/ixmp4/conf/manager.py
@@ -1,18 +1,18 @@
 import enum
-import httpx
-import re
-import os
 import logging
+import os
+import re
 from functools import lru_cache
 
+import httpx
 import pandas as pd
 from pydantic import Field
 
-from ixmp4.core.exceptions import PlatformNotFound, ManagerApiError
+from ixmp4.core.exceptions import ManagerApiError, PlatformNotFound
 
 from .auth import BaseAuth
-from .user import User
 from .base import Config, PlatformInfo
+from .user import User
 
 logger = logging.getLogger(__name__)
 

--- a/ixmp4/conf/toml.py
+++ b/ixmp4/conf/toml.py
@@ -1,12 +1,13 @@
+import json
 from pathlib import Path
 from typing import Any
+
 import toml
-import json
 
 from ixmp4.core.exceptions import PlatformNotFound, PlatformNotUnique
 
-from .user import User
 from .base import Config, PlatformInfo
+from .user import User
 
 
 class TomlPlatformInfo(PlatformInfo):

--- a/ixmp4/core/base.py
+++ b/ixmp4/core/base.py
@@ -1,5 +1,5 @@
-from ixmp4.data.backend import Backend
 from ixmp4.data.abstract import BaseModel
+from ixmp4.data.backend import Backend
 
 
 class BaseFacade(object):

--- a/ixmp4/core/decorators.py
+++ b/ixmp4/core/decorators.py
@@ -1,4 +1,5 @@
 import functools
+
 import pandera as pa
 from pandera.errors import SchemaError as PanderaSchemaError
 

--- a/ixmp4/core/exceptions.py
+++ b/ixmp4/core/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, ClassVar
+from typing import ClassVar, Dict
 
 registry: dict = dict()
 

--- a/ixmp4/core/iamc/variable.py
+++ b/ixmp4/core/iamc/variable.py
@@ -1,10 +1,11 @@
-from typing import Iterable, ClassVar
-
 from datetime import datetime
+from typing import ClassVar, Iterable
+
 import pandas as pd
 
-from ixmp4.data.abstract import Variable as VariableModel, Docs as DocsModel
-from ixmp4.core.base import BaseModelFacade, BaseFacade
+from ixmp4.core.base import BaseFacade, BaseModelFacade
+from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Variable as VariableModel
 
 
 class Variable(BaseModelFacade):

--- a/ixmp4/core/model.py
+++ b/ixmp4/core/model.py
@@ -1,10 +1,11 @@
-from typing import Iterable, ClassVar
-
 from datetime import datetime
+from typing import ClassVar, Iterable
+
 import pandas as pd
 
-from ixmp4.data.abstract import Model as ModelModel, Docs as DocsModel
-from ixmp4.core.base import BaseModelFacade, BaseFacade
+from ixmp4.core.base import BaseFacade, BaseModelFacade
+from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Model as ModelModel
 
 
 class Model(BaseModelFacade):

--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -30,15 +30,16 @@ from functools import partial
 from ixmp4.conf import settings
 from ixmp4.conf.auth import BaseAuth
 from ixmp4.core.exceptions import PlatformNotFound
-from ixmp4.data.backend import SqlAlchemyBackend, RestBackend, Backend
+from ixmp4.data.backend import Backend, RestBackend, SqlAlchemyBackend
 
-from .run import Run as RunModel, RunRepository
+from .iamc import IamcRepository
+from .meta import MetaRepository
 from .model import ModelRepository
+from .region import RegionRepository
+from .run import Run as RunModel
+from .run import RunRepository
 from .scenario import ScenarioRepository
 from .unit import UnitRepository
-from .region import RegionRepository
-from .meta import MetaRepository
-from .iamc import IamcRepository
 
 
 class Platform(object):

--- a/ixmp4/core/region.py
+++ b/ixmp4/core/region.py
@@ -1,9 +1,12 @@
-from typing import Iterable, Optional, Union
 from datetime import datetime
+from typing import Iterable, Optional, Union
+
 import pandas as pd
 
-from ixmp4.data.abstract import Region as RegionModel, Docs as DocsModel
-from .base import BaseModelFacade, BaseFacade
+from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Region as RegionModel
+
+from .base import BaseFacade, BaseModelFacade
 
 
 class Region(BaseModelFacade):

--- a/ixmp4/core/scenario.py
+++ b/ixmp4/core/scenario.py
@@ -1,10 +1,11 @@
-from typing import Iterable, ClassVar
-
 from datetime import datetime
+from typing import ClassVar, Iterable
+
 import pandas as pd
 
-from ixmp4.data.abstract import Scenario as ScenarioModel, Docs as DocsModel
-from ixmp4.core.base import BaseModelFacade, BaseFacade
+from ixmp4.core.base import BaseFacade, BaseModelFacade
+from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Scenario as ScenarioModel
 
 
 class Scenario(BaseModelFacade):

--- a/ixmp4/core/unit.py
+++ b/ixmp4/core/unit.py
@@ -1,9 +1,11 @@
-from typing import Iterable
 from datetime import datetime
+from typing import Iterable
+
 import pandas as pd
 
-from ixmp4.data.abstract import Unit as UnitModel, Docs as DocsModel
-from ixmp4.core.base import BaseModelFacade, BaseFacade
+from ixmp4.core.base import BaseFacade, BaseModelFacade
+from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Unit as UnitModel
 
 
 def to_dimensionless(name):

--- a/ixmp4/data/abstract/base.py
+++ b/ixmp4/data/abstract/base.py
@@ -1,8 +1,8 @@
-from typing import Protocol, Iterable, _ProtocolMeta, ClassVar
+from typing import ClassVar, Iterable, Protocol, _ProtocolMeta
 
 import pandas as pd
 
-from ixmp4.core.exceptions import IxmpError, NotUnique, NotFound, DeletionPrevented
+from ixmp4.core.exceptions import DeletionPrevented, IxmpError, NotFound, NotUnique
 from ixmp4.data import types
 
 

--- a/ixmp4/data/abstract/docs.py
+++ b/ixmp4/data/abstract/docs.py
@@ -1,7 +1,8 @@
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
+
+from ixmp4.data import types
 
 from . import base
-from ixmp4.data import types
 
 
 class Docs(base.BaseModel, Protocol):

--- a/ixmp4/data/abstract/iamc/__init__.py
+++ b/ixmp4/data/abstract/iamc/__init__.py
@@ -1,11 +1,8 @@
 # flake8: noqa
-from .variable import Variable, VariableRepository
-from .measurand import Measurand, MeasurandRepository
-from .timeseries import TimeSeries, TimeSeriesRepository
-from .datapoint import (
+from .datapoint import (  # AnnualDataPoint,; SubAnnualDataPoint,; CategoricalDataPoint,
     DataPoint,
-    #    AnnualDataPoint,
-    #    SubAnnualDataPoint,
-    #    CategoricalDataPoint,
     DataPointRepository,
 )
+from .measurand import Measurand, MeasurandRepository
+from .timeseries import TimeSeries, TimeSeriesRepository
+from .variable import Variable, VariableRepository

--- a/ixmp4/data/abstract/iamc/datapoint.py
+++ b/ixmp4/data/abstract/iamc/datapoint.py
@@ -1,9 +1,10 @@
 import enum
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
 
 import pandas as pd
 
 from ixmp4.data import types
+
 from .. import base
 
 

--- a/ixmp4/data/abstract/iamc/measurand.py
+++ b/ixmp4/data/abstract/iamc/measurand.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
 
 import pandas as pd
 

--- a/ixmp4/data/abstract/iamc/timeseries.py
+++ b/ixmp4/data/abstract/iamc/timeseries.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Iterable, Mapping, TypeVar, Generic
+from typing import Generic, Iterable, Mapping, Protocol, TypeVar
 
 import pandas as pd
 

--- a/ixmp4/data/abstract/meta.py
+++ b/ixmp4/data/abstract/meta.py
@@ -1,12 +1,12 @@
 from enum import Enum
-from typing import Iterable, Protocol, ClassVar
+from typing import ClassVar, Iterable, Protocol
 
 import pandas as pd
-from pydantic import StrictBool, StrictInt, StrictFloat, StrictStr
+from pydantic import StrictBool, StrictFloat, StrictInt, StrictStr
 
 from ixmp4.data import types
-from . import base
 
+from . import base
 
 # as long as all of these are `Strict` the order does not matter
 StrictMetaValue = StrictBool | StrictInt | StrictFloat | StrictStr

--- a/ixmp4/data/abstract/model.py
+++ b/ixmp4/data/abstract/model.py
@@ -1,11 +1,11 @@
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
 
 import pandas as pd
 
-from .docs import DocsRepository
-
 from ixmp4.data import types
+
 from . import base
+from .docs import DocsRepository
 
 
 class Model(base.BaseModel, Protocol):

--- a/ixmp4/data/abstract/region.py
+++ b/ixmp4/data/abstract/region.py
@@ -1,7 +1,9 @@
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
+
 import pandas as pd
 
 from ixmp4.data import types
+
 from . import base
 from .docs import DocsRepository
 

--- a/ixmp4/data/abstract/scenario.py
+++ b/ixmp4/data/abstract/scenario.py
@@ -1,12 +1,11 @@
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
 
 import pandas as pd
 
-
-from .docs import DocsRepository
-
 from ixmp4.data import types
+
 from . import base
+from .docs import DocsRepository
 
 
 class Scenario(base.BaseModel, Protocol):

--- a/ixmp4/data/abstract/unit.py
+++ b/ixmp4/data/abstract/unit.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Iterable
+from typing import Iterable, Protocol
 
 import pandas as pd
 

--- a/ixmp4/data/api/docs.py
+++ b/ixmp4/data/api/docs.py
@@ -1,6 +1,7 @@
-from typing import Iterable, Type, ClassVar
+from typing import ClassVar, Iterable, Type
 
 from ixmp4.data import abstract
+
 from . import base
 
 

--- a/ixmp4/data/api/iamc/__init__.py
+++ b/ixmp4/data/api/iamc/__init__.py
@@ -1,11 +1,8 @@
 # flake8: noqa
 
-from .timeseries import TimeSeries, TimeSeriesRepository
-from .datapoint import (
+from .datapoint import (  # AnnualDataPoint,; SubAnnualDataPoint,; CategoricalDataPoint,
     DataPoint,
-    #    AnnualDataPoint,
-    #    SubAnnualDataPoint,
-    #    CategoricalDataPoint,
     DataPointRepository,
 )
+from .timeseries import TimeSeries, TimeSeriesRepository
 from .variable import Variable, VariableRepository

--- a/ixmp4/data/api/iamc/datapoint.py
+++ b/ixmp4/data/api/iamc/datapoint.py
@@ -1,9 +1,10 @@
-from typing import Iterable, ClassVar
 from datetime import datetime
+from typing import ClassVar, Iterable
 
 import pandas as pd
 
 from ixmp4.data import abstract
+
 from .. import base
 
 

--- a/ixmp4/data/api/iamc/timeseries.py
+++ b/ixmp4/data/api/iamc/timeseries.py
@@ -1,8 +1,9 @@
-from typing import Iterable, Mapping, ClassVar
+from typing import ClassVar, Iterable, Mapping
 
 import pandas as pd
 
 from ixmp4.data import abstract
+
 from .. import base
 
 

--- a/ixmp4/data/api/meta.py
+++ b/ixmp4/data/api/meta.py
@@ -1,8 +1,9 @@
-from typing import Iterable, ClassVar
+from typing import ClassVar, Iterable
 
 import pandas as pd
 
 from ixmp4.data import abstract
+
 from . import base
 
 

--- a/ixmp4/data/api/model.py
+++ b/ixmp4/data/api/model.py
@@ -1,9 +1,10 @@
-from typing import Iterable, ClassVar
 from datetime import datetime
+from typing import ClassVar, Iterable
 
 import pandas as pd
 
 from ixmp4.data import abstract
+
 from . import base
 from .docs import Docs, DocsRepository
 

--- a/ixmp4/data/api/region.py
+++ b/ixmp4/data/api/region.py
@@ -1,8 +1,10 @@
-from typing import Iterable, ClassVar
 from datetime import datetime
+from typing import ClassVar, Iterable
+
 import pandas as pd
 
 from ixmp4.data import abstract
+
 from . import base
 from .docs import Docs, DocsRepository
 

--- a/ixmp4/data/api/run.py
+++ b/ixmp4/data/api/run.py
@@ -1,8 +1,9 @@
-from typing import Iterable, ClassVar
+from typing import ClassVar, Iterable
 
 import pandas as pd
 
 from ixmp4.data import abstract
+
 from . import base
 from .model import Model
 from .scenario import Scenario

--- a/ixmp4/data/api/scenario.py
+++ b/ixmp4/data/api/scenario.py
@@ -1,11 +1,12 @@
-from typing import Iterable, ClassVar
 from datetime import datetime
+from typing import ClassVar, Iterable
 
 import pandas as pd
 
 from ixmp4.data import abstract
-from .docs import DocsRepository, Docs
+
 from . import base
+from .docs import Docs, DocsRepository
 
 
 class Scenario(base.BaseModel):

--- a/ixmp4/data/api/unit.py
+++ b/ixmp4/data/api/unit.py
@@ -1,10 +1,12 @@
-from typing import Iterable, ClassVar
 from datetime import datetime
+from typing import ClassVar, Iterable
+
 import pandas as pd
 
 from ixmp4.data import abstract
-from .docs import Docs, DocsRepository
+
 from . import base
+from .docs import Docs, DocsRepository
 
 
 class Unit(base.BaseModel):

--- a/ixmp4/data/auth/context.py
+++ b/ixmp4/data/auth/context.py
@@ -1,12 +1,12 @@
 import re
+
 import pandas as pd
 
 from ixmp4 import db
-from ixmp4.db import utils
-from ixmp4.data.db import Model
-
-from ixmp4.conf.user import User
 from ixmp4.conf.manager import ManagerConfig, ManagerPlatformInfo
+from ixmp4.conf.user import User
+from ixmp4.data.db import Model
+from ixmp4.db import utils
 
 
 class AuthorizationContext(object):

--- a/ixmp4/data/auth/decorators.py
+++ b/ixmp4/data/auth/decorators.py
@@ -1,7 +1,7 @@
 from functools import wraps
-from typing import Protocol, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Protocol
 
-from ixmp4.core.exceptions import ProgrammingError, Forbidden
+from ixmp4.core.exceptions import Forbidden, ProgrammingError
 
 if TYPE_CHECKING:
     from ..backend.db import SqlAlchemyBackend

--- a/ixmp4/data/backend/__init__.py
+++ b/ixmp4/data/backend/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
-from .base import Backend
 from .api import RestBackend, RestTestBackend
+from .base import Backend
 from .db import SqlAlchemyBackend, SqliteTestBackend

--- a/ixmp4/data/db/docs.py
+++ b/ixmp4/data/db/docs.py
@@ -1,6 +1,6 @@
 from typing import ClassVar, Iterable, TypeVar
-import pandas as pd
 
+import pandas as pd
 from sqlalchemy.exc import NoResultFound
 
 from ixmp4 import db

--- a/ixmp4/data/db/iamc/base.py
+++ b/ixmp4/data/db/iamc/base.py
@@ -1,15 +1,15 @@
 # flake8: noqa
+from ..base import BaseModel as RootBaseModel
 from ..base import (
-    BaseModel as RootBaseModel,
-    Retriever,
+    BulkDeleter,
+    BulkUpserter,
     Creator,
     Deleter,
-    Selecter,
-    Lister,
-    Tabulator,
     Enumerator,
-    BulkUpserter,
-    BulkDeleter,
+    Lister,
+    Retriever,
+    Selecter,
+    Tabulator,
 )
 
 

--- a/ixmp4/data/db/iamc/datapoint/filter.py
+++ b/ixmp4/data/db/iamc/datapoint/filter.py
@@ -1,14 +1,13 @@
-from ixmp4.db import utils, filters
-
-from ixmp4.data.db.iamc.variable import Variable
-from ixmp4.data.db.iamc.timeseries import TimeSeries
-from ixmp4.data.db.iamc.measurand import Measurand
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
-from ixmp4.data.db.unit import Unit
-from ixmp4.data.db.region import Region
+from ixmp4.data.db.iamc.measurand import Measurand
+from ixmp4.data.db.iamc.timeseries import TimeSeries
+from ixmp4.data.db.iamc.variable import Variable
 from ixmp4.data.db.model import Model
-from ixmp4.data.db.scenario import Scenario
+from ixmp4.data.db.region import Region
 from ixmp4.data.db.run import Run
+from ixmp4.data.db.scenario import Scenario
+from ixmp4.data.db.unit import Unit
+from ixmp4.db import filters, utils
 
 
 class RegionFilter(filters.BaseFilter, metaclass=filters.FilterMeta):

--- a/ixmp4/data/db/iamc/measurand.py
+++ b/ixmp4/data/db/iamc/measurand.py
@@ -1,16 +1,16 @@
-from typing import Iterable, ClassVar
-import pandas as pd
+from typing import ClassVar, Iterable
 
+import pandas as pd
 from sqlalchemy.exc import NoResultFound
 
 from ixmp4 import db
 from ixmp4.data import types
-from ixmp4.data.auth.decorators import guard
 from ixmp4.data.abstract import iamc as abstract
+from ixmp4.data.auth.decorators import guard
 
+from ..unit import Unit
 from . import base
 from .variable import Variable
-from ..unit import Unit
 
 
 class Measurand(base.BaseModel):

--- a/ixmp4/data/db/iamc/timeseries.py
+++ b/ixmp4/data/db/iamc/timeseries.py
@@ -1,29 +1,25 @@
-from typing import Any, Mapping, Iterable
+from typing import Any, Iterable, Mapping
 
-import pandas as pd
 import numpy as np
-
+import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.orm import Bundle
 
 from ixmp4 import db
-from ixmp4.db import utils
-from ixmp4.data import types, abstract
+from ixmp4.data import abstract, types
 from ixmp4.data.auth.decorators import guard
 from ixmp4.data.db.iamc.measurand import Measurand
+from ixmp4.db import utils
 
-from ..timeseries import (
-    TimeSeries as BaseTimeSeries,
-    TimeSeriesRepository as BaseTimeSeriesRepository,
-)
+from ..region import Region, RegionRepository
+from ..run import RunRepository
+from ..timeseries import TimeSeries as BaseTimeSeries
+from ..timeseries import TimeSeriesRepository as BaseTimeSeriesRepository
+from ..unit import Unit, UnitRepository
 from ..utils import map_existing
-
 from . import base
 from .measurand import MeasurandRepository
 from .variable import Variable
-from ..run import RunRepository
-from ..unit import Unit, UnitRepository
-from ..region import Region, RegionRepository
 
 
 class TimeSeries(BaseTimeSeries, base.BaseModel):

--- a/ixmp4/data/db/iamc/variable/filter.py
+++ b/ixmp4/data/db/iamc/variable/filter.py
@@ -1,10 +1,10 @@
-from ixmp4.db import filters, utils
+from ixmp4.data.db import filters as base
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
 from ixmp4.data.db.iamc.timeseries import TimeSeries
-from ixmp4.data.db import filters as base
+from ixmp4.db import filters, utils
 
-from . import Variable
 from ..measurand import Measurand
+from . import Variable
 
 
 class VariableFilter(base.VariableFilter, metaclass=filters.FilterMeta):

--- a/ixmp4/data/db/iamc/variable/repository.py
+++ b/ixmp4/data/db/iamc/variable/repository.py
@@ -3,8 +3,8 @@ from typing import Iterable
 import pandas as pd
 
 from ixmp4 import db
-from ixmp4.data.auth.decorators import guard
 from ixmp4.data.abstract import iamc as abstract
+from ixmp4.data.auth.decorators import guard
 
 from .. import base
 from .docs import VariableDocsRepository

--- a/ixmp4/data/db/meta.py
+++ b/ixmp4/data/db/meta.py
@@ -1,19 +1,16 @@
-from typing import Optional, Iterable, Union, ClassVar, cast
+from typing import ClassVar, Iterable, Optional, Union, cast
 
-import pandera as pa
 import pandas as pd
+import pandera as pa
 from pandera.typing import DataFrame, Series
-
 from sqlalchemy.exc import NoResultFound
 
 from ixmp4 import db
-from ixmp4.data import abstract, types
-from ixmp4.data.db.run import Run
-from ixmp4.data.db.model import Model
-from ixmp4.core.exceptions import (
-    InvalidRunMeta,
-)
 from ixmp4.core.decorators import check_types
+from ixmp4.core.exceptions import InvalidRunMeta
+from ixmp4.data import abstract, types
+from ixmp4.data.db.model import Model
+from ixmp4.data.db.run import Run
 
 from ..auth.decorators import guard
 from . import base

--- a/ixmp4/data/db/model/__init__.py
+++ b/ixmp4/data/db/model/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
+from .docs import ModelDocsRepository
 from .model import Model
 from .repository import ModelRepository
-from .docs import ModelDocsRepository

--- a/ixmp4/data/db/model/docs.py
+++ b/ixmp4/data/db/model/docs.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from ixmp4.data import abstract
 
 from .. import base
-from ..docs import docs_model, BaseDocsRepository
+from ..docs import BaseDocsRepository, docs_model
 from .model import Model
 
 ModelDocs = docs_model(Model)

--- a/ixmp4/data/db/model/filter.py
+++ b/ixmp4/data/db/model/filter.py
@@ -1,11 +1,11 @@
 from typing import Optional, Union
 
 from ixmp4 import db
-from ixmp4.db import filters, utils
+from ixmp4.data.db import filters as base
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
 from ixmp4.data.db.iamc.timeseries import TimeSeries
 from ixmp4.data.db.run.model import Run
-from ixmp4.data.db import filters as base
+from ixmp4.db import filters, utils
 
 from . import Model
 

--- a/ixmp4/data/db/model/repository.py
+++ b/ixmp4/data/db/model/repository.py
@@ -7,8 +7,8 @@ from ixmp4.data import abstract
 from ixmp4.data.auth.decorators import guard
 
 from .. import base
-from .model import Model
 from .docs import ModelDocsRepository
+from .model import Model
 
 
 class ModelRepository(

--- a/ixmp4/data/db/region/__init__.py
+++ b/ixmp4/data/db/region/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
+from .docs import RegionDocsRepository
 from .model import Region
 from .repository import RegionRepository
-from .docs import RegionDocsRepository

--- a/ixmp4/data/db/region/docs.py
+++ b/ixmp4/data/db/region/docs.py
@@ -3,9 +3,9 @@ from typing import Iterable
 from ixmp4.data import abstract
 from ixmp4.data.auth.decorators import guard
 
-from ..docs import docs_model, BaseDocsRepository
-from .model import Region
 from .. import base
+from ..docs import BaseDocsRepository, docs_model
+from .model import Region
 
 RegionDocs = docs_model(Region)
 

--- a/ixmp4/data/db/region/filter.py
+++ b/ixmp4/data/db/region/filter.py
@@ -1,10 +1,10 @@
 from typing import Optional, Union
 
 from ixmp4 import db
-from ixmp4.db import filters, utils
+from ixmp4.data.db import filters as base
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
 from ixmp4.data.db.iamc.timeseries import TimeSeries
-from ixmp4.data.db import filters as base
+from ixmp4.db import filters, utils
 
 from . import Region
 

--- a/ixmp4/data/db/region/repository.py
+++ b/ixmp4/data/db/region/repository.py
@@ -1,15 +1,14 @@
 from typing import Iterable
 
 import pandas as pd
-
 from sqlalchemy.exc import NoResultFound
 
 from ixmp4.data import abstract
 from ixmp4.data.auth.decorators import guard
 
 from .. import base
-from .model import Region
 from .docs import RegionDocsRepository
+from .model import Region
 
 
 class RegionRepository(

--- a/ixmp4/data/db/run/filter.py
+++ b/ixmp4/data/db/run/filter.py
@@ -1,5 +1,5 @@
-from ixmp4.db import filters
 from ixmp4.data.db import filters as base
+from ixmp4.db import filters
 
 
 class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):

--- a/ixmp4/data/db/run/repository.py
+++ b/ixmp4/data/db/run/repository.py
@@ -1,18 +1,17 @@
 from typing import Iterable
 
 import pandas as pd
-
 from sqlalchemy.exc import NoResultFound
 
 from ixmp4 import db
-from ixmp4.db import utils
+from ixmp4.core.exceptions import Forbidden, IxmpError, NoDefaultRunVersion
 from ixmp4.data import abstract
 from ixmp4.data.auth.decorators import guard
-from ixmp4.core.exceptions import IxmpError, NoDefaultRunVersion, Forbidden
+from ixmp4.db import utils
 
+from .. import base
 from ..model import Model, ModelRepository
 from ..scenario import Scenario, ScenarioRepository
-from .. import base
 from .model import Run
 
 

--- a/ixmp4/data/db/scenario/__init__.py
+++ b/ixmp4/data/db/scenario/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
+from .docs import ScenarioDocsRepository
 from .model import Scenario
 from .repository import ScenarioRepository
-from .docs import ScenarioDocsRepository

--- a/ixmp4/data/db/scenario/docs.py
+++ b/ixmp4/data/db/scenario/docs.py
@@ -1,4 +1,4 @@
-from ..docs import docs_model, BaseDocsRepository
+from ..docs import BaseDocsRepository, docs_model
 from .model import Scenario
 
 

--- a/ixmp4/data/db/scenario/filter.py
+++ b/ixmp4/data/db/scenario/filter.py
@@ -1,11 +1,11 @@
 from typing import Optional, Union
 
 from ixmp4 import db
-from ixmp4.db import filters, utils
+from ixmp4.data.db import filters as base
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
 from ixmp4.data.db.iamc.timeseries import TimeSeries
 from ixmp4.data.db.run.model import Run
-from ixmp4.data.db import filters as base
+from ixmp4.db import filters, utils
 
 from .model import Scenario
 

--- a/ixmp4/data/db/scenario/model.py
+++ b/ixmp4/data/db/scenario/model.py
@@ -1,7 +1,7 @@
 from typing import ClassVar
 
-from ixmp4.data import abstract, types
 from ixmp4 import db
+from ixmp4.data import abstract, types
 
 from .. import base
 

--- a/ixmp4/data/db/timeseries.py
+++ b/ixmp4/data/db/timeseries.py
@@ -1,15 +1,14 @@
-from typing import Any, Iterable, Mapping, TypeVar, Generic, ClassVar
+from typing import Any, ClassVar, Generic, Iterable, Mapping, TypeVar
 
 import pandas as pd
-
+from sqlalchemy.ext.declarative import AbstractConcreteBase
 from sqlalchemy.orm.decl_api import declared_attr
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.ext.declarative import AbstractConcreteBase
 
 from ixmp4 import db
 from ixmp4.data import abstract
-from ixmp4.data.db.run import Run
 from ixmp4.data.db.model import Model
+from ixmp4.data.db.run import Run
 
 from ..auth.decorators import guard
 from . import base

--- a/ixmp4/data/db/unit/__init__.py
+++ b/ixmp4/data/db/unit/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
+from .docs import UnitDocs, UnitDocsRepository
 from .model import Unit
 from .repository import UnitRepository
-from .docs import UnitDocs, UnitDocsRepository

--- a/ixmp4/data/db/unit/docs.py
+++ b/ixmp4/data/db/unit/docs.py
@@ -4,7 +4,7 @@ from ixmp4.data import abstract
 from ixmp4.data.auth.decorators import guard
 
 from .. import base
-from ..docs import docs_model, BaseDocsRepository
+from ..docs import BaseDocsRepository, docs_model
 from .model import Unit
 
 UnitDocs = docs_model(Unit)

--- a/ixmp4/data/db/unit/filter.py
+++ b/ixmp4/data/db/unit/filter.py
@@ -1,11 +1,11 @@
 from typing import Optional, Union
 
 from ixmp4 import db
-from ixmp4.db import filters, utils
-from ixmp4.data.db.iamc.datapoint import get_datapoint_model
-from ixmp4.data.db.iamc.timeseries import TimeSeries
-from ixmp4.data.db.iamc.measurand import Measurand
 from ixmp4.data.db import filters as base
+from ixmp4.data.db.iamc.datapoint import get_datapoint_model
+from ixmp4.data.db.iamc.measurand import Measurand
+from ixmp4.data.db.iamc.timeseries import TimeSeries
+from ixmp4.db import filters, utils
 
 from . import Unit
 

--- a/ixmp4/data/db/unit/model.py
+++ b/ixmp4/data/db/unit/model.py
@@ -1,7 +1,7 @@
 from typing import ClassVar
 
-from ixmp4.data import abstract, types
 from ixmp4 import db
+from ixmp4.data import abstract, types
 
 from .. import base
 

--- a/ixmp4/db/migrations/versions/c71efc396d2b_initial_migration.py
+++ b/ixmp4/db/migrations/versions/c71efc396d2b_initial_migration.py
@@ -6,9 +6,8 @@ Revises:
 Create Date: 2023-04-26 15:37:46.677955
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # Revision identifiers, used by Alembic.
 revision = "c71efc396d2b"

--- a/ixmp4/db/utils/__init__.py
+++ b/ixmp4/db/utils/__init__.py
@@ -1,7 +1,8 @@
 from contextlib import suppress
-from sqlalchemy import sql, inspect
-from sqlalchemy.sql import ColumnCollection
+
+from sqlalchemy import inspect, sql
 from sqlalchemy.orm import Mapper
+from sqlalchemy.sql import ColumnCollection
 
 from ixmp4.core.exceptions import ProgrammingError
 

--- a/ixmp4/db/utils/alembic.py
+++ b/ixmp4/db/utils/alembic.py
@@ -1,9 +1,8 @@
-from sqlalchemy import create_engine
-from alembic.script import ScriptDirectory
+from alembic import command
 from alembic.config import Config
 from alembic.migration import MigrationContext
-from alembic import command
-
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine
 
 alembic_config = Config("alembic.ini")
 

--- a/ixmp4/db/utils/sqlite.py
+++ b/ixmp4/db/utils/sqlite.py
@@ -1,5 +1,5 @@
-from typing import Generator
 from pathlib import Path
+from typing import Generator
 
 from ixmp4.conf import settings
 

--- a/ixmp4/server/__init__.py
+++ b/ixmp4/server/__init__.py
@@ -12,6 +12,7 @@ This will start ixmp4’s asgi server. Check
 """
 
 from fastapi import FastAPI
+
 from .rest import v1
 
 app = FastAPI()

--- a/ixmp4/server/rest/deps.py
+++ b/ixmp4/server/rest/deps.py
@@ -1,19 +1,15 @@
 import logging
-from typing import Callable, AsyncGenerator
+from typing import AsyncGenerator, Callable
 
 import jwt
-from fastapi import Path, Header, Depends
+from fastapi import Depends, Header, Path
 
-from ixmp4.data.backend.db import SqlAlchemyBackend
 from ixmp4.conf import settings
-from ixmp4.conf.user import local_user, anonymous_user, User
-from ixmp4.conf.manager import ManagerConfig
 from ixmp4.conf.auth import SelfSignedAuth
-from ixmp4.core.exceptions import (
-    InvalidToken,
-    Forbidden,
-    PlatformNotFound,
-)
+from ixmp4.conf.manager import ManagerConfig
+from ixmp4.conf.user import User, anonymous_user, local_user
+from ixmp4.core.exceptions import Forbidden, InvalidToken, PlatformNotFound
+from ixmp4.data.backend.db import SqlAlchemyBackend
 
 logger = logging.getLogger(__name__)
 manager = ManagerConfig(settings.manager_url, SelfSignedAuth(settings.secret_hs256))

--- a/ixmp4/server/rest/docs.py
+++ b/ixmp4/server/rest/docs.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Path, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 
 from . import deps
 from .base import BaseModel

--- a/ixmp4/server/rest/iamc/__init__.py
+++ b/ixmp4/server/rest/iamc/__init__.py
@@ -1,1 +1,1 @@
-from . import model, region, timeseries, datapoint, variable
+from . import datapoint, model, region, timeseries, variable

--- a/ixmp4/server/rest/iamc/datapoint.py
+++ b/ixmp4/server/rest/iamc/datapoint.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.core.exceptions import BadRequest
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.iamc.datapoint.filter import DataPointFilter
 
 from .. import deps

--- a/ixmp4/server/rest/iamc/datapoint.py
+++ b/ixmp4/server/rest/iamc/datapoint.py
@@ -1,14 +1,13 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.core.exceptions import BadRequest
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.iamc.datapoint.filter import DataPointFilter
-from ..decorators import autodoc
 
 from .. import deps
 from ..base import BaseModel
-
+from ..decorators import autodoc
 
 router: APIRouter = APIRouter(
     prefix="/datapoints",

--- a/ixmp4/server/rest/iamc/model.py
+++ b/ixmp4/server/rest/iamc/model.py
@@ -1,11 +1,11 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
+from ixmp4.data import api
 from ixmp4.data.backend import Backend
 from ixmp4.data.db.model.filter import IamcModelFilter
-from ixmp4.data import api
 
-from ..base import BaseModel
 from .. import deps
+from ..base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/models",

--- a/ixmp4/server/rest/iamc/model.py
+++ b/ixmp4/server/rest/iamc/model.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.model.filter import IamcModelFilter
 
 from .. import deps

--- a/ixmp4/server/rest/iamc/region.py
+++ b/ixmp4/server/rest/iamc/region.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.region.filter import IamcRegionFilter, SimpleIamcRegionFilter
 
 from .. import deps

--- a/ixmp4/server/rest/iamc/region.py
+++ b/ixmp4/server/rest/iamc/region.py
@@ -1,11 +1,11 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
-from ixmp4.data.backend import Backend
-from ixmp4.data.db.region.filter import SimpleIamcRegionFilter, IamcRegionFilter
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
+from ixmp4.data.db.region.filter import IamcRegionFilter, SimpleIamcRegionFilter
 
-from ..base import BaseModel
 from .. import deps
+from ..base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/regions",

--- a/ixmp4/server/rest/iamc/scenario.py
+++ b/ixmp4/server/rest/iamc/scenario.py
@@ -1,11 +1,11 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
+from ixmp4.data import api
 from ixmp4.data.backend import Backend
 from ixmp4.data.db.scenario.filter import IamcScenarioFilter
-from ixmp4.data import api
 
-from ..base import BaseModel
 from .. import deps
+from ..base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/scenarios",

--- a/ixmp4/server/rest/iamc/scenario.py
+++ b/ixmp4/server/rest/iamc/scenario.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.scenario.filter import IamcScenarioFilter
 
 from .. import deps

--- a/ixmp4/server/rest/iamc/timeseries.py
+++ b/ixmp4/server/rest/iamc/timeseries.py
@@ -3,7 +3,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Query, Request, Response
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 
 from .. import deps
 from ..base import BaseModel

--- a/ixmp4/server/rest/iamc/timeseries.py
+++ b/ixmp4/server/rest/iamc/timeseries.py
@@ -1,11 +1,12 @@
 from typing import Any
-from fastapi import APIRouter, Depends, Query, Response, Request
 
-from ixmp4.data.backend import Backend
+from fastapi import APIRouter, Depends, Query, Request, Response
+
 from ixmp4.data import api
-from ..base import BaseModel
-from .. import deps
+from ixmp4.data.backend import Backend
 
+from .. import deps
+from ..base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/timeseries",

--- a/ixmp4/server/rest/iamc/unit.py
+++ b/ixmp4/server/rest/iamc/unit.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.unit.filter import IamcUnitFilter, SimpleIamcUnitFilter
 
 from .. import deps

--- a/ixmp4/server/rest/iamc/unit.py
+++ b/ixmp4/server/rest/iamc/unit.py
@@ -1,11 +1,11 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
-from ixmp4.data.backend import Backend
-from ixmp4.data.db.unit.filter import SimpleIamcUnitFilter, IamcUnitFilter
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
+from ixmp4.data.db.unit.filter import IamcUnitFilter, SimpleIamcUnitFilter
 
-from ..base import BaseModel
 from .. import deps
+from ..base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/units",

--- a/ixmp4/server/rest/iamc/variable.py
+++ b/ixmp4/server/rest/iamc/variable.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.iamc.variable.filter import VariableFilter
 
 from .. import deps

--- a/ixmp4/server/rest/iamc/variable.py
+++ b/ixmp4/server/rest/iamc/variable.py
@@ -1,13 +1,12 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.iamc.variable.filter import VariableFilter
 
 from .. import deps
-from ..decorators import autodoc
 from ..base import BaseModel
-
+from ..decorators import autodoc
 
 router: APIRouter = APIRouter(
     prefix="/variables",

--- a/ixmp4/server/rest/meta.py
+++ b/ixmp4/server/rest/meta.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Path, Query
 
 from ixmp4.data import abstract, api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 
 from . import deps
 from .base import BaseModel

--- a/ixmp4/server/rest/meta.py
+++ b/ixmp4/server/rest/meta.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Depends, Path, Query
 
+from ixmp4.data import abstract, api
 from ixmp4.data.backend import Backend
-from ixmp4.data import api, abstract
 
-from .base import BaseModel
 from . import deps
+from .base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/meta",

--- a/ixmp4/server/rest/model.py
+++ b/ixmp4/server/rest/model.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.model.filter import ModelFilter
 
 from . import deps

--- a/ixmp4/server/rest/model.py
+++ b/ixmp4/server/rest/model.py
@@ -1,14 +1,12 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
-
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.model.filter import ModelFilter
 
+from . import deps
 from .base import BaseModel
 from .decorators import autodoc
-from . import deps
-
 
 router: APIRouter = APIRouter(
     prefix="/models",

--- a/ixmp4/server/rest/optimization/indexset.py
+++ b/ixmp4/server/rest/optimization/indexset.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Body, Depends, Query
 from pydantic import StrictInt, StrictStr
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.filters.optimizationindexset import OptimizationIndexSetFilter
 
 from .. import deps

--- a/ixmp4/server/rest/region.py
+++ b/ixmp4/server/rest/region.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Path, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.region.filter import RegionFilter
 
 from . import deps

--- a/ixmp4/server/rest/region.py
+++ b/ixmp4/server/rest/region.py
@@ -1,12 +1,12 @@
-from fastapi import APIRouter, Depends, Query, Body, Path
+from fastapi import APIRouter, Body, Depends, Path, Query
 
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.region.filter import RegionFilter
 
+from . import deps
 from .base import BaseModel
 from .decorators import autodoc
-from . import deps
 
 router: APIRouter = APIRouter(
     prefix="/regions",

--- a/ixmp4/server/rest/run.py
+++ b/ixmp4/server/rest/run.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Path, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.run.filter import RunFilter
 
 from . import deps

--- a/ixmp4/server/rest/run.py
+++ b/ixmp4/server/rest/run.py
@@ -1,12 +1,11 @@
-from fastapi import APIRouter, Depends, Path, Query, Body
+from fastapi import APIRouter, Body, Depends, Path, Query
 
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.run.filter import RunFilter
 
-from .base import BaseModel
 from . import deps
-
+from .base import BaseModel
 
 router: APIRouter = APIRouter(
     prefix="/runs",

--- a/ixmp4/server/rest/scenario.py
+++ b/ixmp4/server/rest/scenario.py
@@ -1,13 +1,12 @@
-from fastapi import APIRouter, Depends, Query, Body
+from fastapi import APIRouter, Body, Depends, Query
 
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.scenario.filter import ScenarioFilter
 
+from . import deps
 from .base import BaseModel
 from .decorators import autodoc
-from . import deps
-
 
 router: APIRouter = APIRouter(
     prefix="/scenarios",

--- a/ixmp4/server/rest/scenario.py
+++ b/ixmp4/server/rest/scenario.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.scenario.filter import ScenarioFilter
 
 from . import deps

--- a/ixmp4/server/rest/unit.py
+++ b/ixmp4/server/rest/unit.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, Depends, Path, Query
 
 from ixmp4.data import api
-from ixmp4.data.backend import Backend
+from ixmp4.data.backend.base import Backend
 from ixmp4.data.db.unit.filter import UnitFilter
 
 from . import deps

--- a/ixmp4/server/rest/unit.py
+++ b/ixmp4/server/rest/unit.py
@@ -1,13 +1,12 @@
-from fastapi import APIRouter, Depends, Query, Body, Path
+from fastapi import APIRouter, Body, Depends, Path, Query
 
-from ixmp4.data.backend import Backend
 from ixmp4.data import api
+from ixmp4.data.backend import Backend
 from ixmp4.data.db.unit.filter import UnitFilter
 
-from .decorators import autodoc
-from .base import BaseModel
 from . import deps
-
+from .base import BaseModel
+from .decorators import autodoc
 
 router: APIRouter = APIRouter(
     prefix="/units",

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,25 +34,25 @@ tz = ["python-dateutil"]
 
 [[package]]
 name = "anyio"
-version = "3.7.1"
+version = "4.0.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "anyio-3.7.1-py3-none-any.whl", hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5"},
-    {file = "anyio-3.7.1.tar.gz", hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780"},
+    {file = "anyio-4.0.0-py3-none-any.whl", hash = "sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f"},
+    {file = "anyio-4.0.0.tar.gz", hash = "sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a"},
 ]
 
 [package.dependencies]
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 
 [package.extras]
-doc = ["Sphinx", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.2.2)", "sphinxcontrib-jquery"]
-test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.17)"]
-trio = ["trio (<0.22)"]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.17)"]
+trio = ["trio (>=0.22)"]
 
 [[package]]
 name = "appnope"
@@ -630,14 +630,14 @@ files = [
 
 [[package]]
 name = "docutils"
-version = "0.18.1"
+version = "0.17.1"
 description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
-    {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
-    {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
+    {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
+    {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
 ]
 
 [[package]]
@@ -1244,14 +1244,14 @@ referencing = ">=0.28.0"
 
 [[package]]
 name = "jupyter-client"
-version = "8.3.0"
+version = "8.3.1"
 description = "Jupyter protocol implementation and client libraries"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.3.0-py3-none-any.whl", hash = "sha256:7441af0c0672edc5d28035e92ba5e32fadcfa8a4e608a434c228836a89df6158"},
-    {file = "jupyter_client-8.3.0.tar.gz", hash = "sha256:3af69921fe99617be1670399a0b857ad67275eefcfa291e2c81a160b7b650f5f"},
+    {file = "jupyter_client-8.3.1-py3-none-any.whl", hash = "sha256:5eb9f55eb0650e81de6b7e34308d8b92d04fe4ec41cd8193a913979e33d8e1a5"},
+    {file = "jupyter_client-8.3.1.tar.gz", hash = "sha256:60294b2d5b869356c893f57b1a877ea6510d60d45cf4b38057f1672d85699ac9"},
 ]
 
 [package.dependencies]
@@ -1608,67 +1608,62 @@ files = [
 
 [[package]]
 name = "pandas"
-version = "2.0.3"
+version = "2.1.0"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pandas-2.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4c7c9f27a4185304c7caf96dc7d91bc60bc162221152de697c98eb0b2648dd8"},
-    {file = "pandas-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f167beed68918d62bffb6ec64f2e1d8a7d297a038f86d4aed056b9493fca407f"},
-    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce0c6f76a0f1ba361551f3e6dceaff06bde7514a374aa43e33b588ec10420183"},
-    {file = "pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba619e410a21d8c387a1ea6e8a0e49bb42216474436245718d7f2e88a2f8d7c0"},
-    {file = "pandas-2.0.3-cp310-cp310-win32.whl", hash = "sha256:3ef285093b4fe5058eefd756100a367f27029913760773c8bf1d2d8bebe5d210"},
-    {file = "pandas-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:9ee1a69328d5c36c98d8e74db06f4ad518a1840e8ccb94a4ba86920986bb617e"},
-    {file = "pandas-2.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b084b91d8d66ab19f5bb3256cbd5ea661848338301940e17f4492b2ce0801fe8"},
-    {file = "pandas-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37673e3bdf1551b95bf5d4ce372b37770f9529743d2498032439371fc7b7eb26"},
-    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9cb1e14fdb546396b7e1b923ffaeeac24e4cedd14266c3497216dd4448e4f2d"},
-    {file = "pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9cd88488cceb7635aebb84809d087468eb33551097d600c6dad13602029c2df"},
-    {file = "pandas-2.0.3-cp311-cp311-win32.whl", hash = "sha256:694888a81198786f0e164ee3a581df7d505024fbb1f15202fc7db88a71d84ebd"},
-    {file = "pandas-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6a21ab5c89dcbd57f78d0ae16630b090eec626360085a4148693def5452d8a6b"},
-    {file = "pandas-2.0.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9e4da0d45e7f34c069fe4d522359df7d23badf83abc1d1cef398895822d11061"},
-    {file = "pandas-2.0.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:32fca2ee1b0d93dd71d979726b12b61faa06aeb93cf77468776287f41ff8fdc5"},
-    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:258d3624b3ae734490e4d63c430256e716f488c4fcb7c8e9bde2d3aa46c29089"},
-    {file = "pandas-2.0.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eae3dc34fa1aa7772dd3fc60270d13ced7346fcbcfee017d3132ec625e23bb0"},
-    {file = "pandas-2.0.3-cp38-cp38-win32.whl", hash = "sha256:f3421a7afb1a43f7e38e82e844e2bca9a6d793d66c1a7f9f0ff39a795bbc5e02"},
-    {file = "pandas-2.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:69d7f3884c95da3a31ef82b7618af5710dba95bb885ffab339aad925c3e8ce78"},
-    {file = "pandas-2.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5247fb1ba347c1261cbbf0fcfba4a3121fbb4029d95d9ef4dc45406620b25c8b"},
-    {file = "pandas-2.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:81af086f4543c9d8bb128328b5d32e9986e0c84d3ee673a2ac6fb57fd14f755e"},
-    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1994c789bf12a7c5098277fb43836ce090f1073858c10f9220998ac74f37c69b"},
-    {file = "pandas-2.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ec591c48e29226bcbb316e0c1e9423622bc7a4eaf1ef7c3c9fa1a3981f89641"},
-    {file = "pandas-2.0.3-cp39-cp39-win32.whl", hash = "sha256:04dbdbaf2e4d46ca8da896e1805bc04eb85caa9a82e259e8eed00254d5e0c682"},
-    {file = "pandas-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:1168574b036cd8b93abc746171c9b4f1b83467438a5e45909fed645cf8692dbc"},
-    {file = "pandas-2.0.3.tar.gz", hash = "sha256:c02f372a88e0d17f36d3093a644c73cfc1788e876a7c4bcb4020a77512e2043c"},
+    {file = "pandas-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:40dd20439ff94f1b2ed55b393ecee9cb6f3b08104c2c40b0cb7186a2f0046242"},
+    {file = "pandas-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d4f38e4fedeba580285eaac7ede4f686c6701a9e618d8a857b138a126d067f2f"},
+    {file = "pandas-2.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e6a0fe052cf27ceb29be9429428b4918f3740e37ff185658f40d8702f0b3e09"},
+    {file = "pandas-2.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d81e1813191070440d4c7a413cb673052b3b4a984ffd86b8dd468c45742d3cc"},
+    {file = "pandas-2.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eb20252720b1cc1b7d0b2879ffc7e0542dd568f24d7c4b2347cb035206936421"},
+    {file = "pandas-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:38f74ef7ebc0ffb43b3d633e23d74882bce7e27bfa09607f3c5d3e03ffd9a4a5"},
+    {file = "pandas-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cda72cc8c4761c8f1d97b169661f23a86b16fdb240bdc341173aee17e4d6cedd"},
+    {file = "pandas-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d97daeac0db8c993420b10da4f5f5b39b01fc9ca689a17844e07c0a35ac96b4b"},
+    {file = "pandas-2.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8c58b1113892e0c8078f006a167cc210a92bdae23322bb4614f2f0b7a4b510f"},
+    {file = "pandas-2.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:629124923bcf798965b054a540f9ccdfd60f71361255c81fa1ecd94a904b9dd3"},
+    {file = "pandas-2.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:70cf866af3ab346a10debba8ea78077cf3a8cd14bd5e4bed3d41555a3280041c"},
+    {file = "pandas-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:d53c8c1001f6a192ff1de1efe03b31a423d0eee2e9e855e69d004308e046e694"},
+    {file = "pandas-2.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:86f100b3876b8c6d1a2c66207288ead435dc71041ee4aea789e55ef0e06408cb"},
+    {file = "pandas-2.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28f330845ad21c11db51e02d8d69acc9035edfd1116926ff7245c7215db57957"},
+    {file = "pandas-2.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9a6ccf0963db88f9b12df6720e55f337447aea217f426a22d71f4213a3099a6"},
+    {file = "pandas-2.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99e678180bc59b0c9443314297bddce4ad35727a1a2656dbe585fd78710b3b9"},
+    {file = "pandas-2.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b31da36d376d50a1a492efb18097b9101bdbd8b3fbb3f49006e02d4495d4c644"},
+    {file = "pandas-2.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0164b85937707ec7f70b34a6c3a578dbf0f50787f910f21ca3b26a7fd3363437"},
+    {file = "pandas-2.1.0.tar.gz", hash = "sha256:62c24c7fc59e42b775ce0679cfa7b14a5f9bfb7643cfbe708c960699e05fb918"},
 ]
 
 [package.dependencies]
-numpy = {version = ">=1.21.0", markers = "python_version >= \"3.10\""}
+numpy = {version = ">=1.22.4", markers = "python_version < \"3.11\""}
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
 tzdata = ">=2022.1"
 
 [package.extras]
-all = ["PyQt5 (>=5.15.1)", "SQLAlchemy (>=1.4.16)", "beautifulsoup4 (>=4.9.3)", "bottleneck (>=1.3.2)", "brotlipy (>=0.7.0)", "fastparquet (>=0.6.3)", "fsspec (>=2021.07.0)", "gcsfs (>=2021.07.0)", "html5lib (>=1.1)", "hypothesis (>=6.34.2)", "jinja2 (>=3.0.0)", "lxml (>=4.6.3)", "matplotlib (>=3.6.1)", "numba (>=0.53.1)", "numexpr (>=2.7.3)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pandas-gbq (>=0.15.0)", "psycopg2 (>=2.8.6)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "python-snappy (>=0.6.0)", "pyxlsb (>=1.0.8)", "qtpy (>=2.2.0)", "s3fs (>=2021.08.0)", "scipy (>=1.7.1)", "tables (>=3.6.1)", "tabulate (>=0.8.9)", "xarray (>=0.21.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)", "zstandard (>=0.15.2)"]
-aws = ["s3fs (>=2021.08.0)"]
-clipboard = ["PyQt5 (>=5.15.1)", "qtpy (>=2.2.0)"]
-compression = ["brotlipy (>=0.7.0)", "python-snappy (>=0.6.0)", "zstandard (>=0.15.2)"]
-computation = ["scipy (>=1.7.1)", "xarray (>=0.21.0)"]
-excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.7)", "pyxlsb (>=1.0.8)", "xlrd (>=2.0.1)", "xlsxwriter (>=1.4.3)"]
+all = ["PyQt5 (>=5.15.6)", "SQLAlchemy (>=1.4.36)", "beautifulsoup4 (>=4.11.1)", "bottleneck (>=1.3.4)", "dataframe-api-compat (>=0.1.7)", "fastparquet (>=0.8.1)", "fsspec (>=2022.05.0)", "gcsfs (>=2022.05.0)", "html5lib (>=1.1)", "hypothesis (>=6.46.1)", "jinja2 (>=3.1.2)", "lxml (>=4.8.0)", "matplotlib (>=3.6.1)", "numba (>=0.55.2)", "numexpr (>=2.8.0)", "odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pandas-gbq (>=0.17.5)", "psycopg2 (>=2.9.3)", "pyarrow (>=7.0.0)", "pymysql (>=1.0.2)", "pyreadstat (>=1.1.5)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)", "pyxlsb (>=1.0.9)", "qtpy (>=2.2.0)", "s3fs (>=2022.05.0)", "scipy (>=1.8.1)", "tables (>=3.7.0)", "tabulate (>=0.8.10)", "xarray (>=2022.03.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)", "zstandard (>=0.17.0)"]
+aws = ["s3fs (>=2022.05.0)"]
+clipboard = ["PyQt5 (>=5.15.6)", "qtpy (>=2.2.0)"]
+compression = ["zstandard (>=0.17.0)"]
+computation = ["scipy (>=1.8.1)", "xarray (>=2022.03.0)"]
+consortium-standard = ["dataframe-api-compat (>=0.1.7)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.0.10)", "pyxlsb (>=1.0.9)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.0.3)"]
 feather = ["pyarrow (>=7.0.0)"]
-fss = ["fsspec (>=2021.07.0)"]
-gcp = ["gcsfs (>=2021.07.0)", "pandas-gbq (>=0.15.0)"]
-hdf5 = ["tables (>=3.6.1)"]
-html = ["beautifulsoup4 (>=4.9.3)", "html5lib (>=1.1)", "lxml (>=4.6.3)"]
-mysql = ["SQLAlchemy (>=1.4.16)", "pymysql (>=1.0.2)"]
-output-formatting = ["jinja2 (>=3.0.0)", "tabulate (>=0.8.9)"]
+fss = ["fsspec (>=2022.05.0)"]
+gcp = ["gcsfs (>=2022.05.0)", "pandas-gbq (>=0.17.5)"]
+hdf5 = ["tables (>=3.7.0)"]
+html = ["beautifulsoup4 (>=4.11.1)", "html5lib (>=1.1)", "lxml (>=4.8.0)"]
+mysql = ["SQLAlchemy (>=1.4.36)", "pymysql (>=1.0.2)"]
+output-formatting = ["jinja2 (>=3.1.2)", "tabulate (>=0.8.10)"]
 parquet = ["pyarrow (>=7.0.0)"]
-performance = ["bottleneck (>=1.3.2)", "numba (>=0.53.1)", "numexpr (>=2.7.1)"]
+performance = ["bottleneck (>=1.3.4)", "numba (>=0.55.2)", "numexpr (>=2.8.0)"]
 plot = ["matplotlib (>=3.6.1)"]
-postgresql = ["SQLAlchemy (>=1.4.16)", "psycopg2 (>=2.8.6)"]
-spss = ["pyreadstat (>=1.1.2)"]
-sql-other = ["SQLAlchemy (>=1.4.16)"]
-test = ["hypothesis (>=6.34.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
-xml = ["lxml (>=4.6.3)"]
+postgresql = ["SQLAlchemy (>=1.4.36)", "psycopg2 (>=2.9.3)"]
+spss = ["pyreadstat (>=1.1.5)"]
+sql-other = ["SQLAlchemy (>=1.4.36)"]
+test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
+xml = ["lxml (>=4.8.0)"]
 
 [[package]]
 name = "pandera"
@@ -1808,14 +1803,14 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-co
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
 
 [package.extras]
@@ -1993,18 +1988,18 @@ test = ["pytest"]
 
 [[package]]
 name = "pybtex-docutils"
-version = "1.0.2"
+version = "1.0.3"
 description = "A docutils backend for pybtex."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pybtex-docutils-1.0.2.tar.gz", hash = "sha256:43aa353b6d498fd5ac30f0073a98e332d061d34fe619d3d50d1761f8fd4aa016"},
-    {file = "pybtex_docutils-1.0.2-py3-none-any.whl", hash = "sha256:6f9e3c25a37bcaac8c4f69513272706ec6253bb708a93d8b4b173f43915ba239"},
+    {file = "pybtex-docutils-1.0.3.tar.gz", hash = "sha256:3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b"},
+    {file = "pybtex_docutils-1.0.3-py3-none-any.whl", hash = "sha256:8fd290d2ae48e32fcb54d86b0efb8d573198653c7e2447d5bec5847095f430b9"},
 ]
 
 [package.dependencies]
-docutils = ">=0.8"
+docutils = ">=0.14"
 pybtex = ">=0.16"
 
 [[package]]
@@ -2500,109 +2495,109 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "rpds-py"
-version = "0.9.2"
+version = "0.10.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "rpds_py-0.9.2-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:ab6919a09c055c9b092798ce18c6c4adf49d24d4d9e43a92b257e3f2548231e7"},
-    {file = "rpds_py-0.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d55777a80f78dd09410bd84ff8c95ee05519f41113b2df90a69622f5540c4f8b"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a216b26e5af0a8e265d4efd65d3bcec5fba6b26909014effe20cd302fd1138fa"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29cd8bfb2d716366a035913ced99188a79b623a3512292963d84d3e06e63b496"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:44659b1f326214950a8204a248ca6199535e73a694be8d3e0e869f820767f12f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:745f5a43fdd7d6d25a53ab1a99979e7f8ea419dfefebcab0a5a1e9095490ee5e"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a987578ac5214f18b99d1f2a3851cba5b09f4a689818a106c23dbad0dfeb760f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf4151acb541b6e895354f6ff9ac06995ad9e4175cbc6d30aaed08856558201f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:03421628f0dc10a4119d714a17f646e2837126a25ac7a256bdf7c3943400f67f"},
-    {file = "rpds_py-0.9.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:13b602dc3e8dff3063734f02dcf05111e887f301fdda74151a93dbbc249930fe"},
-    {file = "rpds_py-0.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fae5cb554b604b3f9e2c608241b5d8d303e410d7dfb6d397c335f983495ce7f6"},
-    {file = "rpds_py-0.9.2-cp310-none-win32.whl", hash = "sha256:47c5f58a8e0c2c920cc7783113df2fc4ff12bf3a411d985012f145e9242a2764"},
-    {file = "rpds_py-0.9.2-cp310-none-win_amd64.whl", hash = "sha256:4ea6b73c22d8182dff91155af018b11aac9ff7eca085750455c5990cb1cfae6e"},
-    {file = "rpds_py-0.9.2-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:e564d2238512c5ef5e9d79338ab77f1cbbda6c2d541ad41b2af445fb200385e3"},
-    {file = "rpds_py-0.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f411330a6376fb50e5b7a3e66894e4a39e60ca2e17dce258d53768fea06a37bd"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e7521f5af0233e89939ad626b15278c71b69dc1dfccaa7b97bd4cdf96536bb7"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8d3335c03100a073883857e91db9f2e0ef8a1cf42dc0369cbb9151c149dbbc1b"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d25b1c1096ef0447355f7293fbe9ad740f7c47ae032c2884113f8e87660d8f6e"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a5d3fbd02efd9cf6a8ffc2f17b53a33542f6b154e88dd7b42ef4a4c0700fdad"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5934e2833afeaf36bd1eadb57256239785f5af0220ed8d21c2896ec4d3a765f"},
-    {file = "rpds_py-0.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:095b460e117685867d45548fbd8598a8d9999227e9061ee7f012d9d264e6048d"},
-    {file = "rpds_py-0.9.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:91378d9f4151adc223d584489591dbb79f78814c0734a7c3bfa9c9e09978121c"},
-    {file = "rpds_py-0.9.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:24a81c177379300220e907e9b864107614b144f6c2a15ed5c3450e19cf536fae"},
-    {file = "rpds_py-0.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:de0b6eceb46141984671802d412568d22c6bacc9b230174f9e55fc72ef4f57de"},
-    {file = "rpds_py-0.9.2-cp311-none-win32.whl", hash = "sha256:700375326ed641f3d9d32060a91513ad668bcb7e2cffb18415c399acb25de2ab"},
-    {file = "rpds_py-0.9.2-cp311-none-win_amd64.whl", hash = "sha256:0766babfcf941db8607bdaf82569ec38107dbb03c7f0b72604a0b346b6eb3298"},
-    {file = "rpds_py-0.9.2-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:b1440c291db3f98a914e1afd9d6541e8fc60b4c3aab1a9008d03da4651e67386"},
-    {file = "rpds_py-0.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0f2996fbac8e0b77fd67102becb9229986396e051f33dbceada3debaacc7033f"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f30d205755566a25f2ae0382944fcae2f350500ae4df4e795efa9e850821d82"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:159fba751a1e6b1c69244e23ba6c28f879a8758a3e992ed056d86d74a194a0f3"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1f044792e1adcea82468a72310c66a7f08728d72a244730d14880cd1dabe36b"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9251eb8aa82e6cf88510530b29eef4fac825a2b709baf5b94a6094894f252387"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01899794b654e616c8625b194ddd1e5b51ef5b60ed61baa7a2d9c2ad7b2a4238"},
-    {file = "rpds_py-0.9.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0c43f8ae8f6be1d605b0465671124aa8d6a0e40f1fb81dcea28b7e3d87ca1e1"},
-    {file = "rpds_py-0.9.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207f57c402d1f8712618f737356e4b6f35253b6d20a324d9a47cb9f38ee43a6b"},
-    {file = "rpds_py-0.9.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b52e7c5ae35b00566d244ffefba0f46bb6bec749a50412acf42b1c3f402e2c90"},
-    {file = "rpds_py-0.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:978fa96dbb005d599ec4fd9ed301b1cc45f1a8f7982d4793faf20b404b56677d"},
-    {file = "rpds_py-0.9.2-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:6aa8326a4a608e1c28da191edd7c924dff445251b94653988efb059b16577a4d"},
-    {file = "rpds_py-0.9.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:aad51239bee6bff6823bbbdc8ad85136c6125542bbc609e035ab98ca1e32a192"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bd4dc3602370679c2dfb818d9c97b1137d4dd412230cfecd3c66a1bf388a196"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dd9da77c6ec1f258387957b754f0df60766ac23ed698b61941ba9acccd3284d1"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:190ca6f55042ea4649ed19c9093a9be9d63cd8a97880106747d7147f88a49d18"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:876bf9ed62323bc7dcfc261dbc5572c996ef26fe6406b0ff985cbcf460fc8a4c"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa2818759aba55df50592ecbc95ebcdc99917fa7b55cc6796235b04193eb3c55"},
-    {file = "rpds_py-0.9.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9ea4d00850ef1e917815e59b078ecb338f6a8efda23369677c54a5825dbebb55"},
-    {file = "rpds_py-0.9.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:5855c85eb8b8a968a74dc7fb014c9166a05e7e7a8377fb91d78512900aadd13d"},
-    {file = "rpds_py-0.9.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:14c408e9d1a80dcb45c05a5149e5961aadb912fff42ca1dd9b68c0044904eb32"},
-    {file = "rpds_py-0.9.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:65a0583c43d9f22cb2130c7b110e695fff834fd5e832a776a107197e59a1898e"},
-    {file = "rpds_py-0.9.2-cp38-none-win32.whl", hash = "sha256:71f2f7715935a61fa3e4ae91d91b67e571aeb5cb5d10331ab681256bda2ad920"},
-    {file = "rpds_py-0.9.2-cp38-none-win_amd64.whl", hash = "sha256:674c704605092e3ebbbd13687b09c9f78c362a4bc710343efe37a91457123044"},
-    {file = "rpds_py-0.9.2-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:07e2c54bef6838fa44c48dfbc8234e8e2466d851124b551fc4e07a1cfeb37260"},
-    {file = "rpds_py-0.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f7fdf55283ad38c33e35e2855565361f4bf0abd02470b8ab28d499c663bc5d7c"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:890ba852c16ace6ed9f90e8670f2c1c178d96510a21b06d2fa12d8783a905193"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50025635ba8b629a86d9d5474e650da304cb46bbb4d18690532dd79341467846"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:517cbf6e67ae3623c5127206489d69eb2bdb27239a3c3cc559350ef52a3bbf0b"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0836d71ca19071090d524739420a61580f3f894618d10b666cf3d9a1688355b1"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c439fd54b2b9053717cca3de9583be6584b384d88d045f97d409f0ca867d80f"},
-    {file = "rpds_py-0.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f68996a3b3dc9335037f82754f9cdbe3a95db42bde571d8c3be26cc6245f2324"},
-    {file = "rpds_py-0.9.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7d68dc8acded354c972116f59b5eb2e5864432948e098c19fe6994926d8e15c3"},
-    {file = "rpds_py-0.9.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f963c6b1218b96db85fc37a9f0851eaf8b9040aa46dec112611697a7023da535"},
-    {file = "rpds_py-0.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5a46859d7f947061b4010e554ccd1791467d1b1759f2dc2ec9055fa239f1bc26"},
-    {file = "rpds_py-0.9.2-cp39-none-win32.whl", hash = "sha256:e07e5dbf8a83c66783a9fe2d4566968ea8c161199680e8ad38d53e075df5f0d0"},
-    {file = "rpds_py-0.9.2-cp39-none-win_amd64.whl", hash = "sha256:682726178138ea45a0766907957b60f3a1bf3acdf212436be9733f28b6c5af3c"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:196cb208825a8b9c8fc360dc0f87993b8b260038615230242bf18ec84447c08d"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c7671d45530fcb6d5e22fd40c97e1e1e01965fc298cbda523bb640f3d923b387"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83b32f0940adec65099f3b1c215ef7f1d025d13ff947975a055989cb7fd019a4"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f67da97f5b9eac838b6980fc6da268622e91f8960e083a34533ca710bec8611"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03975db5f103997904c37e804e5f340c8fdabbb5883f26ee50a255d664eed58c"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:987b06d1cdb28f88a42e4fb8a87f094e43f3c435ed8e486533aea0bf2e53d931"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c861a7e4aef15ff91233751619ce3a3d2b9e5877e0fcd76f9ea4f6847183aa16"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:02938432352359805b6da099c9c95c8a0547fe4b274ce8f1a91677401bb9a45f"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:ef1f08f2a924837e112cba2953e15aacfccbbfcd773b4b9b4723f8f2ddded08e"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:35da5cc5cb37c04c4ee03128ad59b8c3941a1e5cd398d78c37f716f32a9b7f67"},
-    {file = "rpds_py-0.9.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:141acb9d4ccc04e704e5992d35472f78c35af047fa0cfae2923835d153f091be"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:79f594919d2c1a0cc17d1988a6adaf9a2f000d2e1048f71f298b056b1018e872"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:a06418fe1155e72e16dddc68bb3780ae44cebb2912fbd8bb6ff9161de56e1798"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b2eb034c94b0b96d5eddb290b7b5198460e2d5d0c421751713953a9c4e47d10"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b08605d248b974eb02f40bdcd1a35d3924c83a2a5e8f5d0fa5af852c4d960af"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a0805911caedfe2736935250be5008b261f10a729a303f676d3d5fea6900c96a"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab2299e3f92aa5417d5e16bb45bb4586171c1327568f638e8453c9f8d9e0f020"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c8d7594e38cf98d8a7df25b440f684b510cf4627fe038c297a87496d10a174f"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b9ec12ad5f0a4625db34db7e0005be2632c1013b253a4a60e8302ad4d462afd"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:1fcdee18fea97238ed17ab6478c66b2095e4ae7177e35fb71fbe561a27adf620"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:933a7d5cd4b84f959aedeb84f2030f0a01d63ae6cf256629af3081cf3e3426e8"},
-    {file = "rpds_py-0.9.2-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:686ba516e02db6d6f8c279d1641f7067ebb5dc58b1d0536c4aaebb7bf01cdc5d"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:0173c0444bec0a3d7d848eaeca2d8bd32a1b43f3d3fde6617aac3731fa4be05f"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:d576c3ef8c7b2d560e301eb33891d1944d965a4d7a2eacb6332eee8a71827db6"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed89861ee8c8c47d6beb742a602f912b1bb64f598b1e2f3d758948721d44d468"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1054a08e818f8e18910f1bee731583fe8f899b0a0a5044c6e680ceea34f93876"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99e7c4bb27ff1aab90dcc3e9d37ee5af0231ed98d99cb6f5250de28889a3d502"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c545d9d14d47be716495076b659db179206e3fd997769bc01e2d550eeb685596"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9039a11bca3c41be5a58282ed81ae422fa680409022b996032a43badef2a3752"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fb39aca7a64ad0c9490adfa719dbeeb87d13be137ca189d2564e596f8ba32c07"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2d8b3b3a2ce0eaa00c5bbbb60b6713e94e7e0becab7b3db6c5c77f979e8ed1f1"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:99b1c16f732b3a9971406fbfe18468592c5a3529585a45a35adbc1389a529a03"},
-    {file = "rpds_py-0.9.2-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:c27ee01a6c3223025f4badd533bea5e87c988cb0ba2811b690395dfe16088cfe"},
-    {file = "rpds_py-0.9.2.tar.gz", hash = "sha256:8d70e8f14900f2657c249ea4def963bed86a29b81f81f5b76b5a9215680de945"},
+    {file = "rpds_py-0.10.0-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:c1e0e9916301e3b3d970814b1439ca59487f0616d30f36a44cead66ee1748c31"},
+    {file = "rpds_py-0.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ce8caa29ebbdcde67e5fd652c811d34bc01f249dbc0d61e5cc4db05ae79a83b"},
+    {file = "rpds_py-0.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad277f74b1c164f7248afa968700e410651eb858d7c160d109fb451dc45a2f09"},
+    {file = "rpds_py-0.10.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8e1c68303ccf7fceb50fbab79064a2636119fd9aca121f28453709283dbca727"},
+    {file = "rpds_py-0.10.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:780fcb855be29153901c67fc9c5633d48aebef21b90aa72812fa181d731c6b00"},
+    {file = "rpds_py-0.10.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bbd7b24d108509a1b9b6679fcc1166a7dd031dbef1f3c2c73788f42e3ebb3beb"},
+    {file = "rpds_py-0.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0700c2133ba203c4068aaecd6a59bda22e06a5e46255c9da23cbf68c6942215d"},
+    {file = "rpds_py-0.10.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:576da63eae7809f375932bfcbca2cf20620a1915bf2fedce4b9cc8491eceefe3"},
+    {file = "rpds_py-0.10.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:23750a9b8a329844ba1fe267ca456bb3184984da2880ed17ae641c5af8de3fef"},
+    {file = "rpds_py-0.10.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d08395595c42bcd82c3608762ce734504c6d025eef1c06f42326a6023a584186"},
+    {file = "rpds_py-0.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1d7b7b71bcb82d8713c7c2e9c5f061415598af5938666beded20d81fa23e7640"},
+    {file = "rpds_py-0.10.0-cp310-none-win32.whl", hash = "sha256:97f5811df21703446b42303475b8b855ee07d6ab6cdf8565eff115540624f25d"},
+    {file = "rpds_py-0.10.0-cp310-none-win_amd64.whl", hash = "sha256:cdbed8f21204398f47de39b0a9b180d7e571f02dfb18bf5f1b618e238454b685"},
+    {file = "rpds_py-0.10.0-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:7a3a3d3e4f1e3cd2a67b93a0b6ed0f2499e33f47cc568e3a0023e405abdc0ff1"},
+    {file = "rpds_py-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fc72ae476732cdb7b2c1acb5af23b478b8a0d4b6fcf19b90dd150291e0d5b26b"},
+    {file = "rpds_py-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0583f69522732bdd79dca4cd3873e63a29acf4a299769c7541f2ca1e4dd4bc6"},
+    {file = "rpds_py-0.10.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8b9a7cd381970e64849070aca7c32d53ab7d96c66db6c2ef7aa23c6e803f514"},
+    {file = "rpds_py-0.10.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0d292cabd7c8335bdd3237ded442480a249dbcdb4ddfac5218799364a01a0f5c"},
+    {file = "rpds_py-0.10.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6903cdca64f1e301af9be424798328c1fe3b4b14aede35f04510989fc72f012"},
+    {file = "rpds_py-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bed57543c99249ab3a4586ddc8786529fbc33309e5e8a1351802a06ca2baf4c2"},
+    {file = "rpds_py-0.10.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:15932ec5f224b0e35764dc156514533a4fca52dcfda0dfbe462a1a22b37efd59"},
+    {file = "rpds_py-0.10.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb2d59bc196e6d3b1827c7db06c1a898bfa0787c0574af398e65ccf2e97c0fbe"},
+    {file = "rpds_py-0.10.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f99d74ddf9d3b6126b509e81865f89bd1283e3fc1b568b68cd7bd9dfa15583d7"},
+    {file = "rpds_py-0.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f70bec8a14a692be6dbe7ce8aab303e88df891cbd4a39af091f90b6702e28055"},
+    {file = "rpds_py-0.10.0-cp311-none-win32.whl", hash = "sha256:5f7487be65b9c2c510819e744e375bd41b929a97e5915c4852a82fbb085df62c"},
+    {file = "rpds_py-0.10.0-cp311-none-win_amd64.whl", hash = "sha256:748e472345c3a82cfb462d0dff998a7bf43e621eed73374cb19f307e97e08a83"},
+    {file = "rpds_py-0.10.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:d4639111e73997567343df6551da9dd90d66aece1b9fc26c786d328439488103"},
+    {file = "rpds_py-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f4760e1b02173f4155203054f77a5dc0b4078de7645c922b208d28e7eb99f3e2"},
+    {file = "rpds_py-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a6420a36975e0073acaeee44ead260c1f6ea56812cfc6c31ec00c1c48197173"},
+    {file = "rpds_py-0.10.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:58fc4d66ee349a23dbf08c7e964120dc9027059566e29cf0ce6205d590ed7eca"},
+    {file = "rpds_py-0.10.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:063411228b852fb2ed7485cf91f8e7d30893e69b0acb207ec349db04cccc8225"},
+    {file = "rpds_py-0.10.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65af12f70355de29e1092f319f85a3467f4005e959ab65129cb697169ce94b86"},
+    {file = "rpds_py-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:298e8b5d8087e0330aac211c85428c8761230ef46a1f2c516d6a2f67fb8803c5"},
+    {file = "rpds_py-0.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5b9bf77008f2c55dabbd099fd3ac87009471d223a1c7ebea36873d39511b780a"},
+    {file = "rpds_py-0.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c7853f27195598e550fe089f78f0732c66ee1d1f0eaae8ad081589a5a2f5d4af"},
+    {file = "rpds_py-0.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:75dbfd41a61bc1fb0536bf7b1abf272dc115c53d4d77db770cd65d46d4520882"},
+    {file = "rpds_py-0.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b25136212a3d064a8f0b9ebbb6c57094c5229e0de76d15c79b76feff26aeb7b8"},
+    {file = "rpds_py-0.10.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:9affee8cb1ec453382c27eb9043378ab32f49cd4bc24a24275f5c39bf186c279"},
+    {file = "rpds_py-0.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4d55528ef13af4b4e074d067977b1f61408602f53ae4537dccf42ba665c2c7bd"},
+    {file = "rpds_py-0.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7865df1fb564092bcf46dac61b5def25342faf6352e4bc0e61a286e3fa26a3d"},
+    {file = "rpds_py-0.10.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f5cc8c7bc99d2bbcd704cef165ca7d155cd6464c86cbda8339026a42d219397"},
+    {file = "rpds_py-0.10.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cbae50d352e4717ffc22c566afc2d0da744380e87ed44a144508e3fb9114a3f4"},
+    {file = "rpds_py-0.10.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fccbf0cd3411719e4c9426755df90bf3449d9fc5a89f077f4a7f1abd4f70c910"},
+    {file = "rpds_py-0.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d10c431073dc6ebceed35ab22948a016cc2b5120963c13a41e38bdde4a7212"},
+    {file = "rpds_py-0.10.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1b401e8b9aece651512e62c431181e6e83048a651698a727ea0eb0699e9f9b74"},
+    {file = "rpds_py-0.10.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:7618a082c55cf038eede4a918c1001cc8a4411dfe508dc762659bcd48d8f4c6e"},
+    {file = "rpds_py-0.10.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:b3226b246facae14909b465061ddcfa2dfeadb6a64f407f24300d42d69bcb1a1"},
+    {file = "rpds_py-0.10.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a8edd467551c1102dc0f5754ab55cd0703431cd3044edf8c8e7d9208d63fa453"},
+    {file = "rpds_py-0.10.0-cp38-none-win32.whl", hash = "sha256:71333c22f7cf5f0480b59a0aef21f652cf9bbaa9679ad261b405b65a57511d1e"},
+    {file = "rpds_py-0.10.0-cp38-none-win_amd64.whl", hash = "sha256:a8ab1adf04ae2d6d65835995218fd3f3eb644fe20655ca8ee233e2c7270ff53b"},
+    {file = "rpds_py-0.10.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:87c93b25d538c433fb053da6228c6290117ba53ff6a537c133b0f2087948a582"},
+    {file = "rpds_py-0.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e7996aed3f65667c6dcc8302a69368435a87c2364079a066750a2eac75ea01e"},
+    {file = "rpds_py-0.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8856aa76839dc234d3469f1e270918ce6bec1d6a601eba928f45d68a15f04fc3"},
+    {file = "rpds_py-0.10.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:00215f6a9058fbf84f9d47536902558eb61f180a6b2a0fa35338d06ceb9a2e5a"},
+    {file = "rpds_py-0.10.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23a059143c1393015c68936370cce11690f7294731904bdae47cc3e16d0b2474"},
+    {file = "rpds_py-0.10.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3e5c26905aa651cc8c0ddc45e0e5dea2a1296f70bdc96af17aee9d0493280a17"},
+    {file = "rpds_py-0.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c651847545422c8131660704c58606d841e228ed576c8f1666d98b3d318f89da"},
+    {file = "rpds_py-0.10.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:80992eb20755701753e30a6952a96aa58f353d12a65ad3c9d48a8da5ec4690cf"},
+    {file = "rpds_py-0.10.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ffcf18ad3edf1c170e27e88b10282a2c449aa0358659592462448d71b2000cfc"},
+    {file = "rpds_py-0.10.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:08e08ccf5b10badb7d0a5c84829b914c6e1e1f3a716fdb2bf294e2bd01562775"},
+    {file = "rpds_py-0.10.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7150b83b3e3ddaac81a8bb6a9b5f93117674a0e7a2b5a5b32ab31fdfea6df27f"},
+    {file = "rpds_py-0.10.0-cp39-none-win32.whl", hash = "sha256:3455ecc46ea443b5f7d9c2f946ce4017745e017b0d0f8b99c92564eff97e97f5"},
+    {file = "rpds_py-0.10.0-cp39-none-win_amd64.whl", hash = "sha256:afe6b5a04b2ab1aa89bad32ca47bf71358e7302a06fdfdad857389dca8fb5f04"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:b1cb078f54af0abd835ca76f93a3152565b73be0f056264da45117d0adf5e99c"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8e7e2b3577e97fa43c2c2b12a16139b2cedbd0770235d5179c0412b4794efd9b"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae46a50d235f1631d9ec4670503f7b30405103034830bc13df29fd947207f795"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f869e34d2326e417baee430ae998e91412cc8e7fdd83d979277a90a0e79a5b47"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d544a614055b131111bed6edfa1cb0fb082a7265761bcb03321f2dd7b5c6c48"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9c2f6ca9774c2c24bbf7b23086264e6b5fa178201450535ec0859739e6f78d"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2da4a8c6d465fde36cea7d54bf47b5cf089073452f0e47c8632ecb9dec23c07"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac00c41dd315d147b129976204839ca9de699d83519ff1272afbe4fb9d362d12"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:0155c33af0676fc38e1107679be882077680ad1abb6303956b97259c3177e85e"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:db6585b600b2e76e98131e0ac0e5195759082b51687ad0c94505970c90718f4a"},
+    {file = "rpds_py-0.10.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:7b6975d3763d0952c111700c0634968419268e6bbc0b55fe71138987fa66f309"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:6388e4e95a26717b94a05ced084e19da4d92aca883f392dffcf8e48c8e221a24"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:18f87baa20e02e9277ad8960cd89b63c79c05caf106f4c959a9595c43f2a34a5"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92f05fc7d832e970047662b3440b190d24ea04f8d3c760e33e7163b67308c878"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:291c9ce3929a75b45ce8ddde2aa7694fc8449f2bc8f5bd93adf021efaae2d10b"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:861d25ae0985a1dd5297fee35f476b60c6029e2e6e19847d5b4d0a43a390b696"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:668d2b45d62c68c7a370ac3dce108ffda482b0a0f50abd8b4c604a813a59e08f"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:344b89384c250ba6a4ce1786e04d01500e4dac0f4137ceebcaad12973c0ac0b3"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:885e023e73ce09b11b89ab91fc60f35d80878d2c19d6213a32b42ff36543c291"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:841128a22e6ac04070a0f84776d07e9c38c4dcce8e28792a95e45fc621605517"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-musllinux_1_2_i686.whl", hash = "sha256:899b5e7e2d5a8bc92aa533c2d4e55e5ebba095c485568a5e4bedbc163421259a"},
+    {file = "rpds_py-0.10.0-pp38-pypy38_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e7947d9a6264c727a556541b1630296bbd5d0a05068d21c38dde8e7a1c703ef0"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:4992266817169997854f81df7f6db7bdcda1609972d8ffd6919252f09ec3c0f6"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:26d9fd624649a10e4610fab2bc820e215a184d193e47d0be7fe53c1c8f67f370"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0028eb0967942d0d2891eae700ae1a27b7fd18604cfcb16a1ef486a790fee99e"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f9e7e493ded7042712a374471203dd43ae3fff5b81e3de1a0513fa241af9fd41"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2d68a8e8a3a816629283faf82358d8c93fe5bd974dd2704152394a3de4cec22a"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d6d5f061f6a2aa55790b9e64a23dfd87b6664ab56e24cd06c78eb43986cb260b"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c7c4266c1b61eb429e8aeb7d8ed6a3bfe6c890a1788b18dbec090c35c6b93fa"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:80772e3bda6787510d9620bc0c7572be404a922f8ccdfd436bf6c3778119464c"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:b98e75b21fc2ba5285aef8efaf34131d16af1c38df36bdca2f50634bea2d3060"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:d63787f289944cc4bde518ad2b5e70a4f0d6e2ce76324635359c74c113fd188f"},
+    {file = "rpds_py-0.10.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:872f3dcaa8bf2245944861d7311179d2c0c9b2aaa7d3b464d99a7c2e401f01fa"},
+    {file = "rpds_py-0.10.0.tar.gz", hash = "sha256:e36d7369363d2707d5f68950a64c4e025991eb0177db01ccb6aa6facae48b69f"},
 ]
 
 [[package]]
@@ -2742,19 +2737,19 @@ sphinx = ">=2.1"
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "1.2.2"
+version = "1.3.0"
 description = "Read the Docs theme for Sphinx"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "sphinx_rtd_theme-1.2.2-py2.py3-none-any.whl", hash = "sha256:6a7e7d8af34eb8fc57d52a09c6b6b9c46ff44aea5951bc831eeb9245378f3689"},
-    {file = "sphinx_rtd_theme-1.2.2.tar.gz", hash = "sha256:01c5c5a72e2d025bd23d1f06c59a4831b06e6ce6c01fdd5ebfe9986c0a880fc7"},
+    {file = "sphinx_rtd_theme-1.3.0-py2.py3-none-any.whl", hash = "sha256:46ddef89cc2416a81ecfbeaceab1881948c014b1b6e4450b815311a89fb977b0"},
+    {file = "sphinx_rtd_theme-1.3.0.tar.gz", hash = "sha256:590b030c7abb9cf038ec053b95e5380b5c70d61591eb0b552063fbe7c41f0931"},
 ]
 
 [package.dependencies]
 docutils = "<0.19"
-sphinx = ">=1.6,<7"
+sphinx = ">=1.6,<8"
 sphinxcontrib-jquery = ">=4,<5"
 
 [package.extras]
@@ -2781,21 +2776,21 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-bibtex"
-version = "2.5.0"
+version = "2.6.1"
 description = "Sphinx extension for BibTeX style citations."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "sphinxcontrib-bibtex-2.5.0.tar.gz", hash = "sha256:71b42e5db0e2e284f243875326bf9936aa9a763282277d75048826fef5b00eaa"},
-    {file = "sphinxcontrib_bibtex-2.5.0-py3-none-any.whl", hash = "sha256:748f726eaca6efff7731012103417ef130ecdcc09501b4d0c54283bf5f059f76"},
+    {file = "sphinxcontrib-bibtex-2.6.1.tar.gz", hash = "sha256:046b49f070ae5276af34c1b8ddb9bc9562ef6de2f7a52d37a91cb8e53f54b863"},
+    {file = "sphinxcontrib_bibtex-2.6.1-py3-none-any.whl", hash = "sha256:094c772098fe6b030cda8618c45722b2957cad0c04f328ba2b154aa08dfe720a"},
 ]
 
 [package.dependencies]
-docutils = ">=0.8"
+docutils = ">=0.8,<0.18.0 || >=0.20.0"
 pybtex = ">=0.24"
 pybtex-docutils = ">=1.0.0"
-Sphinx = ">=2.1"
+Sphinx = ">=3.5"
 
 [[package]]
 name = "sphinxcontrib-devhelp"
@@ -3325,18 +3320,15 @@ test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "my
 
 [[package]]
 name = "watchgod"
-version = "0.8.2"
+version = "0.7"
 description = "Simple, modern file watching and code reload in python."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.5"
 files = [
-    {file = "watchgod-0.8.2-py3-none-any.whl", hash = "sha256:2f3e8137d98f493ff58af54ea00f4d1433a6afe2ed08ab331a657df468c6bfce"},
-    {file = "watchgod-0.8.2.tar.gz", hash = "sha256:cb11ff66657befba94d828e3b622d5fb76f22fbda1376f355f3e6e51e97d9450"},
+    {file = "watchgod-0.7-py3-none-any.whl", hash = "sha256:d6c1ea21df37847ac0537ca0d6c2f4cdf513562e95f77bb93abbcf05573407b7"},
+    {file = "watchgod-0.7.tar.gz", hash = "sha256:48140d62b0ebe9dd9cf8381337f06351e1f2e70b2203fa9c6eff4e572ca84f29"},
 ]
-
-[package.dependencies]
-anyio = ">=3.0.0,<4"
 
 [[package]]
 name = "wcwidth"

--- a/poetry.lock
+++ b/poetry.lock
@@ -807,6 +807,7 @@ files = [
     {file = "greenlet-2.0.2-cp27-cp27m-win32.whl", hash = "sha256:6c3acb79b0bfd4fe733dff8bc62695283b57949ebcca05ae5c129eb606ff2d74"},
     {file = "greenlet-2.0.2-cp27-cp27m-win_amd64.whl", hash = "sha256:283737e0da3f08bd637b5ad058507e578dd462db259f7f6e4c5c365ba4ee9343"},
     {file = "greenlet-2.0.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae"},
+    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c"},
     {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
     {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
     {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
@@ -815,6 +816,7 @@ files = [
     {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
     {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
     {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
+    {file = "greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
@@ -844,6 +846,7 @@ files = [
     {file = "greenlet-2.0.2-cp37-cp37m-win32.whl", hash = "sha256:3f6ea9bd35eb450837a3d80e77b517ea5bc56b4647f5502cd28de13675ee12f7"},
     {file = "greenlet-2.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7492e2b7bd7c9b9916388d9df23fa49d9b88ac0640db0a5b4ecc2b653bf451e3"},
     {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
+    {file = "greenlet-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
@@ -852,6 +855,7 @@ files = [
     {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
     {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
     {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
+    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417"},
     {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
     {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
     {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
@@ -1144,6 +1148,24 @@ parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+
+[[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jedi"
@@ -2267,6 +2289,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2274,8 +2297,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2292,6 +2322,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2299,6 +2330,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -3502,4 +3534,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "be1c5aee9abf2b24e0f508220616b3815db1e37b0ca50efc389652ecb03bad8e"
+content-hash = "12c03197dbc3baa680e5e445ab5b3c3761131c86fec66537438c46c7b5aa9763"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ pytest-cov = "^2.12.1"
 pytest-lazy-fixture = "^0.6.3"
 snakeviz = "^2.1.1"
 types-toml = "^0.10.8.7"
+isort = "^5.12.0"
 
 [tool.poetry.group.tutorial]
 optional = true
@@ -117,6 +118,9 @@ exclude = [
     'example.py',
     'import.py',
 ]
+
+[tool.isort]
+profile = "black"
 
 [tool.poetry-dynamic-versioning]
 bump = true

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,8 +1,9 @@
 from ixmp4.data.api import DataFrame
+
 from ..utils import (
     api_platforms,
-    create_iamc_query_test_data,
     assert_unordered_equality,
+    create_iamc_query_test_data,
 )
 
 

--- a/tests/api/test_region.py
+++ b/tests/api/test_region.py
@@ -1,8 +1,9 @@
 from ixmp4.data.api import DataFrame
+
 from ..utils import (
     api_platforms,
-    create_iamc_query_test_data,
     assert_unordered_equality,
+    create_iamc_query_test_data,
 )
 
 

--- a/tests/api/test_scenario.py
+++ b/tests/api/test_scenario.py
@@ -1,8 +1,9 @@
 from ixmp4.data.api import DataFrame
+
 from ..utils import (
     api_platforms,
-    create_iamc_query_test_data,
     assert_unordered_equality,
+    create_iamc_query_test_data,
 )
 
 

--- a/tests/api/test_unit.py
+++ b/tests/api/test_unit.py
@@ -1,8 +1,9 @@
 from ixmp4.data.api import DataFrame
+
 from ..utils import (
     api_platforms,
-    create_iamc_query_test_data,
     assert_unordered_equality,
+    create_iamc_query_test_data,
 )
 
 

--- a/tests/conf/test_toml.py
+++ b/tests/conf/test_toml.py
@@ -1,12 +1,13 @@
 import tempfile
-import pytest
-from typing import Protocol
 from pathlib import Path
+from typing import Protocol
 
-from ixmp4.conf.toml import TomlConfig
+import pytest
+
 from ixmp4.conf.credentials import Credentials
+from ixmp4.conf.toml import TomlConfig
 from ixmp4.conf.user import local_user
-from ixmp4.core.exceptions import PlatformNotUnique, PlatformNotFound
+from ixmp4.core.exceptions import PlatformNotFound, PlatformNotUnique
 
 
 @pytest.fixture(scope="class")

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -2,7 +2,7 @@ import pytest
 
 from ixmp4 import DataPoint, InconsistentIamcType
 
-from ..utils import add_regions, add_units, assert_unordered_equality, all_platforms
+from ..utils import add_regions, add_units, all_platforms, assert_unordered_equality
 
 
 @all_platforms

--- a/tests/data/test_iamc_datapoint.py
+++ b/tests/data/test_iamc_datapoint.py
@@ -1,8 +1,9 @@
-import pytest
 import pandas as pd
-from ..utils import add_regions, add_units, all_platforms, assert_unordered_equality
+import pytest
 
 from ixmp4.core.exceptions import BadFilterArguments
+
+from ..utils import add_regions, add_units, all_platforms, assert_unordered_equality
 
 
 @all_platforms

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,11 +1,11 @@
-import pytest
 import pandas as pd
+import pytest
 
 import ixmp4
-from ixmp4.core.exceptions import Forbidden, InvalidCredentials
-from ixmp4.conf.user import User
-from ixmp4.conf.manager import ManagerPlatformInfo, MockManagerConfig
 from ixmp4.conf.auth import ManagerAuth
+from ixmp4.conf.manager import ManagerPlatformInfo, MockManagerConfig
+from ixmp4.conf.user import User
+from ixmp4.core.exceptions import Forbidden, InvalidCredentials
 
 from .utils import add_regions, add_units, database_platforms
 


### PR DESCRIPTION
### Summary
This PR introduces [isort](https://pycqa.github.io/isort/index.html) as a dependency in the `dev` group. It also tries to update `anyio` and `pandas` to their latest versions allowed by our `pyproject.toml`.

#### Context
isort is a tool for sorting and organizing `import` statements. Code contributions to the MESSAGE stack are checked for compliance, so I think we will want to use it for ixmp4, too, for consistency alone. I also think it does make the `import`s more readable. 
isort offers [compatibility with black](https://pycqa.github.io/isort/docs/configuration/black_compatibility.html) and should be easily configurable to run automatically whenever saving code files. For vscode, use the official [isort extension](https://marketplace.visualstudio.com/items?itemName=ms-python.isort) and edit the settings to read
```json
  "[python]": {
    "editor.defaultFormatter": "ms-python.black-formatter",
    "editor.formatOnSave": true,
    "editor.codeActionsOnSave": {
        "source.organizeImports": true
    },
  },
  "black-formatter.importStrategy": "fromEnvironment",
  "isort.args":["--profile", "black"],
  "isort.importStrategy": "fromEnvironment",
```
These settings are partly redundant with our pyproject.toml, which also reads
```pyproject.toml
[tool.isort]
profile = "black"
```
The `importStrategy` ensures that the tools from the virtual environment are used, if they are present. If not, some default versions will be used. `isort.args` enables the black compatibility.  