### PR TITLE
Show extended run-"index" from `Platform.meta.tabulate()`

### DIFF
--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -7,8 +7,6 @@ class MetaRepository(BaseFacade):
     def tabulate(self, **kwargs) -> pd.DataFrame:
         # TODO: accept list of `Run` instances as arg
         # TODO: expand run-id to model-scenario-version-id columns
-        return (
-            self.backend.meta.tabulate(join_run_index=True, **kwargs)
-            .drop(columns=["id", "type"])
-            .rename(columns={"run__id": "run_id"})
+        return self.backend.meta.tabulate(join_run_index=True, **kwargs).drop(
+            columns=["id", "type"]
         )

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -8,7 +8,7 @@ class MetaRepository(BaseFacade):
         # TODO: accept list of `Run` instances as arg
         # TODO: expand run-id to model-scenario-version-id columns
         return (
-            self.backend.meta.tabulate(**kwargs)
+            self.backend.meta.tabulate(join_run_index=True, **kwargs)
             .drop(columns=["id", "type"])
             .rename(columns={"run__id": "run_id"})
         )

--- a/ixmp4/data/abstract/meta.py
+++ b/ixmp4/data/abstract/meta.py
@@ -144,7 +144,7 @@ class RunMetaEntryRepository(
 
     def tabulate(
         self,
-        join_run_index,
+        join_run_index: bool = False,
         **kwargs,
     ) -> pd.DataFrame:
         r"""Tabulates run's meta indicator entries by specified criteria.

--- a/ixmp4/data/abstract/meta.py
+++ b/ixmp4/data/abstract/meta.py
@@ -144,6 +144,7 @@ class RunMetaEntryRepository(
 
     def tabulate(
         self,
+        join_run_index,
         **kwargs,
     ) -> pd.DataFrame:
         r"""Tabulates run's meta indicator entries by specified criteria.

--- a/ixmp4/data/api/base.py
+++ b/ixmp4/data/api/base.py
@@ -129,11 +129,14 @@ class BaseRepository(Generic[ModelType]):
         params["table"] = table
         join_parameters = kwargs.pop("join_parameters", None)
         join_runs = kwargs.pop("join_runs", None)
+        join_run_index = kwargs.pop("join_run_index", None)
 
         if join_parameters is not None:
             params["join_parameters"] = join_parameters
         if join_runs is not None:
             params["join_runs"] = join_runs
+        if join_run_index is not None:
+            params["join_run_index"] = join_run_index
 
         if self.enumeration_method == "GET":
             params.update(kwargs)

--- a/ixmp4/data/db/base.py
+++ b/ixmp4/data/db/base.py
@@ -174,7 +174,6 @@ class Selecter(BaseRepository[ModelType]):
 
     def select(
         self,
-        *args,
         _filter: filters.BaseFilter | None = None,
         _exc: db.sql.Select | None = None,
         _access_type: str = "view",

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -143,6 +143,7 @@ class RunMetaEntryRepository(
     def tabulate(
         self,
         *args,
+        join_run_index: bool = False,
         _raw: bool | None = False,
         **kwargs,
     ) -> pd.DataFrame:

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -153,10 +153,9 @@ class RunMetaEntryRepository(
 
         if join_run_index:
             index_columns = ["model", "scenario", "version"]
-            _exc = select_joined_run_index(self)
+            _exc = select_joined_run_index(self, **kwargs)
             df = super().tabulate(*args, _exc=_exc, **kwargs)
-            if not df.empty:
-                df.drop(columns="run__id", inplace=True)
+            df.drop(columns="run__id", inplace=True)
         else:
             index_columns = ["run__id"]
             df = super().tabulate(*args, **kwargs)

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -155,9 +155,10 @@ class RunMetaEntryRepository(
             index_columns = ["model", "scenario", "version"]
             _exc = select_joined_run_index(self)
             df = super().tabulate(*args, _exc=_exc, **kwargs)
-            df.drop(columns="run__id", inplace=True)
+            if not df.empty:
+                df.drop(columns="run__id", inplace=True)
         else:
-            index_columns = ["run__id", "type", "key", "value"]
+            index_columns = ["run__id"]
             df = super().tabulate(*args, **kwargs)
 
         if df.empty:

--- a/ixmp4/data/db/run/repository.py
+++ b/ixmp4/data/db/run/repository.py
@@ -1,7 +1,9 @@
 from typing import Iterable
 
 import pandas as pd
+from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import Bundle
 
 from ixmp4 import db
 from ixmp4.core.exceptions import Forbidden, IxmpError, NoDefaultRunVersion
@@ -176,3 +178,17 @@ class RunRepository(
 
         run.is_default = False
         self.session.commit()
+
+
+def select_joined_run_index(repository) -> db.sql.Select:
+    _exc = select(
+        Bundle("Model", Model.name.label("model")),
+        Bundle("Scenario", Scenario.name.label("scenario")),
+        Bundle("Run", Run.version),
+        repository.bundle,
+    )
+    return (
+        repository.select(_exc=_exc)
+        .join(Model, onclause=Model.id == Run.model__id)
+        .join(Scenario, onclause=Scenario.id == Run.scenario__id)
+    )

--- a/ixmp4/data/db/run/repository.py
+++ b/ixmp4/data/db/run/repository.py
@@ -180,7 +180,7 @@ class RunRepository(
         self.session.commit()
 
 
-def select_joined_run_index(repository) -> db.sql.Select:
+def select_joined_run_index(repository, **kwargs) -> db.sql.Select:
     _exc = select(
         Bundle("Model", Model.name.label("model")),
         Bundle("Scenario", Scenario.name.label("scenario")),
@@ -188,7 +188,7 @@ def select_joined_run_index(repository) -> db.sql.Select:
         repository.bundle,
     )
     return (
-        repository.select(_exc=_exc)
+        repository.select(_exc=_exc, **kwargs)
         .join(Model, onclause=Model.id == Run.model__id)
         .join(Scenario, onclause=Scenario.id == Run.scenario__id)
     )

--- a/ixmp4/server/rest/meta.py
+++ b/ixmp4/server/rest/meta.py
@@ -39,10 +39,13 @@ def enumerate(
 @router.patch("/", response_model=EnumerationOutput)
 def query(
     filter: RunMetaEntryFilter = Body(None),
+    join_run_index: bool = Query(False),
     table: bool = Query(False),
     backend: Backend = Depends(deps.get_backend),
 ):
-    return backend.meta.enumerate(_filter=filter, table=bool(table))
+    return backend.meta.enumerate(
+        table=bool(table), _filter=filter, join_run_index=join_run_index
+    )
 
 
 @router.post("/", response_model=api.RunMetaEntry)

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -6,6 +6,9 @@ import pytest
 from ..utils import all_platforms
 
 
+EXP_META_COLS = ["model", "scenario", "version", "key", "value"]
+
+
 @all_platforms
 def test_run_meta(test_mp):
     run1 = test_mp.runs.create("Model 1", "Scenario 1")
@@ -23,8 +26,12 @@ def test_run_meta(test_mp):
 
     # assert meta via platform
     exp = pd.DataFrame(
-        [[1, "mint", 13], [1, "mstr", "foo"], [1, "mfloat", -1.9]],
-        columns=["run_id", "key", "value"],
+        [
+            ["Model 1", "Scenario 1", 1, "mint", 13],
+            ["Model 1", "Scenario 1", 1, "mstr", "foo"],
+            ["Model 1", "Scenario 1", 1, "mfloat", -1.9],
+        ],
+        columns=EXP_META_COLS,
     )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
@@ -38,7 +45,9 @@ def test_run_meta(test_mp):
     assert dict(run1.meta) == {"mnew": "bar"}
 
     # assert meta via platform
-    exp = pd.DataFrame([[1, "mnew", "bar"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mnew", "bar"]], columns=EXP_META_COLS
+    )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
     del run1.meta["mnew"]
@@ -49,30 +58,38 @@ def test_run_meta(test_mp):
     assert dict(run1.meta) == {}
 
     # assert meta via platform
-    exp = pd.DataFrame([], columns=["run_id", "key", "value"])
-    pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
+    exp = pd.DataFrame([], columns=EXP_META_COLS)
+    pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp, check_dtype=False)
 
     run2 = test_mp.runs.create("Model 2", "Scenario 2")
     run1.meta = {"mstr": "baz"}
     run2.meta = {"mfloat": 3.1415926535897}
 
     # test default_only run filter
-    exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
+    )
     # run={"default_only": True} is default
     pdt.assert_frame_equal(test_mp.meta.tabulate(), exp)
 
     exp = pd.DataFrame(
-        [[1, "mstr", "baz"], [2, "mfloat", 3.1415926535897]],
-        columns=["run_id", "key", "value"],
+        [
+            ["Model 1", "Scenario 1", 1, "mstr", "baz"],
+            ["Model 2", "Scenario 2", 1, "mfloat", 3.1415926535897],
+        ],
+        columns=EXP_META_COLS,
     )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run={"default_only": False}), exp)
 
     # test is_default run filter
-    exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
+    )
     pdt.assert_frame_equal(test_mp.meta.tabulate(run={"is_default": True}), exp)
 
     exp = pd.DataFrame(
-        [[2, "mfloat", 3.1415926535897]], columns=["run_id", "key", "value"]
+        [["Model 2", "Scenario 2", 1, "mfloat", 3.1415926535897]],
+        columns=EXP_META_COLS,
     )
     pdt.assert_frame_equal(
         test_mp.meta.tabulate(run={"default_only": False, "is_default": False}), exp
@@ -80,7 +97,9 @@ def test_run_meta(test_mp):
 
     # test filter by key
     run1.meta = {"mstr": "baz", "mfloat": 3.1415926535897}
-    exp = pd.DataFrame([[1, "mstr", "baz"]], columns=["run_id", "key", "value"])
+    exp = pd.DataFrame(
+        [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
+    )
     pdt.assert_frame_equal(test_mp.meta.tabulate(key="mstr"), exp)
 
 

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -154,3 +154,10 @@ def test_run_meta_none(test_mp, nonevalue):
         run1.meta["mint"]
 
     assert not dict(test_mp.runs.get("Model", "Scenario").meta)
+
+
+@all_platforms
+def test_platform_meta_empty(test_mp):
+    """Test that an empty dataframe is returned if there are no scenarios"""
+    exp = pd.DataFrame([], columns=["model", "scenario", "version", "key", "value"])
+    pdt.assert_frame_equal(test_mp.meta.tabulate(), exp)

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -8,14 +8,14 @@ from ..utils import all_platforms
 
 @all_platforms
 def test_run_meta(test_mp):
-    run1 = test_mp.runs.create("Model", "Scenario")
+    run1 = test_mp.runs.create("Model 1", "Scenario 1")
     run1.set_as_default()
 
     # set and update different types of meta indicators
     run1.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
     run1.meta["mfloat"] = -1.9
 
-    run2 = test_mp.runs.get("Model", "Scenario")
+    run2 = test_mp.runs.get("Model 1", "Scenario 1")
 
     # assert meta by run
     assert dict(run2.meta) == {"mint": 13, "mfloat": -1.9, "mstr": "foo"}
@@ -31,7 +31,7 @@ def test_run_meta(test_mp):
     # remove all meta indicators and set a new indicator
     run1.meta = {"mnew": "bar"}
 
-    run2 = test_mp.runs.get("Model", "Scenario")
+    run2 = test_mp.runs.get("Model 1", "Scenario 1")
 
     # assert meta by run
     assert dict(run2.meta) == {"mnew": "bar"}
@@ -42,7 +42,7 @@ def test_run_meta(test_mp):
     pdt.assert_frame_equal(test_mp.meta.tabulate(run_id=1), exp)
 
     del run1.meta["mnew"]
-    run2 = test_mp.runs.get("Model", "Scenario")
+    run2 = test_mp.runs.get("Model 1", "Scenario 1")
 
     # assert meta by run
     assert dict(run2.meta) == {}


### PR DESCRIPTION
Per review comment by @meksor at https://github.com/iiasa/ixmp4/pull/33#issuecomment-1829810151, this PR has an alternative implementation to show the model-scenario-version "index" of the meta dataframe.

The joining of columns is now done on the database layer using a new argument `join_run_index`, following the logic that the model-scenario[-version] columns are called "index" in pyam. [Alternative suggestions for the argument-name welcome.]

The argument is optional on the backend, defaulting to show only the run-id. But when calling the meta-dataframe from the facade, the extended "index" is returned.