### PR TITLE
Fetch tags in CI for correct version

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
+      #------------------------------------
+      #  check-out repo and set-up python
+      #------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
         with:
@@ -23,37 +23,42 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
+
+      #------------------------------
+      #  install & configure poetry  
+      #------------------------------
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+
       #----------------------------------
       #  install dynamic version plugin  
       #----------------------------------
       - name: Install poetry-dynamic-versioning
         run: poetry self add "poetry-dynamic-versioning[plugin]"
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
+
+      #------------------------------------
+      #  load cached venv if cache exists
+      #------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
+
+      #------------------------
+      #  install root project
+      #------------------------
       - name: Install library
         run: poetry install --no-interaction --with docs,dev,server
-      #----------------------------------------------
-      #              build the docs
-      #----------------------------------------------
+
+      #------------------
+      #  build the docs
+      #------------------
       - name: Build the docs
         run: |
           source .venv/bin/activate

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -16,6 +16,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -32,6 +32,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------
+      #  install dynamic version plugin  
+      #----------------------------------
+      - name: Install poetry-dynamic-versioning
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
+      #------------------------------------
+      #  check-out repo and set-up python
+      #------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
         with:
@@ -25,9 +25,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
+
+      #------------------------------
+      #  install & configure poetry  
+      #------------------------------
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depths: 0
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -93,6 +93,8 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: actions/setup-python@v5
       #----------------------------------------------
       #  -----  install & configure poetry  -----
@@ -103,6 +105,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------
+      #  install dynamic version plugin  
+      #----------------------------------
+      - name: Install poetry-dynamic-versioning
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depths: 0
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5
@@ -53,6 +53,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------
+      #  install dynamic version plugin  
+      #----------------------------------
+      - name: Install poetry-dynamic-versioning
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------
@@ -94,7 +99,7 @@ jobs:
       #----------------------------------------------
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depths: 0
       - uses: actions/setup-python@v5
       #----------------------------------------------
       #  -----  install & configure poetry  -----

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,9 +32,9 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
+      #------------------------------------
+      #  check-out repo and set-up python
+      #------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
         with:
@@ -44,47 +44,53 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
+
+      #------------------------------
+      #  install & configure poetry  
+      #------------------------------
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+
       #----------------------------------
       #  install dynamic version plugin  
       #----------------------------------
       - name: Install poetry-dynamic-versioning
         run: poetry self add "poetry-dynamic-versioning[plugin]"
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
+
+      #------------------------------------
+      #  load cached venv if cache exists
+      #------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
+
+      #------------------------------------------------
+      #  install dependencies if cache does not exist
+      #------------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root --with dev,server
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
+
       - name: Install PyArrow
         if: ${{ matrix.with-pyarrow }}
         run: pip install pyarrow
 
+      #------------------------
+      #  install root project
+      #------------------------
       - name: Install library
         run: poetry install --no-interaction
-      #----------------------------------------------
-      #              run test suite
-      #----------------------------------------------
+
+      #------------------
+      #  run test suite
+      #------------------
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -94,48 +100,54 @@ jobs:
     name: Code quality
     runs-on: ubuntu-latest
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
+      #------------------------------------
+      #  check-out repo and set-up python
+      #------------------------------------
       - uses: actions/checkout@v4
         with:
           fetch-depths: 0
       - uses: actions/setup-python@v5
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
+
+      #------------------------------
+      #  install & configure poetry  
+      #------------------------------
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+
       #----------------------------------
       #  install dynamic version plugin  
       #----------------------------------
       - name: Install poetry-dynamic-versioning
         run: poetry self add "poetry-dynamic-versioning[plugin]"
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
+
+      #------------------------------------
+      #  load cached venv if cache exists
+      #------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
+
+      #------------------------------------------------
+      #  install dependencies if cache does not exist
+      #------------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root --with dev,server
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
+
+      #------------------------
+      #  install root project
+      #------------------------
       - name: Install library
         run: poetry install --no-interaction
-      #----------------------------------------------
-      # run pre-commit/(mypy, black, ruff)
-      #----------------------------------------------
+
+      #-------------------------------
+      #  run pre-commit/(mypy, ruff)
+      #-------------------------------
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,6 +37,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5


### PR DESCRIPTION
I noticed before that our CI is not installing the correct version of our own library (it keeps being registered as v0.0.0). While reading up on [poetry-dynamic-versioning limitations](https://pypi.org/project/poetry-dynamic-versioning/), I found a [note about Dunamai's limitations](https://github.com/mtkennerly/dunamai#other-notes), which powers poetry-dynamic-versioning. In order to register the version correctly in GitHub Actions, they recommend running the checkout action with `fetch-depth: 0`, which fetches all history for all branches and tags. However, [v4 of the checkout action](https://github.com/actions/checkout) also offers `fetch-tags`, which is `false` by default. 
In theory, this sounds exactly like the thing we need, so this PR sets it to `true` in the relevant workflows. 