### PR TITLE
DRY optimization core layer

### DIFF
--- a/ixmp4/core/optimization/base.py
+++ b/ixmp4/core/optimization/base.py
@@ -49,7 +49,7 @@ class Lister(OptimizationBaseRepository[OptimizationModelType], abstract.Lister)
 
 class Tabulator(OptimizationBaseRepository[OptimizationModelType], abstract.Tabulator):
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
-        return self._backend_repository.tabulate(name=name)
+        return self._backend_repository.tabulate(run_id=self._run.id, name=name)
 
 
 class Enumerator(

--- a/ixmp4/core/optimization/base.py
+++ b/ixmp4/core/optimization/base.py
@@ -1,39 +1,9 @@
-# from typing import Any, ClassVar, Generic, TypeVar
 from typing import Generic, TypeVar
 
 import pandas as pd
 
 from ixmp4.core.base import BaseFacade, BaseModelFacade
-
-# from ixmp4.core.exceptions import IxmpError
 from ixmp4.data import abstract
-
-# class OptimizationBaseModel(BaseModelFacade):
-#     _model: abstract.OptimizationBaseModel
-#     NotFound: ClassVar[type[IxmpError]]
-#     NotUnique: ClassVar[type[IxmpError]]
-
-#     @property
-#     def id(self) -> int:
-#         return self._model.id
-
-#     @property
-#     def name(self) -> str:
-#         return self._model.name
-
-#     @property
-#     def run_id(self) -> int:
-#         return self._model.run__id
-
-#     @property
-#     def data(self) -> dict[str, Any]:
-#         return self._model.data
-
-#     # TODO Stopping here since I'm not convinced of the usefulness. The only benefit I
-#     # see is that we'd separate functional code from placeholders so that if we need
-#     # to change functionality for e.g. getting 'data', we only need to do so in one
-#     # place. Still this feels like a lot of repetition.
-
 
 OptimizationModelType = TypeVar("OptimizationModelType", bound=BaseModelFacade)
 
@@ -52,7 +22,7 @@ class Creator(OptimizationBaseRepository[OptimizationModelType], abstract.Creato
     def create(
         self,
         name: str,
-        # TODO But how do we know show in core layer that e.g. Table needs these?
+        # TODO But how do we now show in core layer that e.g. Table needs these?
         # constrained_to_indexsets: list[str],
         # column_names: list[str] | None = None,
         *args,
@@ -88,7 +58,4 @@ class Enumerator(
     def enumerate(
         self, *args, table: bool = False, **kwargs
     ) -> list[OptimizationModelType] | pd.DataFrame:
-        if table:
-            return self.tabulate(*args, **kwargs)
-        else:
-            return self.list(*args, **kwargs)
+        return self.tabulate(*args, **kwargs) if table else self.list(*args, **kwargs)

--- a/ixmp4/core/optimization/base.py
+++ b/ixmp4/core/optimization/base.py
@@ -1,61 +1,94 @@
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from . import InitKwargs
+
 
 import pandas as pd
+
+# TODO Import this from typing when dropping Python 3.11
+from typing_extensions import TypedDict, Unpack
 
 from ixmp4.core.base import BaseFacade, BaseModelFacade
 from ixmp4.data import abstract
 
-OptimizationModelType = TypeVar("OptimizationModelType", bound=BaseModelFacade)
+FacadeOptimizationModelType = TypeVar(
+    "FacadeOptimizationModelType", bound=BaseModelFacade
+)
+AbstractOptimizationModelType = TypeVar(
+    "AbstractOptimizationModelType", bound=abstract.BaseModel
+)
 
 
-class OptimizationBaseRepository(BaseFacade, Generic[OptimizationModelType]):
+class OptimizationBaseRepository(
+    BaseFacade, Generic[FacadeOptimizationModelType, AbstractOptimizationModelType]
+):
     _run: abstract.Run
-    _backend_repository: abstract.BackendBaseRepository
-    _model_type: type[OptimizationModelType]
+    _backend_repository: abstract.BackendBaseRepository[AbstractOptimizationModelType]
+    _model_type: type[FacadeOptimizationModelType]
 
-    def __init__(self, _run: abstract.Run, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, _run: abstract.Run, **kwargs: Unpack["InitKwargs"]) -> None:
+        super().__init__(**kwargs)
         self._run = _run
 
 
-class Creator(OptimizationBaseRepository[OptimizationModelType], abstract.Creator):
+class Creator(
+    OptimizationBaseRepository[
+        FacadeOptimizationModelType, AbstractOptimizationModelType
+    ],
+    abstract.Creator,
+):
     def create(
-        self,
-        name: str,
-        # TODO But how do we now show in core layer that e.g. Table needs these?
-        # constrained_to_indexsets: list[str],
-        # column_names: list[str] | None = None,
-        *args,
-        **kwargs,
-    ) -> OptimizationModelType:
+        self, name: str, **kwargs: Unpack["abstract.optimization.base.CreateKwargs"]
+    ) -> FacadeOptimizationModelType:
         model = self._backend_repository.create(
-            *args,
-            **dict(kwargs, name=name, run_id=self._run.id),
+            run_id=self._run.id, name=name, **kwargs
         )
         return self._model_type(_backend=self.backend, _model=model)
 
 
-class Retriever(OptimizationBaseRepository[OptimizationModelType], abstract.Retriever):
-    def get(self, name: str, *args, **kwargs) -> OptimizationModelType:
+class Retriever(
+    OptimizationBaseRepository[
+        FacadeOptimizationModelType, AbstractOptimizationModelType
+    ],
+    abstract.Retriever,
+):
+    def get(self, name: str) -> FacadeOptimizationModelType:
         model = self._backend_repository.get(run_id=self._run.id, name=name)
         return self._model_type(_backend=self.backend, _model=model)
 
 
-class Lister(OptimizationBaseRepository[OptimizationModelType], abstract.Lister):
-    def list(self, name: str | None = None) -> list[OptimizationModelType]:
+class Lister(
+    OptimizationBaseRepository[
+        FacadeOptimizationModelType, AbstractOptimizationModelType
+    ],
+    abstract.Lister,
+):
+    def list(self, name: str | None = None) -> list[FacadeOptimizationModelType]:
         models = self._backend_repository.list(run_id=self._run.id, name=name)
         return [self._model_type(_backend=self.backend, _model=m) for m in models]
 
 
-class Tabulator(OptimizationBaseRepository[OptimizationModelType], abstract.Tabulator):
+class Tabulator(
+    OptimizationBaseRepository[
+        FacadeOptimizationModelType, AbstractOptimizationModelType
+    ],
+    abstract.Tabulator,
+):
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
         return self._backend_repository.tabulate(run_id=self._run.id, name=name)
 
 
+class EnumerateKwargs(TypedDict, total=False):
+    name: str | None
+
+
 class Enumerator(
-    Lister[OptimizationModelType], Tabulator[OptimizationModelType], abstract.Enumerator
+    Lister[FacadeOptimizationModelType, AbstractOptimizationModelType],
+    Tabulator[FacadeOptimizationModelType, AbstractOptimizationModelType],
+    abstract.Enumerator,
 ):
     def enumerate(
-        self, *args, table: bool = False, **kwargs
-    ) -> list[OptimizationModelType] | pd.DataFrame:
-        return self.tabulate(*args, **kwargs) if table else self.list(*args, **kwargs)
+        self, table: bool = False, **kwargs: Unpack[EnumerateKwargs]
+    ) -> list[FacadeOptimizationModelType] | pd.DataFrame:
+        return self.tabulate(**kwargs) if table else self.list(**kwargs)

--- a/ixmp4/core/optimization/base.py
+++ b/ixmp4/core/optimization/base.py
@@ -1,0 +1,93 @@
+# from typing import Any, ClassVar, Generic, TypeVar
+from typing import Generic, TypeVar
+
+import pandas as pd
+
+from ixmp4.core.base import BaseFacade, BaseModelFacade
+
+# from ixmp4.core.exceptions import IxmpError
+from ixmp4.data import abstract
+
+# class OptimizationBaseModel(BaseModelFacade):
+#     _model: abstract.OptimizationBaseModel
+#     NotFound: ClassVar[type[IxmpError]]
+#     NotUnique: ClassVar[type[IxmpError]]
+
+#     @property
+#     def id(self) -> int:
+#         return self._model.id
+
+#     @property
+#     def name(self) -> str:
+#         return self._model.name
+
+#     @property
+#     def run_id(self) -> int:
+#         return self._model.run__id
+
+#     @property
+#     def data(self) -> dict[str, Any]:
+#         return self._model.data
+
+#     # TODO Stopping here since I'm not convinced of the usefulness. The only benefit I
+#     # see is that we'd separate functional code from placeholders so that if we need
+#     # to change functionality for e.g. getting 'data', we only need to do so in one
+#     # place. Still this feels like a lot of repetition.
+
+
+OptimizationModelType = TypeVar("OptimizationModelType", bound=BaseModelFacade)
+
+
+class OptimizationBaseRepository(BaseFacade, Generic[OptimizationModelType]):
+    _run: abstract.Run
+    _backend_repository: abstract.BackendBaseRepository
+    _model_type: type[OptimizationModelType]
+
+    def __init__(self, _run: abstract.Run, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._run = _run
+
+
+class Creator(OptimizationBaseRepository[OptimizationModelType], abstract.Creator):
+    def create(
+        self,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+    ) -> OptimizationModelType:
+        model = self._backend_repository.create(
+            name=name,
+            run_id=self._run.id,
+            constrained_to_indexsets=constrained_to_indexsets,
+            column_names=column_names,
+        )
+        return self._model_type(_backend=self.backend, _model=model)
+
+
+class Retriever(OptimizationBaseRepository[OptimizationModelType], abstract.Retriever):
+    def get(self, name: str, *args, **kwargs) -> OptimizationModelType:
+        model = self._backend_repository.get(run_id=self._run.id, name=name)
+        return self._model_type(_backend=self.backend, _model=model)
+
+
+class Lister(OptimizationBaseRepository[OptimizationModelType], abstract.Lister):
+    def list(self, name: str | None = None) -> list[OptimizationModelType]:
+        models = self._backend_repository.list(run_id=self._run.id, name=name)
+        return [self._model_type(_backend=self.backend, _model=m) for m in models]
+
+
+class Tabulator(OptimizationBaseRepository[OptimizationModelType], abstract.Tabulator):
+    def tabulate(self, name: str | None = None) -> pd.DataFrame:
+        return self._backend_repository.tabulate(name=name)
+
+
+class Enumerator(
+    Lister[OptimizationModelType], Tabulator[OptimizationModelType], abstract.Enumerator
+):
+    def enumerate(
+        self, *args, table: bool = False, **kwargs
+    ) -> list[OptimizationModelType] | pd.DataFrame:
+        if table:
+            return self.tabulate(*args, **kwargs)
+        else:
+            return self.list(*args, **kwargs)

--- a/ixmp4/core/optimization/base.py
+++ b/ixmp4/core/optimization/base.py
@@ -52,14 +52,15 @@ class Creator(OptimizationBaseRepository[OptimizationModelType], abstract.Creato
     def create(
         self,
         name: str,
-        constrained_to_indexsets: list[str],
-        column_names: list[str] | None = None,
+        # TODO But how do we know show in core layer that e.g. Table needs these?
+        # constrained_to_indexsets: list[str],
+        # column_names: list[str] | None = None,
+        *args,
+        **kwargs,
     ) -> OptimizationModelType:
         model = self._backend_repository.create(
-            name=name,
-            run_id=self._run.id,
-            constrained_to_indexsets=constrained_to_indexsets,
-            column_names=column_names,
+            *args,
+            **dict(kwargs, name=name, run_id=self._run.id),
         )
         return self._model_type(_backend=self.backend, _model=model)
 

--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -91,3 +91,6 @@ class IndexSetRepository(
         super().__init__(_run=_run, **kwargs)
         self._backend_repository = self.backend.optimization.indexsets
         self._model_type = IndexSet
+
+    def create(self, name: str) -> IndexSet:
+        return super().create(name=name)

--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
 
 # TODO Import this from typing when dropping Python 3.11
 
+import pandas as pd
+
 from ixmp4.core.base import BaseModelFacade
 from ixmp4.data.abstract import Docs as DocsModel
 from ixmp4.data.abstract import IndexSet as IndexSetModel
@@ -87,3 +89,10 @@ class IndexSetRepository(
         super().__init__(*args, **kwargs)
         self._backend_repository = self.backend.optimization.indexsets
         self._model_type = IndexSet
+
+    def tabulate(
+        self, name: str | None = None, include_data: bool = False
+    ) -> pd.DataFrame:
+        return self._backend_repository.tabulate(
+            run_id=self._run.id, name=name, include_data=include_data
+        )

--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -2,16 +2,15 @@ from datetime import datetime
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
-    pass
-
+    from . import InitKwargs
 
 # TODO Import this from typing when dropping Python 3.11
-
-import pandas as pd
+from typing_extensions import Unpack
 
 from ixmp4.core.base import BaseModelFacade
 from ixmp4.data.abstract import Docs as DocsModel
 from ixmp4.data.abstract import IndexSet as IndexSetModel
+from ixmp4.data.abstract import Run
 
 from .base import Creator, Lister, Retriever, Tabulator
 
@@ -83,16 +82,12 @@ class IndexSet(BaseModelFacade):
 
 
 class IndexSetRepository(
-    Creator[IndexSet], Retriever[IndexSet], Lister[IndexSet], Tabulator[IndexSet]
+    Creator[IndexSet, IndexSetModel],
+    Retriever[IndexSet, IndexSetModel],
+    Lister[IndexSet, IndexSetModel],
+    Tabulator[IndexSet, IndexSetModel],
 ):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, _run: Run, **kwargs: Unpack["InitKwargs"]) -> None:
+        super().__init__(_run=_run, **kwargs)
         self._backend_repository = self.backend.optimization.indexsets
         self._model_type = IndexSet
-
-    def tabulate(
-        self, name: str | None = None, include_data: bool = False
-    ) -> pd.DataFrame:
-        return self._backend_repository.tabulate(
-            run_id=self._run.id, name=name, include_data=include_data
-        )

--- a/ixmp4/core/optimization/scalar.py
+++ b/ixmp4/core/optimization/scalar.py
@@ -2,14 +2,15 @@ from datetime import datetime
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
-    pass
-
+    from . import InitKwargs
 
 # TODO Import this from typing when dropping Python 3.11
+from typing_extensions import Unpack
 
 from ixmp4.core.base import BaseModelFacade
 from ixmp4.core.unit import Unit
 from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Run
 from ixmp4.data.abstract import Scalar as ScalarModel
 from ixmp4.data.abstract import Unit as UnitModel
 
@@ -97,9 +98,13 @@ class Scalar(BaseModelFacade):
         return f"<Scalar {self.id} name={self.name}>"
 
 
-class ScalarRepository(Retriever[Scalar], Lister[Scalar], Tabulator[Scalar]):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+class ScalarRepository(
+    Retriever[Scalar, ScalarModel],
+    Lister[Scalar, ScalarModel],
+    Tabulator[Scalar, ScalarModel],
+):
+    def __init__(self, _run: Run, **kwargs: Unpack["InitKwargs"]) -> None:
+        super().__init__(_run=_run, **kwargs)
         self._backend_repository = self.backend.optimization.scalars
         self._model_type = Scalar
 

--- a/ixmp4/core/optimization/table.py
+++ b/ixmp4/core/optimization/table.py
@@ -1,20 +1,18 @@
-from collections.abc import Iterable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
-    from . import InitKwargs
+    pass
 
 import pandas as pd
 
 # TODO Import this from typing when dropping Python 3.11
-from typing_extensions import Unpack
-
-from ixmp4.core.base import BaseFacade, BaseModelFacade
+from ixmp4.core.base import BaseModelFacade
 from ixmp4.data.abstract import Docs as DocsModel
-from ixmp4.data.abstract import Run
 from ixmp4.data.abstract import Table as TableModel
 from ixmp4.data.abstract.optimization import Column
+
+from .base import Creator, Lister, Retriever, Tabulator
 
 
 class Table(BaseModelFacade):
@@ -87,40 +85,10 @@ class Table(BaseModelFacade):
         return f"<Table {self.id} name={self.name}>"
 
 
-class TableRepository(BaseFacade):
-    _run: Run
-
-    def __init__(self, _run: Run, **kwargs: Unpack["InitKwargs"]) -> None:
-        super().__init__(**kwargs)
-        self._run = _run
-
-    def create(
-        self,
-        name: str,
-        constrained_to_indexsets: list[str],
-        column_names: list[str] | None = None,
-    ) -> Table:
-        model = self.backend.optimization.tables.create(
-            name=name,
-            run_id=self._run.id,
-            constrained_to_indexsets=constrained_to_indexsets,
-            column_names=column_names,
-        )
-        return Table(_backend=self.backend, _model=model)
-
-    def get(self, name: str) -> Table:
-        model = self.backend.optimization.tables.get(run_id=self._run.id, name=name)
-        return Table(_backend=self.backend, _model=model)
-
-    def list(self, name: str | None = None) -> Iterable[Table]:
-        tables = self.backend.optimization.tables.list(run_id=self._run.id, name=name)
-        return [
-            Table(
-                _backend=self.backend,
-                _model=i,
-            )
-            for i in tables
-        ]
-
-    def tabulate(self, name: str | None = None) -> pd.DataFrame:
-        return self.backend.optimization.tables.tabulate(run_id=self._run.id, name=name)
+class TableRepository(
+    Creator[Table], Retriever[Table], Lister[Table], Tabulator[Table]
+):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._backend_repository = self.backend.optimization.tables
+        self._model_type = Table

--- a/ixmp4/core/optimization/table.py
+++ b/ixmp4/core/optimization/table.py
@@ -2,13 +2,16 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
-    pass
+    from . import InitKwargs
 
 import pandas as pd
 
 # TODO Import this from typing when dropping Python 3.11
+from typing_extensions import Unpack
+
 from ixmp4.core.base import BaseModelFacade
 from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import Run
 from ixmp4.data.abstract import Table as TableModel
 from ixmp4.data.abstract.optimization import Column
 
@@ -86,9 +89,12 @@ class Table(BaseModelFacade):
 
 
 class TableRepository(
-    Creator[Table], Retriever[Table], Lister[Table], Tabulator[Table]
+    Creator[Table, TableModel],
+    Retriever[Table, TableModel],
+    Lister[Table, TableModel],
+    Tabulator[Table, TableModel],
 ):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, _run: Run, **kwargs: Unpack["InitKwargs"]) -> None:
+        super().__init__(_run=_run, **kwargs)
         self._backend_repository = self.backend.optimization.tables
         self._model_type = Table

--- a/ixmp4/core/optimization/table.py
+++ b/ixmp4/core/optimization/table.py
@@ -98,3 +98,15 @@ class TableRepository(
         super().__init__(_run=_run, **kwargs)
         self._backend_repository = self.backend.optimization.tables
         self._model_type = Table
+
+    def create(
+        self,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+    ) -> Table:
+        return super().create(
+            name=name,
+            constrained_to_indexsets=constrained_to_indexsets,
+            column_names=column_names,
+        )

--- a/ixmp4/data/abstract/__init__.py
+++ b/ixmp4/data/abstract/__init__.py
@@ -30,6 +30,7 @@ from .iamc import (  # AnnualDataPoint,; SubAnnualDataPoint,; CategoricalDataPoi
 from .meta import MetaValue, RunMetaEntry, RunMetaEntryRepository, StrictMetaValue
 from .model import Model, ModelRepository
 from .optimization import (
+    BackendBaseRepository,
     Equation,
     EquationRepository,
     IndexSet,

--- a/ixmp4/data/abstract/optimization/__init__.py
+++ b/ixmp4/data/abstract/optimization/__init__.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 
 from ..annotations import HasIdFilter, HasNameFilter, HasRunIdFilter
+from .base import BackendBaseRepository
 from .column import Column
 from .equation import Equation, EquationRepository
 from .indexset import IndexSet, IndexSetRepository

--- a/ixmp4/data/abstract/optimization/base.py
+++ b/ixmp4/data/abstract/optimization/base.py
@@ -1,0 +1,53 @@
+from typing import Any, Generic, Iterable, Protocol, TypeVar
+
+import pandas as pd
+
+# from ixmp4.data import types
+from .. import base
+from ..docs import DocsRepository
+
+# from .column import Column
+
+
+# TODO Currently not in use
+# class OptimizationBaseModel(base.BaseModel, Protocol):
+#     id: types.Integer
+#     name: types.String
+#     data: types.JsonDict
+#     columns: types.Mapped[list[Column]]
+#     run__id: types.Integer
+#     created_at: types.DateTime
+#     created_by: types.String
+
+
+BackendModelType = TypeVar("BackendModelType", bound=base.BaseModel, covariant=True)
+
+
+class BackendBaseRepository(
+    Generic[BackendModelType],
+    base.Creator,
+    base.Retriever,
+    base.Enumerator,
+    Protocol,
+):
+    docs: DocsRepository
+
+    def create(
+        self,
+        run_id: int,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+    ) -> BackendModelType: ...
+
+    def get(self, run_id: int, name: str) -> BackendModelType: ...
+
+    def get_by_id(self, id: int) -> BackendModelType: ...
+
+    def list(
+        self, *, name: str | None = None, **kwargs
+    ) -> Iterable[BackendModelType]: ...
+
+    def tabulate(self, *, name: str | None = None, **kwargs) -> pd.DataFrame: ...
+
+    def add_data(self, table_id: int, data: dict[str, Any] | pd.DataFrame) -> None: ...

--- a/ixmp4/data/abstract/optimization/base.py
+++ b/ixmp4/data/abstract/optimization/base.py
@@ -1,26 +1,28 @@
-from typing import Generic, Iterable, Protocol, TypeVar
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from . import EnumerateKwargs
 
 import pandas as pd
 
-# from ixmp4.data import types
+# TODO Import this from typing when dropping Python 3.11
+from typing_extensions import TypedDict, Unpack
+
+from ixmp4.data.abstract.unit import Unit
+
 from .. import base
 from ..docs import DocsRepository
 
-# from .column import Column
-
-
-# TODO Currently not in use
-# class OptimizationBaseModel(base.BaseModel, Protocol):
-#     id: types.Integer
-#     name: types.String
-#     data: types.JsonDict
-#     columns: types.Mapped[list[Column]]
-#     run__id: types.Integer
-#     created_at: types.DateTime
-#     created_by: types.String
-
-
 BackendModelType = TypeVar("BackendModelType", bound=base.BaseModel, covariant=True)
+
+
+class CreateKwargs(TypedDict, total=False):
+    value: float
+    unit: str | Unit | None
+    # TODO But how do we now show in core layer that e.g. Table needs these?
+    constrained_to_indexsets: list[str]
+    column_names: list[str] | None
 
 
 class BackendBaseRepository(
@@ -33,26 +35,13 @@ class BackendBaseRepository(
     docs: DocsRepository
 
     def create(
-        self,
-        run_id: int,
-        name: str,
-        # constrained_to_indexsets: list[str],
-        # column_names: list[str] | None = None,
-        *args,
-        **kwargs,
+        self, run_id: int, name: str, **kwargs: Unpack["CreateKwargs"]
     ) -> BackendModelType: ...
 
     def get(self, run_id: int, name: str) -> BackendModelType: ...
 
     def list(
-        self, *, name: str | None = None, **kwargs
+        self, **kwargs: Unpack["EnumerateKwargs"]
     ) -> Iterable[BackendModelType]: ...
 
-    def tabulate(self, *, name: str | None = None, **kwargs) -> pd.DataFrame: ...
-
-    # TODO Not needed as type hint in core layer:
-    # def get_by_id(self, id: int) -> BackendModelType: ...
-
-    # def add_data(
-    #     self, table_id: int, data: dict[str, Any] | pd.DataFrame
-    # ) -> None: ...
+    def tabulate(self, **kwargs: Unpack["EnumerateKwargs"]) -> pd.DataFrame: ...

--- a/ixmp4/data/abstract/optimization/base.py
+++ b/ixmp4/data/abstract/optimization/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Iterable, Protocol, TypeVar
+from typing import Generic, Iterable, Protocol, TypeVar
 
 import pandas as pd
 
@@ -36,13 +36,13 @@ class BackendBaseRepository(
         self,
         run_id: int,
         name: str,
-        constrained_to_indexsets: list[str],
-        column_names: list[str] | None = None,
+        # constrained_to_indexsets: list[str],
+        # column_names: list[str] | None = None,
+        *args,
+        **kwargs,
     ) -> BackendModelType: ...
 
     def get(self, run_id: int, name: str) -> BackendModelType: ...
-
-    def get_by_id(self, id: int) -> BackendModelType: ...
 
     def list(
         self, *, name: str | None = None, **kwargs
@@ -50,4 +50,9 @@ class BackendBaseRepository(
 
     def tabulate(self, *, name: str | None = None, **kwargs) -> pd.DataFrame: ...
 
-    def add_data(self, table_id: int, data: dict[str, Any] | pd.DataFrame) -> None: ...
+    # TODO Not needed as type hint in core layer:
+    # def get_by_id(self, id: int) -> BackendModelType: ...
+
+    # def add_data(
+    #     self, table_id: int, data: dict[str, Any] | pd.DataFrame
+    # ) -> None: ...

--- a/ixmp4/data/abstract/optimization/base.py
+++ b/ixmp4/data/abstract/optimization/base.py
@@ -20,8 +20,7 @@ BackendModelType = TypeVar("BackendModelType", bound=base.BaseModel, covariant=T
 class CreateKwargs(TypedDict, total=False):
     value: float
     unit: str | Unit | None
-    # TODO But how do we now show in core layer that e.g. Table needs these?
-    constrained_to_indexsets: list[str]
+    constrained_to_indexsets: str | list[str] | None
     column_names: list[str] | None
 
 

--- a/ixmp4/data/abstract/optimization/equation.py
+++ b/ixmp4/data/abstract/optimization/equation.py
@@ -13,6 +13,7 @@ from ixmp4.data import types
 
 from .. import base
 from ..docs import DocsRepository
+from .base import BackendBaseRepository
 from .column import Column
 
 
@@ -39,6 +40,7 @@ class Equation(base.BaseModel, Protocol):
 
 
 class EquationRepository(
+    BackendBaseRepository[Equation],
     base.Creator,
     base.Retriever,
     base.Enumerator,

--- a/ixmp4/data/abstract/optimization/indexset.py
+++ b/ixmp4/data/abstract/optimization/indexset.py
@@ -12,6 +12,7 @@ from ixmp4.data import types
 
 from .. import base
 from ..docs import DocsRepository
+from .base import BackendBaseRepository
 
 
 class IndexSet(base.BaseModel, Protocol):
@@ -36,6 +37,7 @@ class IndexSet(base.BaseModel, Protocol):
 
 
 class IndexSetRepository(
+    BackendBaseRepository[IndexSet],
     base.Creator,
     base.Retriever,
     base.Enumerator,

--- a/ixmp4/data/abstract/optimization/parameter.py
+++ b/ixmp4/data/abstract/optimization/parameter.py
@@ -13,6 +13,7 @@ from ixmp4.data import types
 
 from .. import base
 from ..docs import DocsRepository
+from .base import BackendBaseRepository
 from .column import Column
 
 
@@ -39,6 +40,7 @@ class Parameter(base.BaseModel, Protocol):
 
 
 class ParameterRepository(
+    BackendBaseRepository[Parameter],
     base.Creator,
     base.Retriever,
     base.Enumerator,

--- a/ixmp4/data/abstract/optimization/scalar.py
+++ b/ixmp4/data/abstract/optimization/scalar.py
@@ -19,6 +19,7 @@ from ixmp4.data import types
 from .. import base
 from ..docs import DocsRepository
 from ..unit import Unit
+from .base import BackendBaseRepository
 
 
 class Scalar(base.BaseModel, Protocol):
@@ -45,6 +46,7 @@ class Scalar(base.BaseModel, Protocol):
 
 
 class ScalarRepository(
+    BackendBaseRepository[Scalar],
     base.Creator,
     base.Retriever,
     base.Enumerator,

--- a/ixmp4/data/abstract/optimization/scalar.py
+++ b/ixmp4/data/abstract/optimization/scalar.py
@@ -52,20 +52,20 @@ class ScalarRepository(
 ):
     docs: DocsRepository
 
-    def create(self, name: str, value: float, unit_name: str, run_id: int) -> Scalar:
+    def create(self, run_id: int, name: str, value: float, unit_name: str) -> Scalar:
         """Creates a Scalar.
 
         Parameters
         ----------
+        run_id : int
+            The id of the :class:`ixmp4.data.abstract.Run` for which this Scalar is
+            defined.
         name : str
             The name of the Scalar.
         value : float
             The value of the Scalar.
         unit_name : str
             The name of the :class:`ixmp4.data.abstract.Unit` for which this Scalar is
-            defined.
-        run_id : int
-            The id of the :class:`ixmp4.data.abstract.Run` for which this Scalar is
             defined.
 
         Raises

--- a/ixmp4/data/abstract/optimization/table.py
+++ b/ixmp4/data/abstract/optimization/table.py
@@ -13,6 +13,7 @@ from ixmp4.data import types
 
 from .. import base
 from ..docs import DocsRepository
+from .base import BackendBaseRepository
 from .column import Column
 
 
@@ -39,6 +40,7 @@ class Table(base.BaseModel, Protocol):
 
 
 class TableRepository(
+    BackendBaseRepository[Table],
     base.Creator,
     base.Retriever,
     base.Enumerator,

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -12,6 +12,7 @@ from ixmp4.data import types
 
 from .. import base
 from ..docs import DocsRepository
+from .base import BackendBaseRepository
 from .column import Column
 
 
@@ -38,6 +39,7 @@ class Variable(base.BaseModel, Protocol):
 
 
 class VariableRepository(
+    BackendBaseRepository[Variable],
     base.Creator,
     base.Retriever,
     base.Enumerator,


### PR DESCRIPTION
For #94, @danielhuppmann asked in the `core` layer: "Why does `Parameter` not inherit from `Table`"? And sure enough, these optimization items share a lot of common functionality. So before moving on to `Variable` and `Equation`, for which this will be the case even more so, I wanted to take another look at this.

@meksor, I expect you'll be the one to take a look at this. Sorry, this description might be a bit lengthy.

Initially, I interpreted the question as for the DB layer, and how to handle inheritance (or rather _Composition_) there has been recently discussed in #82. Instead, this PR focuses on the core layer, where we also have two classes per optimization item that could potentially benefit from higher reusability (to follow the DRY principle): e.g., the `Table` (mostly a collection of data attributes) and the `TableRespository` (functions to handle `Table`s).
For the `Table`s themselves (and similar), we are currently using Python's [property](https://docs.python.org/3/library/functions.html#property) to make data attributes accessible in a controlled way. Unfortunately, these `property`s don't mix well with inheritance. [This article](https://gist.github.com/Susensio/979259559e2bebcd0273f1a95d7c1e79) describes how to still make it work for the `getter` part, but since we would still have to repeat the same number of lines in the data files, I'm not sure it's worth the effort here. What we stand to gain is a separation of functionality and placeholder code, it seems to me. So when we want to make changes to how e.g. `data` is returned from an optimization model, we would just need to change one place and all others would inherit these changes. However, code repetition would not be decreased and understanding the models might become more complicated, so I've put this on hold for now.
For `TableRepository`, there is luckily a quite straightforward way: we can employ the same approach as in the DB layer and create an `OptimizationBaseRepository` in the core layer that can be extended with `Creator`, `Retriever`, etc as needed. This seems to work well and every optimization item repo then just needs to clarify which `_model_type` and `_backend_repository` it is interested in. 
For better understanding, I wanted to type hint the `_backend_repository` in the `OptimizationBaseRepository`. However, we didn't already have an appropriate object to do so. That's why I have created a `BackendBaseRepository` in `abstract.optimization.base`, which simply announces how the actual `TableRepository` in the DB layer is going to look. I'm not sure if this is the correct location; I've usually worked with abstract models to type hint API/DB layer functionality, but I also don't know where else it would live.

This is the point where I'm not sure I'm naming things correctly anymore. I started from `Table`, which already has `Table.data`, which is arguably the largest part of shared functionality, at least in the DB layer, and which is missing from `IndexSet` and `Scalar`. So these two items could not use the `OptimizationBaseRepository` as it is now, which seems like a misnomer. Maybe the data functionality needs to be further separated (allowing us to DRY even more parts of this layer) or maybe we find another name?
The same applies for `BackendBaseRepository`.

-----

> [!NOTE]
> For the curious: there's an [issue on CPython](https://github.com/python/cpython/issues/59170) about `property`s and inheritance from 2012.
