### PR TITLE
Better handling of `dimensionless` unit

### DIFF
--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -13,15 +13,6 @@ from ..utils import substitute_type
 from .variable import VariableRepository
 
 
-def to_dimensionless(df: pd.DataFrame) -> pd.DataFrame:
-    if "dimensionless" in df.unit:
-        raise ValueError(
-            "Unit name 'dimensionless' is reserved, use an empty string '' instead."
-        )
-    df.replace(to_replace={"unit": ""}, value="dimensionless", inplace=True)
-    return df
-
-
 class RemoveDataPointFrameSchema(pa.DataFrameModel):
     type: Optional[Series[pa.String]] = pa.Field(isin=[t for t in DataPointModel.Type])
     step_year: Optional[Series[pa.Int]] = pa.Field(coerce=True, nullable=True)
@@ -69,7 +60,6 @@ def convert_to_std_format(df: pd.DataFrame, join_runs: bool) -> pd.DataFrame:
 def normalize_df(df: pd.DataFrame, raw: bool, join_runs: bool) -> pd.DataFrame:
     if not df.empty:
         df = df.drop(columns=["time_series__id"])
-        df.unit = df.unit.replace({"dimensionless": ""})
         if raw is False:
             return convert_to_std_format(df, join_runs)
     return df
@@ -120,7 +110,6 @@ class RunIamcData(BaseFacade):
         type: Optional[DataPointModel.Type] = None,
     ):
         df = AddDataPointFrameSchema.validate(df)  # type:ignore
-        df = to_dimensionless(df.copy())
         df["run__id"] = self.run.id
         df = self._get_or_create_ts(df)
         substitute_type(df, type)
@@ -132,7 +121,6 @@ class RunIamcData(BaseFacade):
         type: Optional[DataPointModel.Type] = None,
     ):
         df = RemoveDataPointFrameSchema.validate(df)  # type:ignore
-        df = to_dimensionless(df.copy())
         df["run__id"] = self.run.id
         df = self._get_or_create_ts(df)
         substitute_type(df, type)

--- a/ixmp4/core/optimization/scalar.py
+++ b/ixmp4/core/optimization/scalar.py
@@ -107,8 +107,8 @@ class ScalarRepository(BaseFacade):
             unit_name = unit
         else:
             # TODO: provide logging information about None-units being converted
-            # to dimensionless
-            dimensionless_unit = self.backend.units.create(name="dimensionless")
+            # if unit is None, assume that this is a dimensionless scalar (unit = "")
+            dimensionless_unit = self.backend.units.create(name="")
             unit_name = dimensionless_unit.name
 
         try:

--- a/ixmp4/core/unit.py
+++ b/ixmp4/core/unit.py
@@ -7,14 +7,6 @@ from ixmp4.data.abstract import Docs as DocsModel
 from ixmp4.data.abstract import Unit as UnitModel
 
 
-def to_dimensionless(name):
-    if name == "dimensionless":
-        raise ValueError(
-            "Unit name 'dimensionless' is reserved, use an empty string '' instead."
-        )
-    return "dimensionless" if name == "" else name
-
-
 class Unit(BaseModelFacade):
     _model: UnitModel
     NotUnique = UnitModel.NotUnique
@@ -71,10 +63,12 @@ class UnitRepository(BaseFacade):
         self,
         name: str,
     ) -> Unit:
-        name = to_dimensionless(name)
-        if name.strip() == "":
+        if name != "" and name.strip() == "":
             raise ValueError("Using a space-only unit name is not allowed.")
-
+        if name == "dimensionless":
+            raise ValueError(
+                "Unit name 'dimensionless' is reserved, use an empty string '' instead."
+            )
         model = self.backend.units.create(name)
         return Unit(_backend=self.backend, _model=model)
 
@@ -92,7 +86,7 @@ class UnitRepository(BaseFacade):
         self.backend.units.delete(id)
 
     def get(self, name: str) -> Unit:
-        model = self.backend.units.get(to_dimensionless(name))
+        model = self.backend.units.get(name)
         return Unit(_backend=self.backend, _model=model)
 
     def list(self, name: str | None = None) -> list[Unit]:

--- a/tests/core/test_scalar.py
+++ b/tests/core/test_scalar.py
@@ -60,7 +60,7 @@ class TestCoreScalar:
         assert scalar_1.id != scalar_2.id
 
         scalar_3 = run.optimization.scalars.create("Scalar 3", value=1)
-        assert scalar_3.unit.name == "dimensionless"
+        assert scalar_3.unit.name == ""
 
     def test_get_scalar(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)

--- a/tests/core/test_unit.py
+++ b/tests/core/test_unit.py
@@ -66,6 +66,9 @@ class TestCoreUnit:
 
         assert unit1.id == unit2.id
 
+        assert "" in test_mp.units.tabulate().values
+        assert "" in [unit.name for unit in test_mp.units.list()]
+
     def test_unit_illegal_names(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
         with pytest.raises(ValueError, match="Unit name 'dimensionless' is reserved,"):


### PR DESCRIPTION
This PR removes the special handling of "dimensionless" units, previously introduced because ORACLE had problems with storing empty strings.

Creating units "dimensionless" or multiple whitespaces is still not allowed, users should use an empty string to indicate dimensionless units.