### PR TITLE
Fix Multi-Process Logging

### DIFF
--- a/ixmp4/conf/logging/server.json
+++ b/ixmp4/conf/logging/server.json
@@ -9,24 +9,22 @@
   },
   "loggers": {
     "fastapi": {
-      "level": "NOTSET",
-      "handlers": ["console"]
+      "level": "NOTSET"
     },
     "httpx": {
-      "level": "NOTSET",
-      "handlers": ["console"]
+      "level": "NOTSET"
     },
     "sqlalchemy": {
-      "level": "NOTSET",
-      "handlers": ["console"]
+      "level": "NOTSET"
     },
     "uvicorn.access": {
-      "level": "NOTSET",
-      "handlers": ["console"]
+      "level": "NOTSET"
+    },
+    "uvicorn": {
+      "level": "NOTSET"
     },
     "watchfiles.main": {
-      "level": "ERROR",
-      "handlers": ["console"]
+      "level": "ERROR"
     }
   },
   "handlers": {

--- a/ixmp4/conf/logging/server.json
+++ b/ixmp4/conf/logging/server.json
@@ -10,62 +10,34 @@
   "loggers": {
     "fastapi": {
       "level": "NOTSET",
-      "handlers": ["debug","error","console"]
+      "handlers": ["console"]
     },
     "httpx": {
       "level": "NOTSET",
-      "handlers": ["debug","error"]
+      "handlers": ["console"]
     },
     "sqlalchemy": {
       "level": "NOTSET",
-      "handlers": ["debug","error"]
-    },
-    "uvicorn": {
-      "level": "NOTSET",
-      "handlers": ["debug","error","console"]
+      "handlers": ["console"]
     },
     "uvicorn.access": {
       "level": "NOTSET",
-      "handlers": ["access"]
+      "handlers": ["console"]
     },
     "watchfiles.main": {
       "level": "ERROR",
-      "handlers": ["error","debug"]
+      "handlers": ["console"]
     }
   },
   "handlers": {
-    "access": {
-      "class": "logging.handlers.RotatingFileHandler",
-      "level": "INFO",
-      "formatter": "generic",
-      "filename": "ext://ixmp4.conf.settings.access_file",
-      "mode": "a",
-      "maxBytes": 250000
-    },
     "console": {
       "class": "logging.StreamHandler",
-      "level": "INFO",
-      "formatter": "generic"
-    },
-    "debug": {
-      "class": "logging.handlers.RotatingFileHandler",
       "level": "DEBUG",
-      "formatter": "generic",
-      "filename": "ext://ixmp4.conf.settings.debug_file", 
-      "mode": "a",
-      "maxBytes": 250000
-    },
-    "error": {
-      "class": "logging.handlers.RotatingFileHandler",
-      "level": "WARN",
-      "formatter": "generic",
-      "filename": "ext://ixmp4.conf.settings.error_file",
-      "mode": "a",
-      "maxBytes": 250000
+      "formatter": "generic"
     }
   },
   "root": { 
-    "level": "NOTSET",
-    "handlers": ["debug","error"]
+    "level": "DEBUG",
+    "handlers": ["console"]
   }
 }

--- a/ixmp4/data/backend/db.py
+++ b/ixmp4/data/backend/db.py
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 
 @lru_cache()
 def cached_create_engine(dsn: str) -> Engine:
-    logger.info(f"Creating database engine for {dsn}")
     return create_engine(dsn)
 
 
@@ -74,6 +73,7 @@ class SqlAlchemyBackend(Backend):
 
     def __init__(self, info: PlatformInfo) -> None:
         super().__init__(info)
+        logger.info(f"Creating database engine for platform '{info.name}'.")
         self.make_engine(info.dsn)
         self.make_repositories()
 


### PR DESCRIPTION
The migration to kubernetes has revealed a bug in the use of `RotatingFileHandler`. I am guessing since the write delays on nfs are higher than on the old file system, sometimes when a file is supposed to be rotated another process tries to write to it at the same time. Apparently `RotatingFileHandler` gets a new file descriptor when rotating, leaving all file descriptors except in the Handler that rotated the file, invalid. 
I've disabled file logging completely as a quick fix (kubernetes will keep the stdout logs a little while for us) and turned on console logging for everything. Hopefully we can switch over to a log aggregation service soon so we don't need file logging at all.
I also noticed that we print some passwords to the logs, i've fixed that here as well.