### PR TITLE
Clarify CI test names

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,7 +22,7 @@ jobs:
           - python-version: "3.12"
             with-pyarrow: false
             postgres-version: "16"
-    name: py${{ matrix.python-version }}-with_pyarrow=${{ matrix.with-pyarrow }}-pgsql${{ matrix.postgres-version }}
+    name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql${{ matrix.postgres-version }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,6 +22,7 @@ jobs:
           - python-version: "3.12"
             with-pyarrow: false
             postgres-version: "16"
+    name: py${{ matrix.python-version }}-with_pyarrow=${{ matrix.with-pyarrow }}-pgsql${{ matrix.postgres-version }}
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
#69 added another dimension to the pytest CI runs, `postgres-version`. Our CI names now look like this: `test / test (3.10, false, 15) (pull_request)`. This PR adapts the names of the runs to add clarity about what the numbers and bool in the test name mean.