### PR TITLE
Fix dynamic versioning

### DIFF
--- a/ixmp4/__init__.py
+++ b/ixmp4/__init__.py
@@ -16,4 +16,5 @@ from ixmp4.core.exceptions import NotFound as NotFound
 from ixmp4.core.exceptions import NotUnique as NotUnique
 from ixmp4.data.abstract import DataPoint as DataPoint
 
-__version__ = importlib.metadata.version("ixmp4")
+__version__ = "0.0.0"
+__version_tuple__ = (0, 0, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ line-length = 88
 max-complexity = 10
 
 [tool.poetry-dynamic-versioning]
-bump = true
 enable = true
 style = "pep440"
 vcs = "git"


### PR DESCRIPTION
Was pretty simple: the plugin runs some simple string substitution over all files, making it work by just using these two lines in the top level `__init__.py`:

```py
__version__ = "0.0.0"
__version_tuple__ = (0, 0, 0)
```