### PR TITLE
Nicer log output on RestAPI connection

### DIFF
--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -44,7 +44,7 @@ class RestBackend(Backend):
         max_concurrent_requests: int = settings.client_max_concurrent_requests,
     ) -> None:
         super().__init__(info)
-        logger.info(f"Connecting to IXMP4 REST API at {info.dsn}.")
+        logger.debug(f"Connecting to IXMP4 REST API at {info.dsn}.")
         self.semaphore = asyncio.Semaphore(max_concurrent_requests)
         self.timeout = httpx.Timeout(settings.client_timeout, connect=60.0)
         if isinstance(info, ManagerPlatformInfo):

--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -80,8 +80,15 @@ class RestBackend(Backend):
             raise UnknownApiError(f"Server response not OK. ({root.status_code})")
 
         api_info = APIInfo(**root.json())
-        logger.info(f"Connected to Platform '{api_info.name}'")
-        logger.info("Server IXMP4 Version: " + api_info.version)
+        logger.info(f"Connected to IXMP4 Platform '{api_info.name}'")
+
+        import ixmp4
+
+        if ixmp4.__version__ != api_info.version:
+            logger.warning(
+                "IXMP4 Client and Server versions do not match. "
+                f"(Client: {ixmp4.__version__}, Server: {api_info.version})"
+            )
 
         logger.debug("Server UTC Time: " + api_info.utcnow.strftime("%c"))
         logger.debug("Server Is Managed: " + str(api_info.is_managed))

--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -47,10 +47,10 @@ class RestBackend(Backend):
         logger.debug(f"Connecting to IXMP4 REST API at {info.dsn}.")
         self.semaphore = asyncio.Semaphore(max_concurrent_requests)
         self.timeout = httpx.Timeout(settings.client_timeout, connect=60.0)
+        self.make_client(info.dsn, auth=auth)
         if isinstance(info, ManagerPlatformInfo):
             if info.notice is not None:
-                logger.info("Platform notice: " + info.notice)
-        self.make_client(info.dsn, auth=auth)
+                logger.info("Platform notice: >\n" + info.notice)
         self.create_repositories()
 
     def make_client(self, rest_url: str, auth: BaseAuth | None):


### PR DESCRIPTION
A little beautification of the log when connecting to a Platform via the RestAPI.

New output
- the name of the platform
- a warning if the server and client versions are not in line
- the platform notice (if available)

The dsn is now only shown in debug mode.