### PR TITLE
Implement simple filters

### DIFF
--- a/ixmp4/data/db/iamc/datapoint/filter.py
+++ b/ixmp4/data/db/iamc/datapoint/filter.py
@@ -1,7 +1,5 @@
 from typing import ClassVar
 
-from pydantic import model_validator
-
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
 from ixmp4.data.db.iamc.measurand import Measurand
 from ixmp4.data.db.iamc.timeseries import TimeSeries
@@ -20,11 +18,6 @@ class RegionFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
 
     sqla_model: ClassVar[type] = Region
 
-    @model_validator(mode="before")
-    @classmethod
-    def expand_simple_filters(cls, v):
-        return filters.expand_simple_filter(v)
-
     def join(self, exc, session):
         model = get_datapoint_model(session)
         if not utils.is_joined(exc, TimeSeries):
@@ -38,11 +31,6 @@ class UnitFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
     name: filters.String
 
     sqla_model: ClassVar[type] = Unit
-
-    @model_validator(mode="before")
-    @classmethod
-    def expand_simple_filters(cls, v):
-        return filters.expand_simple_filter(v)
 
     def join(self, exc, session):
         model = get_datapoint_model(session)
@@ -61,11 +49,6 @@ class VariableFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
 
     sqla_model: ClassVar[type] = Variable
 
-    @model_validator(mode="before")
-    @classmethod
-    def expand_simple_filters(cls, v):
-        return filters.expand_simple_filter(v)
-
     def join(self, exc, session):
         model = get_datapoint_model(session)
         if not utils.is_joined(exc, TimeSeries):
@@ -82,11 +65,6 @@ class ModelFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
 
     sqla_model: ClassVar[type] = Model
 
-    @model_validator(mode="before")
-    @classmethod
-    def expand_simple_filters(cls, v):
-        return filters.expand_simple_filter(v)
-
     def join(self, exc, session):
         model = get_datapoint_model(session)
         if not utils.is_joined(exc, TimeSeries):
@@ -102,11 +80,6 @@ class ScenarioFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
     name: filters.String
 
     sqla_model: ClassVar[type] = Scenario
-
-    @model_validator(mode="before")
-    @classmethod
-    def expand_simple_filters(cls, v):
-        return filters.expand_simple_filter(v)
 
     def join(self, exc, session):
         model = get_datapoint_model(session)

--- a/ixmp4/data/db/iamc/datapoint/filter.py
+++ b/ixmp4/data/db/iamc/datapoint/filter.py
@@ -1,5 +1,7 @@
 from typing import ClassVar
 
+from pydantic import model_validator
+
 from ixmp4.data.db.iamc.datapoint import get_datapoint_model
 from ixmp4.data.db.iamc.measurand import Measurand
 from ixmp4.data.db.iamc.timeseries import TimeSeries
@@ -18,6 +20,11 @@ class RegionFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
 
     sqla_model: ClassVar[type] = Region
 
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        return filters.expand_simple_filter(v)
+
     def join(self, exc, session):
         model = get_datapoint_model(session)
         if not utils.is_joined(exc, TimeSeries):
@@ -31,6 +38,11 @@ class UnitFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
     name: filters.String
 
     sqla_model: ClassVar[type] = Unit
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        return filters.expand_simple_filter(v)
 
     def join(self, exc, session):
         model = get_datapoint_model(session)
@@ -49,6 +61,11 @@ class VariableFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
 
     sqla_model: ClassVar[type] = Variable
 
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        return filters.expand_simple_filter(v)
+
     def join(self, exc, session):
         model = get_datapoint_model(session)
         if not utils.is_joined(exc, TimeSeries):
@@ -65,6 +82,11 @@ class ModelFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
 
     sqla_model: ClassVar[type] = Model
 
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        return filters.expand_simple_filter(v)
+
     def join(self, exc, session):
         model = get_datapoint_model(session)
         if not utils.is_joined(exc, TimeSeries):
@@ -80,6 +102,11 @@ class ScenarioFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
     name: filters.String
 
     sqla_model: ClassVar[type] = Scenario
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        return filters.expand_simple_filter(v)
 
     def join(self, exc, session):
         model = get_datapoint_model(session)

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -255,14 +255,6 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
     )
     sqla_model: ClassVar[type | None] = None
 
-    @model_validator(mode="before")
-    @classmethod
-    def expand_simple_filters(cls, v):
-        for key, value in v.items():
-            if key in ["model", "scenario", "region", "variable", "unit"]:
-                v[key] = expand_simple_filter(value)
-        return v
-
     def __init__(self, **data: Any) -> None:
         try:
             super().__init__(**data)

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -307,5 +307,9 @@ def expand_simple_filter(value):
             return dict(name__like=value)
         else:
             return dict(name=value)
+    elif isinstance(value, list):
+        if any(["*" in v for v in value]):
+            raise NotImplementedError("Filter by list with wildcard is not implemented")
+        return dict(name__in=value)
 
     return value

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -255,6 +255,18 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
     )
     sqla_model: ClassVar[type | None] = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        for key, value in v.items():
+            if key in ["model", "scenario", "region", "variable", "unit"]:
+                if isinstance(value, str):
+                    if "*" in value:
+                        v[key] = dict(name__in=value)
+                    else:
+                        v[key] = dict(name=value)
+        return v
+
     def __init__(self, **data: Any) -> None:
         try:
             super().__init__(**data)

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -1,7 +1,7 @@
 from types import UnionType
 from typing import Any, ClassVar, Optional, Union, get_args, get_origin
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from pydantic.fields import FieldInfo
 
 from ixmp4 import db
@@ -254,6 +254,11 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
         populate_by_name=True,
     )
     sqla_model: ClassVar[type | None] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_simple_filters(cls, v):
+        return expand_simple_filter(v)
 
     def __init__(self, **data: Any) -> None:
         try:

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -260,11 +260,7 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
     def expand_simple_filters(cls, v):
         for key, value in v.items():
             if key in ["model", "scenario", "region", "variable", "unit"]:
-                if isinstance(value, str):
-                    if "*" in value:
-                        v[key] = dict(name__in=value)
-                    else:
-                        v[key] = dict(name=value)
+                v[key] = expand_simple_filter(value)
         return v
 
     def __init__(self, **data: Any) -> None:
@@ -311,3 +307,13 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
                     column = getattr(model, sqla_column, None)
                 exc = filter_func(exc, column, value, session=session)
         return exc.distinct()
+
+
+def expand_simple_filter(value):
+    if isinstance(value, str):
+        if "*" in value:
+            return dict(name__like=value)
+        else:
+            return dict(name=value)
+
+    return value

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -37,7 +37,7 @@ def test_run_categorical_datapoints_raw(test_mp, test_data_categorical, request)
 @all_platforms
 @pytest.mark.parametrize("_type", (DataPoint.Type.ANNUAL, DataPoint.Type.DATETIME))
 def test_run_inconsistent_categorical_raises(
-    test_mp, test_data_categorical, _type, request
+        test_mp, test_data_categorical, _type, request
 ):
     test_mp = request.getfixturevalue(test_mp)
     with pytest.raises(SchemaError):
@@ -53,7 +53,7 @@ def test_run_datetime_datapoints_raw(test_mp, test_data_datetime, request):
 @all_platforms
 @pytest.mark.parametrize("_type", (DataPoint.Type.ANNUAL, DataPoint.Type.CATEGORICAL))
 def test_run_inconsistent_datetime_type_raises(
-    test_mp, test_data_datetime, _type, request
+        test_mp, test_data_datetime, _type, request
 ):
     test_mp = request.getfixturevalue(test_mp)
     with pytest.raises(SchemaError):
@@ -76,7 +76,15 @@ def test_unit_as_string_dimensionless_raises(test_mp, test_data_annual, request)
 
 
 @all_platforms
-def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request):
+@pytest.mark.parametrize("filters", (
+        dict(variable={"name": "Primary Energy"}),
+        dict(variable={"name": "Primary Energy"}, unit={"name": "EJ/yr"}),
+        dict(variable={"name__like": "* Energy"}, unit={"name": "EJ/yr"}),
+        dict(variable="Primary Energy"),
+        dict(variable="Primary Energy", unit="EJ/yr"),
+        dict(variable="* Energy", unit="EJ/yr"),
+))
+def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request, filters):
     test_mp = request.getfixturevalue(test_mp)
     # Filter run directly
     add_regions(test_mp, test_data_annual["region"].unique())
@@ -84,9 +92,7 @@ def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request):
 
     run = test_mp.runs.create("Model", "Scenario")
     run.iamc.add(test_data_annual, type=DataPoint.Type.ANNUAL)
-    obs = run.iamc.tabulate(
-        raw=True, variable={"name": "Primary Energy"}, unit={"name": "EJ/yr"}
-    ).drop(["id", "type"], axis=1)
+    obs = run.iamc.tabulate(raw=True, **filters).drop(["id", "type"], axis=1)
     exp = test_data_annual[test_data_annual.variable == "Primary Energy"]
     assert_unordered_equality(obs, exp, check_like=True)
 

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -37,7 +37,7 @@ def test_run_categorical_datapoints_raw(test_mp, test_data_categorical, request)
 @all_platforms
 @pytest.mark.parametrize("_type", (DataPoint.Type.ANNUAL, DataPoint.Type.DATETIME))
 def test_run_inconsistent_categorical_raises(
-        test_mp, test_data_categorical, _type, request
+    test_mp, test_data_categorical, _type, request
 ):
     test_mp = request.getfixturevalue(test_mp)
     with pytest.raises(SchemaError):
@@ -53,7 +53,7 @@ def test_run_datetime_datapoints_raw(test_mp, test_data_datetime, request):
 @all_platforms
 @pytest.mark.parametrize("_type", (DataPoint.Type.ANNUAL, DataPoint.Type.CATEGORICAL))
 def test_run_inconsistent_datetime_type_raises(
-        test_mp, test_data_datetime, _type, request
+    test_mp, test_data_datetime, _type, request
 ):
     test_mp = request.getfixturevalue(test_mp)
     with pytest.raises(SchemaError):
@@ -76,7 +76,9 @@ def test_unit_as_string_dimensionless_raises(test_mp, test_data_annual, request)
 
 
 @all_platforms
-@pytest.mark.parametrize("filters", (
+@pytest.mark.parametrize(
+    "filters",
+    (
         dict(variable={"name": "Primary Energy"}),
         dict(variable={"name": "Primary Energy"}, unit={"name": "EJ/yr"}),
         dict(variable={"name__like": "* Energy"}, unit={"name": "EJ/yr"}),
@@ -85,7 +87,8 @@ def test_unit_as_string_dimensionless_raises(test_mp, test_data_annual, request)
         dict(variable="Primary Energy", unit="EJ/yr"),
         dict(variable="* Energy", unit="EJ/yr"),
         dict(variable=["Primary Energy", "Some Other Variable"]),
-))
+    ),
+)
 def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request, filters):
     test_mp = request.getfixturevalue(test_mp)
     # Filter run directly

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -80,9 +80,12 @@ def test_unit_as_string_dimensionless_raises(test_mp, test_data_annual, request)
         dict(variable={"name": "Primary Energy"}),
         dict(variable={"name": "Primary Energy"}, unit={"name": "EJ/yr"}),
         dict(variable={"name__like": "* Energy"}, unit={"name": "EJ/yr"}),
+        dict(variable={"name__in": ["Primary Energy", "Some Other Variable"]}),
         dict(variable="Primary Energy"),
         dict(variable="Primary Energy", unit="EJ/yr"),
         dict(variable="* Energy", unit="EJ/yr"),
+        dict(variable=["Primary Energy", "Some Other Variable"]),
+
 ))
 def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request, filters):
     test_mp = request.getfixturevalue(test_mp)

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -85,7 +85,6 @@ def test_unit_as_string_dimensionless_raises(test_mp, test_data_annual, request)
         dict(variable="Primary Energy", unit="EJ/yr"),
         dict(variable="* Energy", unit="EJ/yr"),
         dict(variable=["Primary Energy", "Some Other Variable"]),
-
 ))
 def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request, filters):
     test_mp = request.getfixturevalue(test_mp)

--- a/tests/data/test_iamc_datapoint.py
+++ b/tests/data/test_iamc_datapoint.py
@@ -71,7 +71,6 @@ def test_filtering(test_mp, filter, exp_filter, request):
 @pytest.mark.parametrize(
     "filter",
     [
-        {"unit": "test"},
         {"dne": {"dne": "test"}},
         {"region": {"dne": "test"}},
         {"region": {"name__in": False}},


### PR DESCRIPTION
This PR implements a "short-hand notation" for filters in the facade-layer following the conventions of the pyam package, which allows to do `df.filter(variable="Primary *")` for like-comparing (using * as a wildcard).

The implementation replaces string or lists to the more elaborate filter-dictionary-style used in the ixmp4 data layer and the Rest API.