### PR TITLE
Quickfix for numpy.types as meta indicators

### DIFF
--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -131,7 +131,9 @@ class RunMetaFacade(BaseFacade, UserDict):
         except KeyError:
             pass
 
-        self.backend.meta.create(self.run.id, key, numpy_to_pytype(value))
+        value = numpy_to_pytype(value)
+        if value is not None:
+            self.backend.meta.create(self.run.id, key, value)
         self.df, self.data = self._get()
 
     def __delitem__(self, key):
@@ -142,4 +144,9 @@ class RunMetaFacade(BaseFacade, UserDict):
 
 def numpy_to_pytype(value):
     """Cast numpy-types to basic Python types"""
-    return value.item() if isinstance(value, np.generic) else value
+    if value is np.nan:  # np.nan is cast to 'float', not None
+        return None
+    elif isinstance(value, np.generic):
+        return value.item()
+    else:
+        return value

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -112,7 +112,6 @@ class RunMetaFacade(BaseFacade, UserDict):
         return df, dict(zip(df["key"], df["value"]))
 
     def _set(self, meta: dict):
-        print("You are here")
         df = pd.DataFrame({"key": self.data.keys()})
         df["run__id"] = self.run.id
         self.backend.meta.bulk_delete(df)
@@ -125,7 +124,6 @@ class RunMetaFacade(BaseFacade, UserDict):
         self.df, self.data = self._get()
 
     def __setitem__(self, key, value: int | float | str | bool):
-        print("You are there")
         try:
             del self[key]
         except KeyError:

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -1,6 +1,7 @@
 from collections import UserDict
 from typing import ClassVar, Iterable
 
+import numpy as np
 import pandas as pd
 
 from ixmp4.data.abstract import Run as RunModel
@@ -124,6 +125,9 @@ class RunMetaFacade(BaseFacade, UserDict):
             del self[key]
         except KeyError:
             pass
+
+        if isinstance(value, np.int64):
+            value = int(value)
 
         self.backend.meta.create(self.run.id, key, value)
         self.df, self.data = self._get()

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -89,7 +89,7 @@ def test_run_meta(test_mp):
     "npvalue1, pyvalue1, npvalue2, pyvalue2",
     [
         (np.int64(1), 1, np.int64(13), 13),
-        (np.float64(1.9), 1.9, np.float128(13.9), 13.9),
+        (np.float64(1.9), 1.9, np.float64(13.9), 13.9),
     ],
 )
 def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -8,11 +8,7 @@ from ..utils import all_platforms
 
 @all_platforms
 def test_run_meta(test_mp):
-    run1 = test_mp.Run(
-        "Model",
-        "Scenario",
-        version="new",
-    )
+    run1 = test_mp.Run("Model", "Scenario", version="new")
     run1.set_as_default()
 
     # set and update different types of meta indicators
@@ -98,11 +94,7 @@ def test_run_meta(test_mp):
 )
 def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     """Test that numpy types are cast to simple types"""
-    run1 = test_mp.Run(
-        "Model",
-        "Scenario",
-        version="new",
-    )
+    run1 = test_mp.Run("Model", "Scenario", version="new")
     run1.set_as_default()
 
     # set multiple meta indicators of same type ("value"-column of numpy-type)
@@ -120,3 +112,26 @@ def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     # assert that meta values were saved and updated correctly
     run2 = test_mp.Run("Model", "Scenario")
     assert dict(run2.meta) == {"key": pyvalue2, "other key": "some value"}
+
+
+@all_platforms
+@pytest.mark.parametrize("nonevalue", (None, np.nan))
+def test_run_meta_none(test_mp, nonevalue):
+    """Test that None-values are handled correctly"""
+    run1 = test_mp.Run("Model", "Scenario", version="new")
+    run1.set_as_default()
+
+    # set multiple indicators where one value is None
+    run1.meta = {"mint": 13, "mnone": nonevalue}
+    assert run1.meta["mint"] == 13
+    with pytest.raises(KeyError, match="'mnone'"):
+        run1.meta["mnone"]
+
+    assert dict(test_mp.Run("Model", "Scenario").meta) == {"mint": 13}
+
+    # delete indicator via setter
+    run1.meta["mint"] = nonevalue
+    with pytest.raises(KeyError, match="'mint'"):
+        run1.meta["mint"]
+
+    assert not dict(test_mp.Run("Model", "Scenario").meta)

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -97,6 +97,7 @@ def test_run_meta(test_mp):
     ],
 )
 def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
+    """Test that numpy types are cast to simple types"""
     run1 = test_mp.Run(
         "Model",
         "Scenario",
@@ -104,8 +105,12 @@ def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     )
     run1.set_as_default()
 
-    # set and update different types of meta indicators
-    run1.meta = {"key": npvalue1}
+    # set multiple meta indicators of same type ("value"-column of numpy-type)
+    run1.meta = {"key": npvalue1, "other key": npvalue1}
+    assert run1.meta["key"] == pyvalue1
+
+    # set meta indicators of different types ("value"-column of type `object`)
+    run1.meta = {"key": npvalue1, "other key": "some value"}
     assert run1.meta["key"] == pyvalue1
 
     run1.meta["key"] = npvalue2
@@ -114,4 +119,4 @@ def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     run2 = test_mp.Run("Model", "Scenario")
 
     # assert meta by run
-    assert dict(run2.meta) == {"key": pyvalue2}
+    assert dict(run2.meta) == {"key": pyvalue2, "other key": "some value"}

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -113,10 +113,10 @@ def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     run1.meta = {"key": npvalue1, "other key": "some value"}
     assert run1.meta["key"] == pyvalue1
 
+    # set meta via setter
     run1.meta["key"] = npvalue2
     assert run1.meta["key"] == pyvalue2
 
+    # assert that meta values were saved and updated correctly
     run2 = test_mp.Run("Model", "Scenario")
-
-    # assert meta by run
     assert dict(run2.meta) == {"key": pyvalue2, "other key": "some value"}

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 
 from ..utils import all_platforms
 
@@ -88,7 +89,14 @@ def test_run_meta(test_mp):
 
 
 @all_platforms
-def test_run_meta_numpy_int(test_mp):
+@pytest.mark.parametrize(
+    "npvalue1, pyvalue1, npvalue2, pyvalue2",
+    [
+        (np.int64(1), 1, np.int64(13), 13),
+        (np.float64(1.9), 1.9, np.float(13.9), 13.9),
+    ],
+)
+def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     run1 = test_mp.Run(
         "Model",
         "Scenario",
@@ -97,13 +105,13 @@ def test_run_meta_numpy_int(test_mp):
     run1.set_as_default()
 
     # set and update different types of meta indicators
-    run1.meta = {"npint": np.int64(1)}
-    assert run1.meta["npint"] == 1
+    run1.meta = {"key": npvalue1}
+    assert run1.meta["key"] == pyvalue1
 
-    run1.meta["npint"] = np.int64(13)
-    assert run1.meta["npint"] == 13
+    run1.meta["key"] = npvalue2
+    assert run1.meta["key"] == pyvalue2
 
     run2 = test_mp.Run("Model", "Scenario")
 
     # assert meta by run
-    assert dict(run2.meta) == {"npint": 13}
+    assert dict(run2.meta) == {"key": pyvalue2}

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 
@@ -84,3 +85,25 @@ def test_run_meta(test_mp):
     run1.meta = {"mstr": "baz", "mfloat": 3.1415926535897}
     exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
     pdt.assert_frame_equal(test_mp.meta.tabulate(key="mstr"), exp)
+
+
+@all_platforms
+def test_run_meta_numpy_int(test_mp):
+    run1 = test_mp.Run(
+        "Model",
+        "Scenario",
+        version="new",
+    )
+    run1.set_as_default()
+
+    # set and update different types of meta indicators
+    run1.meta = {"npint": np.int64(1)}
+    assert run1.meta["npint"] == 1
+
+    run1.meta["npint"] = np.int64(13)
+    assert run1.meta["npint"] == 13
+
+    run2 = test_mp.Run("Model", "Scenario")
+
+    # assert meta by run
+    assert dict(run2.meta) == {"npint": 13}

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -89,7 +89,7 @@ def test_run_meta(test_mp):
     "npvalue1, pyvalue1, npvalue2, pyvalue2",
     [
         (np.int64(1), 1, np.int64(13), 13),
-        (np.float64(1.9), 1.9, np.float(13.9), 13.9),
+        (np.float64(1.9), 1.9, np.float128(13.9), 13.9),
     ],
 )
 def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):


### PR DESCRIPTION
This PR implements a quick-fix when setting meta-indicators with numpy-types, as are used in pd.DataFrames. The PR also improves handling of `None`, so that these values are ignored when setting from a dictionary `run.meta = {"key": None}` and are used as "delete" when using the setter like `run.meta["key"] = None`.