### PR TITLE
Add option to (top-level) filter `meta` by model and scenario

### DIFF
--- a/ixmp4/data/db/meta/filter.py
+++ b/ixmp4/data/db/meta/filter.py
@@ -1,5 +1,7 @@
 from ixmp4.data.db import filters as base
 from ixmp4.data.db.run import Run
+from ixmp4.data.db.filters.model import ModelFilter
+from ixmp4.data.db.filters.scenario import ScenarioFilter
 from ixmp4.db import filters, utils
 
 from .model import RunMetaEntry
@@ -13,6 +15,8 @@ class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):
 
 
 class RunMetaEntryFilter(base.RunMetaEntryFilter, metaclass=filters.FilterMeta):
+    model: ModelFilter
+    scenario: ScenarioFilter
     run: RunFilter = filters.Field(
         default=RunFilter(id=None, version=None, is_default=True)
     )

--- a/ixmp4/data/db/meta/filter.py
+++ b/ixmp4/data/db/meta/filter.py
@@ -1,7 +1,7 @@
 from ixmp4.data.db import filters as base
-from ixmp4.data.db.run import Run
 from ixmp4.data.db.filters.model import ModelFilter
 from ixmp4.data.db.filters.scenario import ScenarioFilter
+from ixmp4.data.db.run import Run
 from ixmp4.db import filters, utils
 
 from .model import RunMetaEntry


### PR DESCRIPTION
As I wrote in #66, I believe that it is more intuitive to filter like

```python
platform.meta.tabulate(run={default_only=True}, model={"name": "Model 1"})
```

instead of (the multi-nested)
```python
platform.meta.tabulate(run={default_only=True, model={"name": "Model 1"}))
```

because 1. model and scenario names are part of the Model and Scenario tables (not Run) and 2. because it's less complex.

This PR adds the `ModelFiler` and `ScenarioFilter` to the `RunMetaEntryFilter`. The warning about cartesian products was solved by #69 (it seems).

Note that this PR is directed into #69.
