### PR TITLE
add iamc filter for tabulate/ list runs

### DIFF
--- a/ixmp4/data/db/run/filter.py
+++ b/ixmp4/data/db/run/filter.py
@@ -1,7 +1,27 @@
 from ixmp4.data.db import filters as base
-from ixmp4.db import filters
+from ixmp4.data.db.iamc.datapoint import get_datapoint_model
+from ixmp4.data.db.iamc.timeseries import TimeSeries
+from ixmp4.data.db.run.model import Run
+from ixmp4.db import filters, utils
+
+
+class IamcRunFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
+    region: base.RegionFilter
+    variable: base.VariableFilter
+    unit: base.UnitFilter
+
+    def join(self, exc, session=None):
+        if not utils.is_joined(exc, TimeSeries):
+            exc = exc.join(TimeSeries, onclause=TimeSeries.run__id == Run.id)
+
+        model = get_datapoint_model(session)
+        if not utils.is_joined(exc, model):
+            exc = exc.join(model, onclause=model.time_series__id == TimeSeries.id)
+        return exc
 
 
 class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):
+    iamc: IamcRunFilter | filters.Boolean
+
     def join(self, exc, **kwargs):
         return exc

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -96,7 +96,7 @@ class TestCoreRun:
 
     def test_filter_run(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
-        run1, _ = create_filter_test_data(test_mp)
+        run1, run2 = create_filter_test_data(test_mp)
 
         res = test_mp.runs.tabulate(
             default_only=False,
@@ -134,6 +134,22 @@ class TestCoreRun:
             default_only=False,
             scenario={"name": "Scenario 2"},
         )
+        assert sorted(res["model"].tolist()) == ["Model 2"]
+        assert sorted(res["scenario"].tolist()) == ["Scenario 2"]
 
+        remove_data = test_mp.iamc.tabulate(
+            model={"name": "Model 1"},
+            scenario={"name": "Scenario 1"},
+            run={"default_only": False},
+            region={"name": "Region 3"},
+        )
+        run1.iamc.remove(remove_data)
+        run2.iamc.remove(remove_data)
+        res = test_mp.runs.tabulate(
+            default_only=False,
+            iamc={
+                "region": {"name": "Region 3"},
+            },
+        )
         assert sorted(res["model"].tolist()) == ["Model 2"]
         assert sorted(res["scenario"].tolist()) == ["Scenario 2"]


### PR DESCRIPTION
Added `iamc` filter similar to `mp.backend.models.tabulate` and `mp.backend.scenarios.tabulate` to `mp.runs.tabulate` (all applies to `.list` methods as well).

Why was this added?
To be able to filter runs by whether they have `IAMC` data associated with certain properties, e.g. get all runs that have `IAMC` data for the `Cumulative Emissions|CO2` variable or the `World` region.

usage:
```
mp.runs.tabulate(
            iamc={
                "variable": {"name__like": "Cumulative Emissions|CO2*"},
                "unit": {"name": "World"},
            }
        )
```