### PR TITLE
Simplify pandas minimum requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1439,9 +1439,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
     {version = ">=1.22.4,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2,<2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0,<2", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3517,4 +3517,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "37f9ddbc3d8887e22bbb3bffeb828378f60321ff3baee79cd7b2fb8d07260bb0"
+content-hash = "1e7a7a07fcf3b7695105df9612f13de49690fd68b2544a55fed4264819fc9782"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,7 @@ fastapi = ">=0.100.0"
 httpx = { extras = ["http2"], version = ">=0.25.0" }
 openpyxl = ">=3.0.9"
 # remove legacy-handling in timeseries- and meta-repositories when dropping pandas < 2.2
-pandas = [
-    { version = ">=2.1.1", python = ">=3.12" },
-    { version = ">=2.0.0", python = ">=3.10" }
-]
+pandas = ">=2.0.0"
 pandera = ">=0.17.0"
 pydantic = ">=2.3.0"
 python = ">=3.10, <3.13"


### PR DESCRIPTION
Providing minimum requirements as a list in `pyproject.toml` causes **grayskull** to fail (which creates recipes for releasing on conda). Given that the correct matching of python-version and available pandas will be handled by pip or conda anyway, no need to complicate our dependency list.