### PR TITLE
Fix API deletes

### DIFF
--- a/ixmp4/data/api/base.py
+++ b/ixmp4/data/api/base.py
@@ -232,7 +232,7 @@ class BaseRepository(Generic[ModelType]):
         return self._request("POST", *args, **kwargs)  # type: ignore
 
     def _delete(self, id: int):
-        self._request("DELETE", self.prefix + str(id))
+        self._request("DELETE", f"{self.prefix}{str(id)}/")
 
 
 class Retriever(BaseRepository[ModelType]):

--- a/ixmp4/server/rest/__init__.py
+++ b/ixmp4/server/rest/__init__.py
@@ -19,7 +19,7 @@ from .iamc import variable as iamc_variable
 from .middleware import RequestSizeLoggerMiddleware, RequestTimeLoggerMiddleware
 from .optimization import indexset, scalar
 
-v1 = FastAPI(servers=[{"url": "/v1", "description": "v1"}])
+v1 = FastAPI(servers=[{"url": "/v1", "description": "v1"}], redirect_slashes=False)
 
 if settings.mode == "debug":
     v1.add_middleware(RequestSizeLoggerMiddleware)

--- a/ixmp4/server/rest/__init__.py
+++ b/ixmp4/server/rest/__init__.py
@@ -19,7 +19,12 @@ from .iamc import variable as iamc_variable
 from .middleware import RequestSizeLoggerMiddleware, RequestTimeLoggerMiddleware
 from .optimization import indexset, scalar
 
-v1 = FastAPI(servers=[{"url": "/v1", "description": "v1"}], redirect_slashes=False)
+v1 = FastAPI(
+    servers=[{"url": "/v1", "description": "v1"}],
+    redirect_slashes=False,
+    docs_url="/docs/",
+    redoc_url="/redoc/",
+)
 
 if settings.mode == "debug":
     v1.add_middleware(RequestSizeLoggerMiddleware)


### PR DESCRIPTION
Currently on the production setup deletes fail because no trailing slash is added in the api layer and there is some mishap in how that request is redirected...
I've fixed the api layer and set `redirect_slashes=False` for fastapi. All requests to endpoints without trailing slashed will thus result in a `404`. 
The docs are now also served with trailing slashes so i can use an nginx rewrite instead of the fastapi redirect.
Should fix #57