### PR TITLE
Fix filters only being callable once

### DIFF
--- a/ixmp4/data/db/base.py
+++ b/ixmp4/data/db/base.py
@@ -265,13 +265,12 @@ class Enumerator(Lister[ModelType], Tabulator[ModelType]):
 
     def count(
         self,
-        _exc: db.sql.Select | None = None,
-        *args,
         **kwargs,
     ) -> int:
-        if _exc is None:
-            _exc = self.select(*args, **kwargs)
-        _exc = db.select(db.func.count()).select_from(_exc.subquery())
+        _exc = self.select(
+            _exc=db.select(db.func.count()).select_from(self.model_class),
+            **kwargs,
+        )
         return self.session.execute(_exc).scalar_one()
 
 

--- a/ixmp4/data/db/base.py
+++ b/ixmp4/data/db/base.py
@@ -268,7 +268,9 @@ class Enumerator(Lister[ModelType], Tabulator[ModelType]):
         **kwargs,
     ) -> int:
         _exc = self.select(
-            _exc=db.select(db.func.count()).select_from(self.model_class),
+            _exc=db.select(db.func.count(self.model_class.id.distinct())).select_from(
+                self.model_class
+            ),
             **kwargs,
         )
         return self.session.execute(_exc).scalar_one()

--- a/ixmp4/data/db/docs.py
+++ b/ixmp4/data/db/docs.py
@@ -49,13 +49,16 @@ class BaseDocsRepository(
 ):
     dimension_model_class: ClassVar[type[base.BaseModel]]
 
-    def select(self, *, dimension_id: int | None = None) -> db.sql.Select:
-        exc: db.sql.Select = db.select(self.model_class)
+    def select(
+        self, *, _exc: db.sql.Select | None = None, dimension_id: int | None = None
+    ) -> db.sql.Select:
+        if _exc is None:
+            _exc = db.select(self.model_class)
 
         if dimension_id is not None:
-            exc = exc.where(self.model_class.dimension__id == dimension_id)
+            _exc = _exc.where(self.model_class.dimension__id == dimension_id)
 
-        return exc
+        return _exc
 
     def add(self, dimension_id: int, description: str) -> DocsType:
         docs = self.model_class(description=description, dimension__id=dimension_id)

--- a/ixmp4/data/generator.py
+++ b/ixmp4/data/generator.py
@@ -120,12 +120,12 @@ class MockDataGenerator(object):
             ],
         )
         if type == DataPoint.Type.ANNUAL:
-            amount = min(40, max)
+            amount = min(20, max)
             start_year = random.randint(1950, 2000)
             steps_annual = [start_year + i for i in range(amount)]
             df["step_year"] = steps_annual
         if type == DataPoint.Type.CATEGORICAL:
-            amount = min(100, max)
+            amount = min(50, max)
             num_categories = random.randint(2, 10)
             start_year = random.randint(1950, 2000)
             categories = cycle([f"Category {i}" for i in range(num_categories)])
@@ -138,7 +138,7 @@ class MockDataGenerator(object):
             df["step_year"] = steps_year
             df["step_category"] = steps_category
         if type == DataPoint.Type.DATETIME:
-            amount = min(200, max)
+            amount = min(100, max)
             dt = timedelta(minutes=random.randint(1, 360) * 10)
             start_dt = datetime(
                 year=random.randint(1950, 2000),
@@ -154,10 +154,10 @@ class MockDataGenerator(object):
         return df
 
     def generate(self):
-        model_names = cycle(self.yield_model_names())
-        runs = cycle(self.yield_runs(model_names=model_names))
-        regions = cycle(self.yield_regions())
-        units = cycle(self.yield_units())
-        variable_names = cycle(self.yield_variable_names())
+        model_names = cycle([n for n in self.yield_model_names()])
+        runs = cycle([r for r in self.yield_runs(model_names=model_names)])
+        regions = cycle([r for r in self.yield_regions()])
+        units = cycle([u for u in self.yield_units()])
+        variable_names = cycle([v for v in self.yield_variable_names()])
         for df in self.yield_datapoints(runs, variable_names, units, regions):
             pass

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -258,7 +258,7 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
     def __init__(self, **data: Any) -> None:
         try:
             super().__init__(**data)
-            self._dumped_model = self.model_dump(mode="json")
+            self._dumped_model = dict(self)
         except ValidationError as e:
             raise BadFilterArguments(model=e.title, errors=e.errors())
 

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -258,6 +258,7 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
     def __init__(self, **data: Any) -> None:
         try:
             super().__init__(**data)
+            self._dumped_model = self.model_dump(mode="json")
         except ValidationError as e:
             raise BadFilterArguments(model=e.title, errors=e.errors())
 
@@ -266,8 +267,7 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
 
     def apply(self, exc: db.sql.Select, model, session) -> db.sql.Select:
         for name, field_info in self.model_fields.items():
-            value = getattr(self, name, field_info.get_default())
-
+            value = self._dumped_model.get(name, field_info.get_default())
             if isinstance(value, BaseFilter):
                 submodel = getattr(value, "sqla_model", None)
                 model_getter = getattr(value, "get_sqla_model", None)

--- a/ixmp4/server/rest/region.py
+++ b/ixmp4/server/rest/region.py
@@ -22,7 +22,7 @@ class RegionInput(BaseModel):
 @autodoc
 @router.patch("/", response_model=EnumerationOutput[api.Region])
 def query(
-    filter: RegionFilter = Body(None),
+    filter: RegionFilter = Body(RegionFilter()),
     table: bool = Query(False),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -1,0 +1,49 @@
+import pytest
+
+from ..utils import gen_obj_nums, generated_api_platforms
+
+
+@generated_api_platforms
+@pytest.mark.parametrize(
+    "endpoint,filters,total",
+    [
+        (
+            "models/",
+            {"iamc": {"run": {"default_only": False}}},
+            gen_obj_nums["num_models"],
+        ),
+        ("runs/", {"default_only": False}, gen_obj_nums["num_runs"]),
+        (
+            "regions/",
+            None,
+            gen_obj_nums["num_regions"],
+        ),
+        (
+            "units/",
+            {"iamc": {"run": {"default_only": False}}},
+            gen_obj_nums["num_units"],
+        ),
+        (
+            "iamc/datapoints/",
+            {"run": {"default_only": False}},
+            gen_obj_nums["num_datapoints"],
+        ),
+    ],
+)
+def test_pagination(generated_mp, endpoint, filters, total):
+    client = generated_mp.backend.client
+    offset, limit = None, None
+    while offset is None or offset + limit < total:
+        url = endpoint + "?table=true"
+        if offset is not None:
+            url += f"&offset={offset}&limit={limit}"
+        res = client.patch(url, json=filters)
+        data = res.json()
+        pagination = data.pop("pagination")
+        offset, limit = pagination["offset"], pagination["limit"]
+        ret_total = data.pop("total")
+        num_expected = min(total - offset, limit)
+        num_ret = len(data["results"]["index"])
+        assert num_ret == num_expected
+        assert ret_total == total
+        offset += limit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from ixmp4.data.backend import RestTestBackend, SqliteTestBackend
 from ixmp4.data.backend.db import PostgresTestBackend
 from ixmp4.data.generator import MockDataGenerator
 
+from .utils import gen_obj_nums
+
 TEST_DATA_BIG = None
 try:
     TEST_DATA_BIG = pd.read_csv("./tests/test-data/iamc-test-data_annual_big.csv")
@@ -157,13 +159,5 @@ def test_api_pgsql_mp_generated(test_pgsql_mp_generated):
 
 
 def generate_mock_data(mp):
-    gen = MockDataGenerator(
-        mp,
-        num_models=10,
-        num_runs=30,
-        num_regions=100,
-        num_variables=200,
-        num_units=50,
-        num_datapoints=10_000,
-    )
+    gen = MockDataGenerator(mp, **gen_obj_nums)
     gen.generate()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pandas.testing as pdt
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 from ixmp4 import DataPoint
 
@@ -26,38 +27,54 @@ def assert_unordered_equality(df1, df2, **kwargs):
 all_platforms = pytest.mark.parametrize(
     "test_mp",
     [
-        pytest.lazy_fixture("test_sqlite_mp"),
-        pytest.lazy_fixture("test_pgsql_mp"),
-        pytest.lazy_fixture("test_api_sqlite_mp"),
-        pytest.lazy_fixture("test_api_pgsql_mp"),
+        lazy_fixture("test_sqlite_mp"),
+        lazy_fixture("test_pgsql_mp"),
+        lazy_fixture("test_api_sqlite_mp"),
+        lazy_fixture("test_api_pgsql_mp"),
     ],
 )
 
 generated_platforms = pytest.mark.parametrize(
     "generated_mp",
     [
-        pytest.lazy_fixture("test_sqlite_mp_generated"),
-        pytest.lazy_fixture("test_pgsql_mp_generated"),
-        pytest.lazy_fixture("test_api_sqlite_mp_generated"),
-        pytest.lazy_fixture("test_api_pgsql_mp_generated"),
+        lazy_fixture("test_sqlite_mp_generated"),
+        lazy_fixture("test_pgsql_mp_generated"),
+        lazy_fixture("test_api_sqlite_mp_generated"),
+        lazy_fixture("test_api_pgsql_mp_generated"),
     ],
 )
 
+generated_api_platforms = pytest.mark.parametrize(
+    "generated_mp",
+    [
+        lazy_fixture("test_api_sqlite_mp_generated"),
+        lazy_fixture("test_api_pgsql_mp_generated"),
+    ],
+)
 
 api_platforms = pytest.mark.parametrize(
     "test_mp",
     [
-        pytest.lazy_fixture("test_api_sqlite_mp"),
-        pytest.lazy_fixture("test_api_pgsql_mp"),
+        lazy_fixture("test_api_sqlite_mp"),
+        lazy_fixture("test_api_pgsql_mp"),
     ],
 )
 
 database_platforms = pytest.mark.parametrize(
     "test_mp",
     [
-        pytest.lazy_fixture("test_sqlite_mp"),
-        pytest.lazy_fixture("test_pgsql_mp"),
+        lazy_fixture("test_sqlite_mp"),
+        lazy_fixture("test_pgsql_mp"),
     ],
+)
+
+gen_obj_nums = dict(
+    num_models=10,
+    num_runs=30,
+    num_regions=100,
+    num_variables=200,
+    num_units=50,
+    num_datapoints=10_000,
 )
 
 


### PR DESCRIPTION
Weirdly, when calling model_dump twice on the same pydantic model instance, the second time all fields defined with "Iterable" are empty...
Added a fix to circumvent this. 