### PR TITLE
Fix typo in action input

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depths: 0
+          fetch-depth: 0
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depths: 0
+          fetch-depth: 0
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5
@@ -105,7 +105,7 @@ jobs:
       #------------------------------------
       - uses: actions/checkout@v4
         with:
-          fetch-depths: 0
+          fetch-depth: 0
       - uses: actions/setup-python@v5
 
       #------------------------------


### PR DESCRIPTION
#59 introduced a typo in some ci keywords, unfortunately. `fetch-depths` is unknown, it should be `fetch-depth` instead. This PR fixes.