### PR TITLE
Refactor the facade API to create/get runs

### DIFF
--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -25,8 +25,6 @@ In development mode additional commands are available:
 
 """
 
-from functools import partial
-
 from ixmp4.conf import settings
 from ixmp4.conf.auth import BaseAuth
 from ixmp4.core.exceptions import PlatformNotFound
@@ -36,7 +34,6 @@ from .iamc import IamcRepository
 from .meta import MetaRepository
 from .model import ModelRepository
 from .region import RegionRepository
-from .run import Run as RunModel
 from .run import RunRepository
 from .scenario import ScenarioRepository
 from .unit import UnitRepository

--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -46,8 +46,6 @@ class Platform(object):
     """A modeling platform instance as a connection to a data backend.
     Enables the manipulation of data via the `Run` class and `Repository` instances."""
 
-    Run: partial[RunModel]
-
     runs: RunRepository
     iamc: IamcRepository
     models: ModelRepository
@@ -84,8 +82,6 @@ class Platform(object):
             self.backend = _backend
         else:
             raise TypeError("__init__() is missing required argument 'name'")
-
-        self.Run = partial(RunModel, _backend=self.backend)
 
         self.runs = RunRepository(_backend=self.backend)
         self.iamc = IamcRepository(_backend=self.backend)

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -65,7 +65,7 @@ class RunRepository(BaseFacade):
         self,
         model: str,
         scenario: str,
-    ):
+    ) -> Run:
         return Run(
             _backend=self.backend, _model=self.backend.runs.create(model, scenario)
         )
@@ -75,7 +75,7 @@ class RunRepository(BaseFacade):
         model: str,
         scenario: str,
         version: int | None = None,
-    ):
+    ) -> Run:
         if version is None:
             _model = self.backend.runs.get_default_version(model, scenario)
         else:

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -68,7 +68,7 @@ def test_run_tabulate_with_filter(test_mp, test_data_annual):
     add_regions(test_mp, test_data_annual["region"].unique())
     add_units(test_mp, test_data_annual["unit"].unique())
 
-    run = test_mp.Run("Model", "Scenario", version="new")
+    run = test_mp.runs.create("Model", "Scenario")
     run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
     obs = run.iamc.tabulate(
         variable={"name": "Primary Energy"}, unit={"name": "EJ/yr"}
@@ -89,7 +89,7 @@ def do_run_datapoints(test_mp, ixmp_data, type=None, arg_data=None):
     add_regions(test_mp, ixmp_data["region"].unique())
     add_units(test_mp, ixmp_data["unit"].unique())
 
-    run = test_mp.Run("Model", "Scenario", version="new")
+    run = test_mp.runs.create("Model", "Scenario")
 
     # == Full Addition ==
     # Save to database

--- a/tests/core/test_indexset.py
+++ b/tests/core/test_indexset.py
@@ -6,7 +6,7 @@ from ..utils import all_platforms
 @all_platforms
 class TestCoreIndexSet:
     def test_create_indexset(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         index_set_1 = run.optimization.IndexSet("IndexSet 1")
         returned_index_set_1 = run.optimization.IndexSet("IndexSet 1")
         assert index_set_1.id == returned_index_set_1.id
@@ -15,7 +15,7 @@ class TestCoreIndexSet:
         assert index_set_1.id != index_set_2.id
 
     def test_add_elements(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         test_elements = ["foo", "bar"]
         index_set_1 = run.optimization.IndexSet("IndexSet 1")
         index_set_1.add(test_elements)
@@ -37,7 +37,7 @@ class TestCoreIndexSet:
         assert len(index_set_3.elements) == len(index_set_4.elements)
 
     def test_indexset_docs(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         index_set_1 = run.optimization.IndexSet("IndexSet 1")
         docs = "Documentation of IndexSet 1"
         index_set_1.docs = docs

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -8,14 +8,14 @@ from ..utils import all_platforms
 
 @all_platforms
 def test_run_meta(test_mp):
-    run1 = test_mp.Run("Model", "Scenario", version="new")
+    run1 = test_mp.runs.create("Model", "Scenario")
     run1.set_as_default()
 
     # set and update different types of meta indicators
     run1.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
     run1.meta["mfloat"] = -1.9
 
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.runs.get("Model", "Scenario")
 
     # assert meta by run
     assert dict(run2.meta) == {"mint": 13, "mfloat": -1.9, "mstr": "foo"}
@@ -31,7 +31,7 @@ def test_run_meta(test_mp):
     # remove all meta indicators and set a new indicator
     run1.meta = {"mnew": "bar"}
 
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.runs.get("Model", "Scenario")
 
     # assert meta by run
     assert dict(run2.meta) == {"mnew": "bar"}
@@ -42,7 +42,7 @@ def test_run_meta(test_mp):
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
     del run1.meta["mnew"]
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.runs.get("Model", "Scenario")
 
     # assert meta by run
     assert dict(run2.meta) == {}
@@ -52,7 +52,7 @@ def test_run_meta(test_mp):
     exp = pd.DataFrame([], columns=["run_id", "key", "value"])
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
-    run2 = test_mp.Run("Model 2", "Scenario 2", version="new")
+    run2 = test_mp.runs.create("Model 2", "Scenario 2")
     run1.meta = {"mstr": "baz"}
     run2.meta = {"mfloat": 3.1415926535897}
 
@@ -94,7 +94,7 @@ def test_run_meta(test_mp):
 )
 def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     """Test that numpy types are cast to simple types"""
-    run1 = test_mp.Run("Model", "Scenario", version="new")
+    run1 = test_mp.runs.create("Model", "Scenario")
     run1.set_as_default()
 
     # set multiple meta indicators of same type ("value"-column of numpy-type)
@@ -110,7 +110,7 @@ def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
     assert run1.meta["key"] == pyvalue2
 
     # assert that meta values were saved and updated correctly
-    run2 = test_mp.Run("Model", "Scenario")
+    run2 = test_mp.runs.get("Model", "Scenario")
     assert dict(run2.meta) == {"key": pyvalue2, "other key": "some value"}
 
 
@@ -118,7 +118,7 @@ def test_run_meta_numpy(test_mp, npvalue1, pyvalue1, npvalue2, pyvalue2):
 @pytest.mark.parametrize("nonevalue", (None, np.nan))
 def test_run_meta_none(test_mp, nonevalue):
     """Test that None-values are handled correctly"""
-    run1 = test_mp.Run("Model", "Scenario", version="new")
+    run1 = test_mp.runs.create("Model", "Scenario")
     run1.set_as_default()
 
     # set multiple indicators where one value is None
@@ -127,11 +127,11 @@ def test_run_meta_none(test_mp, nonevalue):
     with pytest.raises(KeyError, match="'mnone'"):
         run1.meta["mnone"]
 
-    assert dict(test_mp.Run("Model", "Scenario").meta) == {"mint": 13}
+    assert dict(test_mp.runs.get("Model", "Scenario").meta) == {"mint": 13}
 
     # delete indicator via setter
     run1.meta["mint"] = nonevalue
     with pytest.raises(KeyError, match="'mint'"):
         run1.meta["mint"]
 
-    assert not dict(test_mp.Run("Model", "Scenario").meta)
+    assert not dict(test_mp.runs.get("Model", "Scenario").meta)

--- a/tests/core/test_region.py
+++ b/tests/core/test_region.py
@@ -38,7 +38,7 @@ class TestCoreRegion:
         add_regions(test_mp, test_data_annual["region"].unique())
         add_units(test_mp, test_data_annual["unit"].unique())
 
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
 
         with pytest.raises(Region.DeletionPrevented):
@@ -74,7 +74,7 @@ class TestCoreRegion:
 
         test_data_annual["region"] = "foo"
 
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         with pytest.raises(Region.NotFound):
             run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
 

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -22,14 +22,14 @@ def _expected_runs_table(*row_default):
 @all_platforms
 class TestCoreRun:
     def test_run_versions(self, test_mp):
-        run1 = test_mp.Run("Model", "Scenario", version="new")
-        run2 = test_mp.Run("Model", "Scenario", version="new")
+        run1 = test_mp.runs.create("Model", "Scenario")
+        run2 = test_mp.runs.create("Model", "Scenario")
 
         assert run1.id != run2.id
 
         # no default version is assigned, so list & tabulate are empty
         with pytest.raises(Run.NoDefaultVersion):
-            run = test_mp.Run("Model", "Scenario")
+            _ = test_mp.runs.get("Model", "Scenario")
         assert test_mp.runs.list() == []
         assert test_mp.runs.tabulate().empty
 
@@ -58,12 +58,12 @@ class TestCoreRun:
         )
 
         # default version can be retrieved directly
-        run = test_mp.Run("Model", "Scenario")
+        run = test_mp.runs.get("Model", "Scenario")
         assert run1.id == run.id
 
         # default version can be changed
         run2.set_as_default()
-        run = test_mp.Run("Model", "Scenario")
+        run = test_mp.runs.get("Model", "Scenario")
         assert run2.id == run.id
 
         # list shows changed default version only
@@ -78,7 +78,7 @@ class TestCoreRun:
         # unsetting default means run cannot be retrieved directly
         run2.unset_as_default()
         with pytest.raises(Run.NoDefaultVersion):
-            test_mp.Run("Model", "Scenario")
+            test_mp.runs.get("Model", "Scenario")
 
         # non-default version cannot be again set as un-default
         with pytest.raises(IxmpError):
@@ -135,7 +135,7 @@ class TestCoreRun:
         add_regions(test_mp, test_data_annual["region"].unique())
         add_units(test_mp, test_data_annual["unit"].unique())
 
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
         obs = run.iamc.tabulate(
             variable={"name": "Primary Energy"}, unit={"name": "EJ/yr"}
@@ -156,7 +156,7 @@ def do_run_datapoints(test_mp, ixmp_data, type=None, arg_data=None):
     add_regions(test_mp, ixmp_data["region"].unique())
     add_units(test_mp, ixmp_data["unit"].unique())
 
-    run = test_mp.Run("Model", "Scenario", version="new")
+    run = test_mp.runs.create("Model", "Scenario")
 
     # == Full Addition ==
     # Save to database

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -21,6 +21,11 @@ def _expected_runs_table(*row_default):
 
 @all_platforms
 class TestCoreRun:
+    def test_run_notfound(self, test_mp):
+        # no Run with that model and scenario name exists
+        with pytest.raises(Run.NotFound):
+            _ = test_mp.runs.get("Unknown Model", "Unknown Scenario", version=1)
+
     def test_run_versions(self, test_mp):
         run1 = test_mp.runs.create("Model", "Scenario")
         run2 = test_mp.runs.create("Model", "Scenario")

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -38,6 +38,10 @@ class TestCoreRun:
         assert test_mp.runs.list() == []
         assert test_mp.runs.tabulate().empty
 
+        # getting a specific version works even if no default version is assigned
+        assert run1.id == test_mp.runs.get("Model", "Scenario", version=1).id
+
+        # getting the table and list for all runs works
         run_list = test_mp.runs.list(default_only=False)
         assert len(run_list) == 2
         assert run_list[0].id == run1.id

--- a/tests/core/test_unit.py
+++ b/tests/core/test_unit.py
@@ -39,7 +39,7 @@ class TestCoreUnit:
         add_regions(test_mp, test_data_annual["region"].unique())
         add_units(test_mp, test_data_annual["unit"].unique())
 
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
 
         with pytest.raises(Unit.DeletionPrevented):
@@ -78,7 +78,7 @@ class TestCoreUnit:
 
         test_data_annual["unit"] = "foo"
 
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         with pytest.raises(Unit.NotFound):
             run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
 

--- a/tests/core/test_variable.py
+++ b/tests/core/test_variable.py
@@ -23,7 +23,7 @@ def create_testcase_iamc_variables(test_mp):
         ],
         columns=["region", "variable", "unit", "step_year", "value"],
     )
-    run = test_mp.Run("Model", "Scenario", "new")
+    run = test_mp.runs.create("Model", "Scenario")
     run.iamc.add(variable_data, type=ixmp4.DataPoint.Type.ANNUAL)
     run.set_as_default()
 
@@ -50,7 +50,7 @@ class TestCoreVariable:
             ],
             columns=["region", "variable", "unit", "step_year", "value"],
         )
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.iamc.add(variable_data, type=ixmp4.DataPoint.Type.ANNUAL)
         run.set_as_default()
 

--- a/tests/data/test_iamc_datapoint.py
+++ b/tests/data/test_iamc_datapoint.py
@@ -50,7 +50,7 @@ def test_filtering(test_mp, filter, exp_filter):
         add_regions(test_mp, data.region.unique())
         add_units(test_mp, data.unit.unique())
         # add the data for two different models to test filtering
-        test_mp.Run(f"model_{i + 1}", f"scen_{i + 1}", version="new").iamc.add(data)
+        test_mp.runs.create(f"model_{i + 1}", f"scen_{i + 1}").iamc.add(data)
 
     obs = (
         test_mp.backend.iamc.datapoints.tabulate(join_parameters=True, **filter)

--- a/tests/data/test_meta.py
+++ b/tests/data/test_meta.py
@@ -22,7 +22,7 @@ TEST_ENTRIES_DF = pd.DataFrame(
 @all_platforms
 class TestDataMeta:
     def test_create_get_entry(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.set_as_default()
 
         for key, value, type in TEST_ENTRIES:
@@ -38,7 +38,7 @@ class TestDataMeta:
             assert entry.type == type
 
     def test_entry_unique(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         test_mp.backend.meta.create(run.id, "Key", "Value")
 
         with pytest.raises(RunMetaEntry.NotUnique):
@@ -51,13 +51,13 @@ class TestDataMeta:
         with pytest.raises(RunMetaEntry.NotFound):
             test_mp.backend.meta.get(-1, "Key")
 
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
 
         with pytest.raises(RunMetaEntry.NotFound):
             test_mp.backend.meta.get(run.id, "Key")
 
     def test_delete_entry(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         entry = test_mp.backend.meta.create(run.id, "Key", "Value")
         test_mp.backend.meta.delete(entry.id)
 
@@ -65,7 +65,7 @@ class TestDataMeta:
             test_mp.backend.meta.get(run.id, "Key")
 
     def test_list_entry(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.set_as_default()
 
         for key, value, _ in TEST_ENTRIES:
@@ -79,7 +79,7 @@ class TestDataMeta:
             assert entry.type == type
 
     def test_tabulate_entry(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.set_as_default()
 
         for key, value, _ in TEST_ENTRIES:
@@ -92,9 +92,9 @@ class TestDataMeta:
         assert_unordered_equality(entries, true_entries)
 
     def test_tabulate_entries_with_run_filters(self, test_mp):
-        run1 = test_mp.Run("Model", "Scenario", "new")
+        run1 = test_mp.runs.create("Model", "Scenario")
         run1.set_as_default()
-        run2 = test_mp.Run("Model 2", "Scenario 2", "new")
+        run2 = test_mp.runs.create("Model 2", "Scenario 2")
 
         # Splitting the loop to more easily correct the id column below
         for key, value, _ in TEST_ENTRIES:
@@ -127,7 +127,7 @@ class TestDataMeta:
         )
 
     def test_tabulate_entries_with_key_filters(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", "new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.set_as_default()
 
         for key, value, _ in TEST_ENTRIES:
@@ -144,7 +144,7 @@ class TestDataMeta:
         assert_unordered_equality(entry, true_entry, check_dtype=False)
 
     def test_entry_bulk_operations(self, test_mp):
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         run.set_as_default()
 
         entries = TEST_ENTRIES_DF.copy()
@@ -204,7 +204,7 @@ class TestDataMeta:
             ],
             columns=["key", "value"],
         )
-        run = test_mp.Run("Model", "Scenario", version="new")
+        run = test_mp.runs.create("Model", "Scenario")
         entries["run__id"] = run.id
 
         duplicated_entries = pd.concat([entries] * 2, ignore_index=True)

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -30,8 +30,8 @@ class TestDataModel:
             test_mp.models.get("Model")
 
     def test_list_model(self, test_mp):
-        test_mp.Run("Model 1", "Scenario", version="new")
-        test_mp.Run("Model 2", "Scenario", version="new")
+        test_mp.runs.create("Model 1", "Scenario")
+        test_mp.runs.create("Model 2", "Scenario")
 
         models = sorted(test_mp.backend.models.list(), key=lambda x: x.id)
         assert models[0].id == 1
@@ -40,8 +40,8 @@ class TestDataModel:
         assert models[1].name == "Model 2"
 
     def test_tabulate_model(self, test_mp):
-        test_mp.Run("Model 1", "Scenario", version="new")
-        test_mp.Run("Model 2", "Scenario", version="new")
+        test_mp.runs.create("Model 1", "Scenario")
+        test_mp.runs.create("Model 2", "Scenario")
 
         true_models = pd.DataFrame(
             [

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -57,8 +57,8 @@ class TestDataModel:
         )
 
     def test_map_model(self, test_mp):
-        test_mp.Run("Model 1", "Scenario", version="new")
-        test_mp.Run("Model 2", "Scenario", version="new")
+        test_mp.runs.create("Model 1", "Scenario")
+        test_mp.runs.create("Model 2", "Scenario")
         assert test_mp.backend.models.map() == {1: "Model 1", 2: "Model 2"}
 
     def test_filter_model(self, test_mp):

--- a/tests/data/test_scenario.py
+++ b/tests/data/test_scenario.py
@@ -58,8 +58,8 @@ class TestDataScenario:
         )
 
     def test_map_scenario(self, test_mp):
-        test_mp.Run("Model", "Scenario 1", version="new")
-        test_mp.Run("Model", "Scenario 2", version="new")
+        test_mp.runs.create("Model", "Scenario 1")
+        test_mp.runs.create("Model", "Scenario 2")
 
         assert test_mp.backend.scenarios.map() == {1: "Scenario 1", 2: "Scenario 2"}
 

--- a/tests/data/test_scenario.py
+++ b/tests/data/test_scenario.py
@@ -30,8 +30,8 @@ class TestDataScenario:
             test_mp.scenarios.get("Scenario")
 
     def test_list_scenario(self, test_mp):
-        test_mp.Run("Model", "Scenario 1", version="new")
-        test_mp.Run("Model", "Scenario 2", version="new")
+        test_mp.runs.create("Model", "Scenario 1")
+        test_mp.runs.create("Model", "Scenario 2")
 
         scenarios = sorted(test_mp.backend.scenarios.list(), key=lambda x: x.id)
 
@@ -41,8 +41,8 @@ class TestDataScenario:
         assert scenarios[1].name == "Scenario 2"
 
     def test_tabulate_scenario(self, test_mp):
-        test_mp.Run("Model", "Scenario 1", version="new")
-        test_mp.Run("Model", "Scenario 2", version="new")
+        test_mp.runs.create("Model", "Scenario 1")
+        test_mp.runs.create("Model", "Scenario 2")
 
         true_scenarios = pd.DataFrame(
             [

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -129,7 +129,7 @@ def test_guards(user, truths, test_sqlite_mp):
     mp.regions.create("Test Region", hierarchy="default")
     mp.units.create("Test Unit")
 
-    run = mp.Run("Model", "Scenario", version="new")
+    run = mp.runs.create("Model", "Scenario")
     run.iamc.add(TEST_DF, type=ixmp4.DataPoint.Type.ANNUAL)
     run.set_as_default()
 
@@ -188,9 +188,9 @@ def test_guards(user, truths, test_sqlite_mp):
                     del u.docs
 
                 with pytest.raises(Forbidden):
-                    run = mp.Run("Model", "Scenario", version="new")
+                    mp.runs.create("Model", "Scenario")
 
-                run = mp.Run("Model", "Scenario")
+                run = mp.runs.get("Model", "Scenario")
 
                 with pytest.raises(Forbidden):
                     run.iamc.add(TEST_DF, type=ixmp4.DataPoint.Type.ANNUAL)
@@ -227,14 +227,14 @@ def test_filters(model, platform, access, test_mp, test_data_annual):
     add_regions(mp, test_data_annual["region"].unique())
     add_units(mp, test_data_annual["unit"].unique())
 
-    run = mp.Run(model, "Scenario", version="new")
+    run = mp.runs.create(model, "Scenario")
     run.iamc.add(test_data_annual, type=ixmp4.DataPoint.Type.ANNUAL)
     run.meta = {"meta": "test"}
     run.set_as_default()
 
     with mp.backend.auth(user, mock_manager, platform):
         if access in ["view", "edit"]:
-            run = mp.Run(model, "Scenario")
+            run = mp.runs.get(model, "Scenario")
             assert not run.iamc.tabulate().empty
             assert run.meta == {"meta": "test"}
             assert mp.models.list()[0].name == model
@@ -249,7 +249,7 @@ def test_filters(model, platform, access, test_mp, test_data_annual):
 
             else:
                 with pytest.raises(Forbidden):
-                    _ = mp.Run(model, "Scenario", version="new")
+                    _ = mp.runs.create(model, "Scenario")
 
                 with pytest.raises(Forbidden):
                     run.iamc.add(test_data_annual, type=ixmp4.DataPoint.Type.ANNUAL)
@@ -264,7 +264,7 @@ def test_filters(model, platform, access, test_mp, test_data_annual):
                     run.meta = {"meta": "test"}
         else:
             with pytest.raises((ixmp4.Run.NotFound, ixmp4.Run.NoDefaultVersion)):
-                mp.Run(model, "Scenario")
+                mp.runs.get(model, "Scenario")
 
             assert mp.runs.tabulate().empty
             assert mp.runs.tabulate(default_only=False).empty

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -18,9 +18,9 @@ def add_datapoints(test_mp, df, type=None):
         model_name, scenario_name = ms
 
         try:
-            run = test_mp.Run(model=model_name, scenario=scenario_name, version=1)
+            run = test_mp.runs.get(model=model_name, scenario=scenario_name, version=1)
         except NotFound:
-            run = test_mp.Run(model=model_name, scenario=scenario_name, version="new")
+            run = test_mp.runs.create(model=model_name, scenario=scenario_name)
 
         run.iamc.add(run_df.drop(columns=["model", "scenario"]), type=type)
 
@@ -31,9 +31,9 @@ def remove_datapoints(test_mp, df, type=None):
         model_name, scenario_name = ms
 
         try:
-            run = test_mp.Run(model=model_name, scenario=scenario_name, version=1)
+            run = test_mp.runs.get(model=model_name, scenario=scenario_name, version=1)
         except NotFound:
-            run = test_mp.Run(model=model_name, scenario=scenario_name, version="new")
+            run = test_mp.runs.create(model=model_name, scenario=scenario_name)
 
         run.iamc.remove(run_df.drop(columns=["model", "scenario"]), type=type)
 
@@ -43,7 +43,7 @@ def tabulate_datapoints(test_mp, **kwargs):
 
     dfs = []
     for run_model in runs:
-        run = test_mp.Run(_model=run_model)
+        run = test_mp.runs.get(_model=run_model)
         df = run.iamc.tabulate(**kwargs)
         df["model"] = run.model.name
         df["scenario"] = run.scenario.name

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -59,7 +59,7 @@ def create_filter_test_data(test_mp):
         test_mp.backend.units.create(f"Unit {str(i)}")
     test_mp.backend.units.create("Unit 5")
 
-    run1 = test_mp.Run("Model 1", "Scenario 1", "new")
+    run1 = test_mp.runs.create("Model 1", "Scenario 1")
     run1.set_as_default()
     run1_data = pd.DataFrame(
         [
@@ -72,7 +72,7 @@ def create_filter_test_data(test_mp):
     )
     run1.iamc.add(run1_data, type=DataPoint.Type.ANNUAL)
 
-    run2 = test_mp.Run("Model 1", "Scenario 1", "new")
+    run2 = test_mp.runs.create("Model 1", "Scenario 1")
     run2_data = pd.DataFrame(
         [
             ["Region 3", "Variable 1", "Unit 3", 2020, 1],
@@ -84,7 +84,7 @@ def create_filter_test_data(test_mp):
     )
     run2.iamc.add(run2_data, type=DataPoint.Type.ANNUAL)
 
-    run3 = test_mp.Run("Model 2", "Scenario 2", "new")
+    run3 = test_mp.runs.create("Model 2", "Scenario 2")
     run3.iamc.add(run2_data, type=DataPoint.Type.ANNUAL)
     run3.set_as_default()
 
@@ -92,9 +92,9 @@ def create_filter_test_data(test_mp):
 
 
 def create_iamc_query_test_data(test_mp):
-    run1 = test_mp.Run("Model 1", "Scenario 1", version="new")
+    run1 = test_mp.runs.create("Model 1", "Scenario 1")
     run1.set_as_default()
-    run2 = test_mp.Run("Model 2", "Scenario 2", version="new")
+    run2 = test_mp.runs.create("Model 2", "Scenario 2")
     run2.set_as_default()
     r1 = test_mp.backend.regions.create("Region 1", "Hierarchy")
     r2 = test_mp.backend.regions.create("Region 2", "Hierarchy")

--- a/tutorial/transport/py_transport.ipynb
+++ b/tutorial/transport/py_transport.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = mp.Run(model=\"transport problem\", scenario=\"standard\", version=\"new\")"
+    "run = mp.runs.create(model=\"transport problem\", scenario=\"standard\")"
    ]
   },
   {


### PR DESCRIPTION
As just discussed, this PR changes the API to create/get runs from the (implicit)

```python
Platform.Run(model, scenario, version="new")
```
to the more pythonic 
```python
Platform.runs.create(model, scenario)
```
and a corresponding get
```python
Platform.runs.get(model, scenario)
```

Maybe I'm a bit old-fashioned, but I'd still like to keep the default vs. non-default selection implicit in the `get()` method on the facade-layer.

fyi @pmussak @glatterf42 