### PR TITLE
Show extended run-"index" from `Platform.meta.tabulate()`

### DIFF
--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -1,19 +1,18 @@
 import pandas as pd
 
+from .run import RunRepository
 from .base import BaseFacade
 
 
 class MetaRepository(BaseFacade):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.runs = RunRepository(_backend=self.backend)
+
     def tabulate(self, **kwargs) -> pd.DataFrame:
         # TODO: accept list of `Run` instances as arg
-
-        runs = self.backend.runs.tabulate(**kwargs.get("run", {})).set_index("id")
-        meta = self.backend.meta.tabulate(**kwargs)
-
-        for column, mapper in [
-            ("model", self.backend.models.map()),
-            ("scenario", self.backend.scenarios.map()),
-        ]:
-            meta[column] = meta["run__id"].map(dict(runs[f"{column}__id"])).map(mapper)
-        meta["version"] = meta["run__id"].map(dict(runs["version"])).map(int)
+        runs = self.runs.tabulate(**kwargs.get("run", {}))
+        meta = self.backend.meta.tabulate(**kwargs).merge(
+            runs, left_on="run__id", right_on="id"
+        )
         return meta[["model", "scenario", "version", "key", "value"]]

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from .run import RunRepository
 from .base import BaseFacade
+from .run import RunRepository
 
 
 class MetaRepository(BaseFacade):

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -6,9 +6,14 @@ from .base import BaseFacade
 class MetaRepository(BaseFacade):
     def tabulate(self, **kwargs) -> pd.DataFrame:
         # TODO: accept list of `Run` instances as arg
-        # TODO: expand run-id to model-scenario-version-id columns
-        return (
-            self.backend.meta.tabulate(**kwargs)
-            .drop(columns=["id", "type"])
-            .rename(columns={"run__id": "run_id"})
-        )
+
+        runs = self.backend.runs.tabulate(**kwargs.get("run", {})).set_index("id")
+        meta = self.backend.meta.tabulate(**kwargs)
+
+        for column, mapper in [
+            ("model", self.backend.models.map()),
+            ("scenario", self.backend.scenarios.map()),
+        ]:
+            meta[column] = meta["run__id"].map(dict(runs[f"{column}__id"])).map(mapper)
+        meta["version"] = meta["run__id"].map(dict(runs["version"])).map(int)
+        return meta[["model", "scenario", "version", "key", "value"]]

--- a/ixmp4/core/model.py
+++ b/ixmp4/core/model.py
@@ -74,6 +74,9 @@ class ModelRepository(BaseFacade):
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
         return self.backend.models.tabulate(name=name)
 
+    def map(self) -> dict:
+        return self.backend.scenarios.map()
+
     def _get_model_id(self, model: str) -> int | None:
         if model is None:
             return None

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -88,12 +88,8 @@ class RunRepository(BaseFacade):
 
     def tabulate(self, default_only: bool = True) -> pd.DataFrame:
         runs = self.backend.runs.tabulate(default_only=default_only)
-        runs["model"] = runs["model__id"].map(
-            dict([(m.id, m.name) for m in self.backend.models.list()])
-        )
-        runs["scenario"] = runs["scenario__id"].map(
-            dict([(s.id, s.name) for s in self.backend.scenarios.list()])
-        )
+        runs["model"] = runs["model__id"].map(self.backend.models.map())
+        runs["scenario"] = runs["scenario__id"].map(self.backend.scenarios.map())
         return runs[["id", "model", "scenario", "version", "is_default"]]
 
 

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -71,7 +71,7 @@ class Run(BaseModelFacade):
         self._meta._set(meta)
 
     def set_as_default(self):
-        """Sets this run as the default version for its `model` + `scenario` combination."""
+        """Sets this run as default version for this `model - scenario` combination."""
         self.backend.runs.set_as_default_version(self._model.id)
 
     def unset_as_default(self):
@@ -80,14 +80,14 @@ class Run(BaseModelFacade):
 
 
 class RunRepository(BaseFacade):
-    def list(self, default_only: bool = True) -> Iterable[Run]:
+    def list(self, default_only: bool = True, **kwargs) -> Iterable[Run]:
         return [
             Run(_backend=self.backend, _model=r)
-            for r in self.backend.runs.list(default_only=default_only)
+            for r in self.backend.runs.list(default_only=default_only, **kwargs)
         ]
 
-    def tabulate(self, default_only: bool = True) -> pd.DataFrame:
-        runs = self.backend.runs.tabulate(default_only=default_only)
+    def tabulate(self, default_only: bool = True, **kwargs) -> pd.DataFrame:
+        runs = self.backend.runs.tabulate(default_only=default_only, **kwargs)
         runs["model"] = runs["model__id"].map(self.backend.models.map())
         runs["scenario"] = runs["scenario__id"].map(self.backend.scenarios.map())
         return runs[["id", "model", "scenario", "version", "is_default"]]

--- a/ixmp4/core/scenario.py
+++ b/ixmp4/core/scenario.py
@@ -74,6 +74,9 @@ class ScenarioRepository(BaseFacade):
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
         return self.backend.scenarios.tabulate(name=name)
 
+    def map(self) -> dict:
+        return self.backend.scenarios.map()
+
     def _get_scenario_id(self, scenario: str) -> int | None:
         if scenario is None:
             return None

--- a/ixmp4/data/abstract/model.py
+++ b/ixmp4/data/abstract/model.py
@@ -113,3 +113,13 @@ class ModelRepository(
 
         """
         ...
+
+    def map(self):
+        """A dictionary of id to name
+
+        Returns
+        -------
+        :class:`dict`:
+            A dictionary `id` -> `name`
+        """
+        ...

--- a/ixmp4/data/abstract/scenario.py
+++ b/ixmp4/data/abstract/scenario.py
@@ -105,3 +105,12 @@ class ScenarioRepository(base.Creator, base.Retriever, base.Enumerator, Protocol
                 - name
         """
         ...
+
+    def map(self) -> dict:
+        """Return a mapping of scenario-id to scenario-name
+
+        Returns
+        -------
+        :class:`dict`
+        """
+        ...

--- a/ixmp4/data/api/model.py
+++ b/ixmp4/data/api/model.py
@@ -54,6 +54,9 @@ class ModelRepository(
     def enumerate(self, *args, **kwargs) -> Iterable[Model] | pd.DataFrame:
         return super().enumerate(*args, **kwargs)
 
+    def map(self, *args, **kwargs):
+        return dict([(m.id, m.name) for m in self.list(*args, **kwargs)])
+
 
 class ModelDocsRepository(DocsRepository):
     model_class = Docs

--- a/ixmp4/data/api/scenario.py
+++ b/ixmp4/data/api/scenario.py
@@ -57,3 +57,6 @@ class ScenarioRepository(
 
     def enumerate(self, *args, **kwargs) -> Iterable[Scenario] | pd.DataFrame:
         return super().enumerate(*args, **kwargs)
+
+    def map(self, *args, **kwargs):
+        return dict([(s.id, s.name) for s in self.list(*args, **kwargs)])

--- a/ixmp4/data/db/model/repository.py
+++ b/ixmp4/data/db/model/repository.py
@@ -52,3 +52,13 @@ class ModelRepository(
     @guard("view")
     def tabulate(self, *args, **kwargs) -> pd.DataFrame:
         return super().tabulate(*args, **kwargs)
+
+    def map(self, *args, **kwargs):
+        """A dictionary of id to name
+
+        Returns
+        -------
+        :class:`dict`:
+            A dictionary `id` -> `name`
+        """
+        return dict([(m.id, m.name) for m in self.list(*args, **kwargs)])

--- a/ixmp4/data/db/scenario/repository.py
+++ b/ixmp4/data/db/scenario/repository.py
@@ -62,3 +62,6 @@ class ScenarioRepository(
     @guard("view")
     def tabulate(self, *args, **kwargs) -> pd.DataFrame:
         return super().tabulate(*args, **kwargs)
+
+    def map(self):
+        return dict([(s.id, s.name) for s in self.list()])

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -6,16 +6,19 @@ import pytest
 from ..utils import all_platforms
 
 
+EXP_META_COLS = ["model", "scenario", "version", "key", "value"]
+
+
 @all_platforms
 def test_run_meta(test_mp):
-    run1 = test_mp.Run("Model", "Scenario", version="new")
+    run1 = test_mp.Run("Model 1", "Scenario 1", version="new")
     run1.set_as_default()
 
     # set and update different types of meta indicators
     run1.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
     run1.meta["mfloat"] = -1.9
 
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.Run("Model 1", "Scenario 1")
 
     # assert meta by run
     assert dict(run2.meta) == {"mint": 13, "mfloat": -1.9, "mstr": "foo"}
@@ -23,56 +26,70 @@ def test_run_meta(test_mp):
 
     # assert meta via platform
     exp = pd.DataFrame(
-        [[1, "mint", 13], [1, "mstr", "foo"], [1, "mfloat", -1.9]],
-        columns=["run_id", "key", "value"],
+        [
+            ["Model 1", "Scenario 1", 1, "mint", 13],
+            ["Model 1", "Scenario 1", 1, "mstr", "foo"],
+            ["Model 1", "Scenario 1", 1, "mfloat", -1.9],
+        ],
+        columns=EXP_META_COLS,
     )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
     # remove all meta indicators and set a new indicator
     run1.meta = {"mnew": "bar"}
 
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.Run("Model 1", "Scenario 1")
 
     # assert meta by run
     assert dict(run2.meta) == {"mnew": "bar"}
     assert dict(run1.meta) == {"mnew": "bar"}
 
     # assert meta via platform
-    exp = pd.DataFrame([[1, "mnew", "bar"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mnew", "bar"]], columns=EXP_META_COLS
+    )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
     del run1.meta["mnew"]
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.Run("Model 1", "Scenario 1")
 
     # assert meta by run
     assert dict(run2.meta) == {}
     assert dict(run1.meta) == {}
 
     # assert meta via platform
-    exp = pd.DataFrame([], columns=["run_id", "key", "value"])
-    pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
+    exp = pd.DataFrame([], columns=EXP_META_COLS)
+    pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp, check_dtype=False)
 
     run2 = test_mp.Run("Model 2", "Scenario 2", version="new")
     run1.meta = {"mstr": "baz"}
     run2.meta = {"mfloat": 3.1415926535897}
 
     # test default_only run filter
-    exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
+    )
     # run={"default_only": True} is default
     pdt.assert_frame_equal(test_mp.meta.tabulate(), exp)
 
     exp = pd.DataFrame(
-        [[1, "mstr", "baz"], [2, "mfloat", 3.1415926535897]],
-        columns=["run_id", "key", "value"],
+        [
+            ["Model 1", "Scenario 1", 1, "mstr", "baz"],
+            ["Model 2", "Scenario 2", 1, "mfloat", 3.1415926535897],
+        ],
+        columns=EXP_META_COLS,
     )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run={"default_only": False}), exp)
 
     # test is_default run filter
-    exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
+    )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run={"is_default": True}), exp)
 
     exp = pd.DataFrame(
-        [[2, "mfloat", 3.1415926535897]], columns=["run_id", "key", "value"]
+        [["Model 2", "Scenario 2", 1, "mfloat", 3.1415926535897]],
+        columns=EXP_META_COLS,
     )
     pdt.assert_frame_equal(
         test_mp.meta.tabulate(run={"default_only": False, "is_default": False}), exp
@@ -80,7 +97,9 @@ def test_run_meta(test_mp):
 
     # test filter by key
     run1.meta = {"mstr": "baz", "mfloat": 3.1415926535897}
-    exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
+    )
     pdt.assert_frame_equal(test_mp.meta.tabulate(key="mstr"), exp)
 
 


### PR DESCRIPTION
While further working on the pyam-imxp4-integration, I noticed an inconsistency:
- `Platform.runs.tabulate()` returns a dataframe with the columns run-id, model, scenario, version
- `Platform.iamc.tabulate()` returns a dataframe with (only) the "user-readable index" model, scenario, version, ...
- `Platform.meta.tabulate()` returns a dataframe only with (only) the run-id, ...

In actual work (like the pyam-integration), the model-scenario-version is more relevant.

So this PR extends the `Platform.meta.tabulate()` to return the "extended index" of model-name, scenario-name and version number.

As a utility, the PR also adds a `map()` endpoint to the model- and scenario-repository for easy translation of id's to names.

If there is a need for having (only) the run-id at the facade/core-layer, I'd be happy to implement that as a kwarg to both iamc/meta tabulate methods (and if someone has a good suggestion for the name of that argument...)