### PR TITLE
Publish to conda forge

### DIFF
--- a/.github/workflows/publish_conda.yaml
+++ b/.github/workflows/publish_conda.yaml
@@ -1,6 +1,5 @@
 on:
   workflow_dispatch:
-    branches: [main]
 
 jobs:
   test:
@@ -11,7 +10,7 @@ jobs:
         uses: actions/conda-skeleton-publish@v1
         with:
           pypi_package: "driptorch"
-          python_version: "3.10 3.11"
+          python_version: "3.10"
           upload_channel: "conda-forge"
           access_token: ${{ secrets.ANACONDA_TOKEN }}
           stable: true

--- a/.github/workflows/publish_conda.yaml
+++ b/.github/workflows/publish_conda.yaml
@@ -1,0 +1,17 @@
+on:
+  workflow_dispatch:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Conda skeleton publish
+    steps:
+      - name: Publish conda package from PyPI package
+        uses: actions/conda-skeleton-publish@v1
+        with:
+          pypi_package: "driptorch"
+          python_version: "3.10 3.11"
+          upload_channel: "conda-forge"
+          access_token: ${{ secrets.ANACONDA_TOKEN }}
+          stable: true

--- a/.github/workflows/publish_conda.yaml
+++ b/.github/workflows/publish_conda.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Publish conda package from PyPI package
         uses: actions/conda-skeleton-publish@v1
         with:
-          pypi_package: "driptorch"
+          pypi_package: "ixmp4"
           python_version: "3.10"
           upload_channel: "conda-forge"
           access_token: ${{ secrets.ANACONDA_TOKEN }}


### PR DESCRIPTION
This is how far I got into researching how to publish to conda forge. 
In short there's a lot of different options. 

The potentially easiest one I've found I've added to this PR in the publish_conda.yaml workflow file. This is a GitHub action that looks like it just takes a package from pypi and publishes it on conda forge. It's currently set up as a manual trigger so it should be worth a short to just try if it works.
For uploading I've created an anaconda account and added a repository secret `ANACONDA_TOKEN`. Potentially this can work.
For now the workflow is set on manual trigger but for the future we could run it after we publish to pypi.
I haven't tested it yet so anyone of @danielhuppmann, @glatterf42 or @meksor could try this one.

If this does not work there are a number of GH action workflows that promise to publish to anaconda from GitHub:
* https://github.com/marketplace/actions/publish-conda
* https://github.com/marketplace/actions/publish-conda-package-to-anaconda-org
both of those look good but are quite old and potentially outdated.

There are some additional files required detailed here: https://conda-forge.org/docs/maintainer/adding_pkgs.html#optional-bld-bat-and-or-build-sh.