### PR TITLE
Support pandas 2.0 and 2.1

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,6 +18,12 @@ jobs:
           - "16"
         pandas-version:
           - false
+          - "2.1.3"
+          - "2.1.2"
+          - "2.1.1"
+          - "2.1.0"
+          - "2.0.1"
+          - "2.0.0"
         include:
           - python-version: "3.12"
             with-pyarrow: true
@@ -27,14 +33,6 @@ jobs:
             with-pyarrow: false
             postgres-version: "15"
             pandas-version: false
-          - python-version: "3.12"
-            with-pyarrow: true
-            postgres-version: "16"
-            pandas-version: "2.1.1"
-          - python-version: "3.10"
-            with-pyarrow: true
-            postgres-version: "16"
-            pandas-version: "2.0.0"
 
     name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql=${{ matrix.postgres-version }} | pandas=${{ matrix.pandas-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,6 +16,8 @@ jobs:
           - false
         postgres-version:
           - "16"
+        pandas-version:
+          - false
         include:
           - python-version: "3.12"
             with-pyarrow: true
@@ -23,6 +25,10 @@ jobs:
           - python-version: "3.12"
             with-pyarrow: false
             postgres-version: "15"
+          - python-version: "3.12"
+            pandas-version: "2.1.1"
+          - python-version: "3.10"
+            pandas-version: "2.0.0"
     name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql${{ matrix.postgres-version }}
     runs-on: ubuntu-latest
     services:
@@ -89,6 +95,10 @@ jobs:
       - name: Install PyArrow
         if: ${{ matrix.with-pyarrow }}
         run: pip install pyarrow
+
+      - name: Install legacy pandas
+        if: ${{ matrix.pandas-version }}
+        run: pip install pandas==${{ matrix.pandas-version }}
 
       #------------------------
       #  install root project

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -36,7 +36,7 @@ jobs:
             postgres-version: "16"
             pandas-version: "2.0.0"
 
-    name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql${{ matrix.postgres-version }} | pandas${{ matrix.pandas-version }}
+    name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql=${{ matrix.postgres-version }} | pandas=${{ matrix.pandas-version }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,7 +34,7 @@ jobs:
           - python-version: "3.10"
             with-pyarrow: true
             postgres-version: "16"
-            pandas-version: "2.1.3"
+            pandas-version: "2.0.0"
 
 
     name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql=${{ matrix.postgres-version }} | pandas=${{ matrix.pandas-version }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,7 +5,7 @@ on: pull_request
 
 jobs:
   test:
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version:
@@ -18,12 +18,6 @@ jobs:
           - "16"
         pandas-version:
           - false
-          - "2.1.3"
-          - "2.1.2"
-          - "2.1.1"
-          - "2.1.0"
-          - "2.0.1"
-          - "2.0.0"
         include:
           - python-version: "3.12"
             with-pyarrow: true
@@ -33,6 +27,15 @@ jobs:
             with-pyarrow: false
             postgres-version: "15"
             pandas-version: false
+          - python-version: "3.11"
+            with-pyarrow: true
+            postgres-version: "16"
+            pandas-version: "2.1.3"
+          - python-version: "3.10"
+            with-pyarrow: true
+            postgres-version: "16"
+            pandas-version: "2.1.3"
+
 
     name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql=${{ matrix.postgres-version }} | pandas=${{ matrix.pandas-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install legacy pandas
         if: ${{ matrix.pandas-version }}
-        run: pip install pandas==${{ matrix.pandas-version }}
+        run: poetry add pandas@${{ matrix.pandas-version }} --lock
 
       #------------------------
       #  install root project

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,14 +22,21 @@ jobs:
           - python-version: "3.12"
             with-pyarrow: true
             postgres-version: "16"
+            pandas-version: false
           - python-version: "3.12"
             with-pyarrow: false
             postgres-version: "15"
+            pandas-version: false
           - python-version: "3.12"
+            with-pyarrow: true
+            postgres-version: "16"
             pandas-version: "2.1.1"
           - python-version: "3.10"
+            with-pyarrow: true
+            postgres-version: "16"
             pandas-version: "2.0.0"
-    name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql${{ matrix.postgres-version }}
+
+    name: py${{ matrix.python-version }} | with-pyarrow=${{ matrix.with-pyarrow }} | pgsql${{ matrix.postgres-version }} | pandas${{ matrix.pandas-version }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/ixmp4/data/db/iamc/timeseries/repository.py
+++ b/ixmp4/data/db/iamc/timeseries/repository.py
@@ -128,7 +128,7 @@ class TimeSeriesRepository(
             return df
 
         # ensure compatibility with pandas < 2.2
-        # TODO remove legacy-handing when dropping support for pandas < 2.2
+        # TODO remove legacy-handling when dropping support for pandas < 2.2
         if pd.__version__[0:3] in ["2.0", "2.1"]:
             apply_args = dict()
         else:

--- a/ixmp4/data/db/iamc/timeseries/repository.py
+++ b/ixmp4/data/db/iamc/timeseries/repository.py
@@ -127,9 +127,16 @@ class TimeSeriesRepository(
             df["unit__id"] = unit__id
             return df
 
+        # ensure compatibility with pandas < 2.2
+        # TODO remove legacy-handing when dropping support for pandas < 2.2
+        if pd.__version__[0:3] in ["2.0", "2.1"]:
+            apply_args = dict()
+        else:
+            apply_args = dict(include_groups=False)
+
         return pd.DataFrame(
             df.groupby(["variable", "unit__id"], group_keys=False).apply(
-                map_measurand, include_groups=False
+                map_measurand, **apply_args
             )
         )
 

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -192,7 +192,7 @@ class RunMetaEntryRepository(
             return df.drop(columns=RunMetaEntry._column_map.values())
 
         # ensure compatibility with pandas y 2.2
-        # TODO remove legacy-handing when dropping support for pandas < 2.2
+        # TODO remove legacy-handling when dropping support for pandas < 2.2
         if pd.__version__[0:3] in ["2.0", "2.1"]:
             apply_args = dict()
         else:

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -191,8 +191,15 @@ class RunMetaEntryRepository(
             df["type"] = type_str
             return df.drop(columns=RunMetaEntry._column_map.values())
 
+        # ensure compatibility with pandas y 2.2
+        # TODO remove legacy-handing when dropping support for pandas < 2.2
+        if pd.__version__[0:3] in ["2.0", "2.1"]:
+            apply_args = dict()
+        else:
+            apply_args = dict(include_groups=False)
+
         return df.groupby("type", group_keys=False).apply(
-            map_value_column, include_groups=False
+            map_value_column, **apply_args
         )
 
     @check_types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ alembic = ">=1.12.0"
 fastapi = ">=0.100.0"
 httpx = { extras = ["http2"], version = ">=0.25.0" }
 openpyxl = ">=3.0.9"
+# remove legacy-handling in timeseries- and meta-repositories when dropping pandas < 2.2
 pandas = [
-    {version = ">=2.1.1", python = ">=3.12"},
-    {version = ">=2.0.0", python = ">=3.10"}
+    { version = ">=2.1.1", python = ">=3.12" },
+    { version = ">=2.0.0", python = ">=3.10" }
 ]
 pandera = ">=0.17.0"
 pydantic = ">=2.3.0"


### PR DESCRIPTION
This PR implements a work-around for the changed API of pandas 2.2 for `GroupBy.apply()` and adds two tests for older pandas versions.