### PR TITLE
Fix Request dispatching

### DIFF
--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -36,7 +36,7 @@ class Settings(BaseSettings):
     max_page_size: int = 10_000
     default_page_size: int = 5_000
     client_default_upload_chunk_size: int = 10_000
-    client_max_concurrent_requests: int = Field(2, lt=4)
+    client_max_concurrent_requests: int = Field(2, lte=4)
     client_max_request_retries: int = Field(3)
     client_backoff_factor: int = Field(5)
     client_timeout: int = Field(30)

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -36,7 +36,7 @@ class Settings(BaseSettings):
     max_page_size: int = 10_000
     default_page_size: int = 5_000
     client_default_upload_chunk_size: int = 10_000
-    client_max_concurrent_requests: int = Field(2, lte=4)
+    client_max_concurrent_requests: int = Field(2, le=4)
     client_max_request_retries: int = Field(3)
     client_backoff_factor: int = Field(5)
     client_timeout: int = Field(30)

--- a/ixmp4/data/api/base.py
+++ b/ixmp4/data/api/base.py
@@ -244,7 +244,7 @@ class BaseRepository(Generic[ModelType]):
         json: dict | None,
     ) -> list[list | dict]:
         """Uses the backends executor to send many pagination requests concurrently."""
-        requests: list[tuple] = []
+        requests: list[futures.Future] = []
         with self.backend.executor as exec:
             for req_offset in range(start, total, limit):
                 if params is not None:

--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -181,3 +181,5 @@ class RestTestBackend(RestBackend):
 
     def close(self):
         self.client.close()
+        self.executor.shutdown(cancel_futures=True)
+

--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -1,5 +1,5 @@
-import asyncio
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 import httpx
 import pandas as pd
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 class RestBackend(Backend):
     client: httpx.Client
     async_client: httpx.AsyncClient
-    semaphore: asyncio.Semaphore
+    executor: ThreadPoolExecutor
     timeout: httpx.Timeout
 
     def __init__(
@@ -45,7 +45,7 @@ class RestBackend(Backend):
     ) -> None:
         super().__init__(info)
         logger.info(f"Connecting to IXMP4 REST API at {info.dsn}.")
-        self.semaphore = asyncio.Semaphore(max_concurrent_requests)
+        self.executor = ThreadPoolExecutor(max_workers=max_concurrent_requests)
         self.timeout = httpx.Timeout(settings.client_timeout, connect=60.0)
         if isinstance(info, ManagerPlatformInfo):
             if info.notice is not None:

--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -182,4 +182,3 @@ class RestTestBackend(RestBackend):
     def close(self):
         self.client.close()
         self.executor.shutdown(cancel_futures=True)
-

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -1,9 +1,18 @@
+import asyncio
+
 import pytest
 
 from ixmp4 import DataPoint
+from ixmp4.conf import settings
 from ixmp4.core.exceptions import SchemaError
 
-from ..utils import add_regions, add_units, all_platforms, assert_unordered_equality
+from ..utils import (
+    add_regions,
+    add_units,
+    all_platforms,
+    assert_unordered_equality,
+    generated_platforms,
+)
 
 
 @all_platforms
@@ -101,6 +110,24 @@ def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request, filter
     exp = test_data_annual[test_data_annual.variable == "Primary Energy"]
     assert_unordered_equality(obs, exp, check_like=True)
 
+
+
+@generated_platforms
+def test_mp_tabulate_big_async(generated_mp, request):
+    """Tests if big tabulations work in async contexts."""
+    generated_mp = request.getfixturevalue(generated_mp)
+
+    async def tabulate():
+        return generated_mp.iamc.tabulate(raw=True, run={"default_only": False})
+
+    res = asyncio.run(tabulate())
+    assert len(res) > settings.default_page_size
+
+@generated_platforms
+def test_mp_tabulate_big(generated_mp, request):
+    generated_mp = request.getfixturevalue(generated_mp)
+    res = generated_mp.iamc.tabulate(raw=True, run={"default_only": False})
+    assert len(res) > settings.default_page_size
 
 def do_run_datapoints(test_mp, data, raw=True, _type=None):
     # Test adding, updating, removing data to a run

--- a/tests/core/test_iamc.py
+++ b/tests/core/test_iamc.py
@@ -111,7 +111,6 @@ def test_run_tabulate_with_filter_raw(test_mp, test_data_annual, request, filter
     assert_unordered_equality(obs, exp, check_like=True)
 
 
-
 @generated_platforms
 def test_mp_tabulate_big_async(generated_mp, request):
     """Tests if big tabulations work in async contexts."""
@@ -123,11 +122,13 @@ def test_mp_tabulate_big_async(generated_mp, request):
     res = asyncio.run(tabulate())
     assert len(res) > settings.default_page_size
 
+
 @generated_platforms
 def test_mp_tabulate_big(generated_mp, request):
     generated_mp = request.getfixturevalue(generated_mp)
     res = generated_mp.iamc.tabulate(raw=True, run={"default_only": False})
     assert len(res) > settings.default_page_size
+
 
 def do_run_datapoints(test_mp, data, raw=True, _type=None):
     # Test adding, updating, removing data to a run


### PR DESCRIPTION
#76 Introduced a problem for programs who themselves are running within something like an [`asyncio.run`](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run) call. 
Since this is the case for any jupyter notebook this is not very convenient. 
I switched the approach to use a `ThreadPoolExecutor` instead and it seems to work, please verify @danielhuppmann.

