### PR TITLE
Add filtering by model and scenario name in MetaRepository

### DIFF
--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -5,8 +5,7 @@ from .base import BaseFacade
 
 class MetaRepository(BaseFacade):
     def tabulate(self, **kwargs) -> pd.DataFrame:
-        # TODO: accept list of `Run` instances as arg
-        # TODO: expand run-id to model-scenario-version-id columns
+        # TODO: accept list of `Run` instances as argument
         return self.backend.meta.tabulate(join_run_index=True, **kwargs).drop(
             columns=["id", "type"]
         )

--- a/ixmp4/data/db/meta/filter.py
+++ b/ixmp4/data/db/meta/filter.py
@@ -1,24 +1,10 @@
-from typing import ClassVar
-
 from ixmp4.data.db import filters as base
-from ixmp4.data.db.model import Model
 from ixmp4.data.db.run import Run
-from ixmp4.data.db.scenario import Scenario
+from ixmp4.data.db.model.filter import ModelFilter
+from ixmp4.data.db.scenario.filter import ScenarioFilter
 from ixmp4.db import filters, utils
 
 from .model import RunMetaEntry
-
-
-class ModelFilter(base.RunFilter, metaclass=filters.FilterMeta):
-    name: filters.String
-
-    sqla_model: ClassVar[type] = Model
-
-
-class ScenarioFilter(base.RunFilter, metaclass=filters.FilterMeta):
-    name: filters.String
-
-    sqla_model: ClassVar[type] = Scenario
 
 
 class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):

--- a/ixmp4/data/db/meta/filter.py
+++ b/ixmp4/data/db/meta/filter.py
@@ -1,8 +1,24 @@
+from typing import ClassVar
+
 from ixmp4.data.db import filters as base
+from ixmp4.data.db.model import Model
 from ixmp4.data.db.run import Run
+from ixmp4.data.db.scenario import Scenario
 from ixmp4.db import filters, utils
 
 from .model import RunMetaEntry
+
+
+class ModelFilter(base.RunFilter, metaclass=filters.FilterMeta):
+    name: filters.String
+
+    sqla_model: ClassVar[type] = Model
+
+
+class ScenarioFilter(base.RunFilter, metaclass=filters.FilterMeta):
+    name: filters.String
+
+    sqla_model: ClassVar[type] = Scenario
 
 
 class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):
@@ -13,6 +29,8 @@ class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):
 
 
 class RunMetaEntryFilter(base.RunMetaEntryFilter, metaclass=filters.FilterMeta):
+    model: ModelFilter
+    scenario: ScenarioFilter
     run: RunFilter = filters.Field(
         default=RunFilter(id=None, version=None, is_default=True)
     )


### PR DESCRIPTION
For the integration with **pyam**, I want a feature to filter the MetaRepository by model and scenario name, like
```python
platform.meta.tabulate(run={'default_only': True}, scenario={name="scen_a"})
```

The PR below implements these filters and they work as expected, but I get the following warning
```
/Users/dh/.venv/iamc/lib/python3.12/site-packages/pandas/io/sql.py:1600: SAWarning:
SELECT statement has a cartesian product between FROM element(s) "runmetaentry"
and FROM element "scenario".  Apply join condition(s) between each element to resolve.
```

Any pointers to how/where to resolve that, @meksor @pmussak?

