### PR TITLE
Change filter-wildcard to `*`

### DIFF
--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -17,19 +17,19 @@ def in_(c, v):
 
 
 def like(c, v):
-    return c.like(v)
+    return c.like(escape_wildcard(v), escape="\\")
 
 
 def ilike(c, v):
-    return c.ilike(v)
+    return c.ilike(escape_wildcard(v), escape="\\")
 
 
 def notlike(c, v):
-    return c.notlike(v)
+    return c.notlike(escape_wildcard(v), escape="\\")
 
 
 def notilike(c, v):
-    return c.notilike(v)
+    return c.notilike(escape_wildcard(v), escape="\\")
 
 
 def gt(c, v):
@@ -46,6 +46,10 @@ def gte(c, v):
 
 def lte(c, v):
     return c <= v
+
+
+def escape_wildcard(v):
+    return v.replace("%", "\\%").replace("*", "%")
 
 
 class Integer(int):

--- a/tests/data/test_iamc_datapoint.py
+++ b/tests/data/test_iamc_datapoint.py
@@ -15,6 +15,9 @@ from ..utils import add_regions, add_units, all_platforms, assert_unordered_equa
         ({"region": {"name__in": ["World"]}}, ("region", "__eq__", "World")),
         ({"region": {"hierarchy": "default"}}, ("region", "isin", ["World", "Europe"])),
         ({"unit": {"name": "EJ/yr"}}, ("unit", "__eq__", "EJ/yr")),
+        ({"unit": {"name": "%"}}, ("unit", "__eq__", "%")),
+        ({"unit": {"name__like": "*"}}, ("unit", "isin", ["EJ/yr", "%"])),
+        ({"unit": {"name__like": "%"}}, ("unit", "__eq__", "%")),
         (
             {"variable": {"name__in": ["Primary Energy"]}},
             ("variable", "isin", ["Primary Energy"]),
@@ -47,7 +50,7 @@ def test_filtering(test_mp, filter, exp_filter):
         add_regions(test_mp, data.region.unique())
         add_units(test_mp, data.unit.unique())
         # add the data for two different models to test filtering
-        test_mp.Run(f"model_{i+1}", f"scen_{i+1}", version="new").iamc.add(data)
+        test_mp.Run(f"model_{i + 1}", f"scen_{i + 1}", version="new").iamc.add(data)
 
     obs = (
         test_mp.backend.iamc.datapoints.tabulate(join_parameters=True, **filter)

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -59,7 +59,7 @@ class TestDataModel:
     def test_filter_model(self, test_mp):
         run1, _ = create_filter_test_data(test_mp)
 
-        res = test_mp.backend.models.tabulate(name__like="Model %")
+        res = test_mp.backend.models.tabulate(name__like="Model *")
         assert sorted(res["name"].tolist()) == ["Model 1", "Model 2"]
 
         res = test_mp.backend.models.tabulate(


### PR DESCRIPTION
The pyam package and the manager-service use `*` as a wildcard, whereas SQL uses `%`.

This PR changes the API to be consistent with pyam, and also adding escaping to the string-like-filters so that it is possible to filter (only) for the percentage sign as a unit.