### PR TITLE
Introduce optimization variable

### DIFF
--- a/ixmp4/core/__init__.py
+++ b/ixmp4/core/__init__.py
@@ -5,6 +5,9 @@ from .optimization.indexset import IndexSet as IndexSet
 from .optimization.scalar import Scalar as Scalar
 from .optimization.table import Table as Table
 from .optimization.parameter import Parameter as Parameter
+
+# TODO Is this really the name we want to use?
+from .optimization.variable import Variable as OptimizationVariable
 from .platform import Platform as Platform
 from .region import Region as Region
 from .run import Run as Run

--- a/ixmp4/core/optimization/data.py
+++ b/ixmp4/core/optimization/data.py
@@ -5,6 +5,7 @@ from .indexset import IndexSetRepository
 from .parameter import ParameterRepository
 from .scalar import ScalarRepository
 from .table import TableRepository
+from .variable import VariableRepository
 
 
 class OptimizationData(BaseFacade):
@@ -15,6 +16,7 @@ class OptimizationData(BaseFacade):
     parameters: ParameterRepository
     scalars: ScalarRepository
     tables: TableRepository
+    variables: VariableRepository
 
     def __init__(self, *args, run: Run, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -22,3 +24,4 @@ class OptimizationData(BaseFacade):
         self.parameters = ParameterRepository(_backend=self.backend, _run=run)
         self.scalars = ScalarRepository(_backend=self.backend, _run=run)
         self.tables = TableRepository(_backend=self.backend, _run=run)
+        self.variables = VariableRepository(_backend=self.backend, _run=run)

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, ClassVar, Iterable
+from typing import Any, ClassVar, Iterable, Never
 
 import pandas as pd
 
@@ -49,11 +49,11 @@ class Variable(BaseModelFacade):
         return self._model.data.get("marginals", [])
 
     @property
-    def constrained_to_indexsets(self) -> list[str]:
+    def constrained_to_indexsets(self) -> list[str | Never]:
         return [column.indexset.name for column in self._model.columns]
 
     @property
-    def columns(self) -> list[Column]:
+    def columns(self) -> list[Column | Never]:
         return self._model.columns
 
     @property
@@ -100,7 +100,7 @@ class VariableRepository(BaseFacade):
     def create(
         self,
         name: str,
-        constrained_to_indexsets: list[str],
+        constrained_to_indexsets: str | list[str] | None = None,
         column_names: list[str] | None = None,
     ) -> Variable:
         model = self.backend.optimization.variables.create(

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -134,4 +134,6 @@ class VariableRepository(BaseFacade):
         ]
 
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
-        return self.backend.optimization.variables.tabulate(name=name)
+        return self.backend.optimization.variables.tabulate(
+            run_id=self._run.id, name=name
+        )

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -1,0 +1,131 @@
+from datetime import datetime
+from typing import Any, ClassVar, Iterable
+
+import pandas as pd
+
+from ixmp4.core.base import BaseFacade, BaseModelFacade
+from ixmp4.data.abstract import Docs as DocsModel
+from ixmp4.data.abstract import OptimizationVariable as VariableModel
+from ixmp4.data.abstract import Run
+from ixmp4.data.abstract.optimization import Column
+
+
+class Variable(BaseModelFacade):
+    _model: VariableModel
+    NotFound: ClassVar = VariableModel.NotFound
+    NotUnique: ClassVar = VariableModel.NotUnique
+
+    @property
+    def id(self) -> int:
+        return self._model.id
+
+    @property
+    def name(self) -> str:
+        return self._model.name
+
+    @property
+    def run_id(self) -> int:
+        return self._model.run__id
+
+    @property
+    def data(self) -> dict[str, Any]:
+        return self._model.data
+
+    def add(self, data: dict[str, Any] | pd.DataFrame) -> None:
+        """Adds data to an existing Variable."""
+        self.backend.optimization.variables.add_data(
+            variable_id=self._model.id, data=data
+        )
+        self._model.data = self.backend.optimization.variables.get(
+            run_id=self._model.run__id, name=self._model.name
+        ).data
+
+    @property
+    def levels(self) -> list:
+        return self._model.data.get("levels", [])
+
+    @property
+    def marginals(self) -> list:
+        return self._model.data.get("marginals", [])
+
+    @property
+    def constrained_to_indexsets(self) -> list[str]:
+        return [column.indexset.name for column in self._model.columns]
+
+    @property
+    def columns(self) -> list[Column]:
+        return self._model.columns
+
+    @property
+    def created_at(self) -> datetime | None:
+        return self._model.created_at
+
+    @property
+    def created_by(self) -> str | None:
+        return self._model.created_by
+
+    @property
+    def docs(self):
+        try:
+            return self.backend.optimization.variables.docs.get(self.id).description
+        except DocsModel.NotFound:
+            return None
+
+    @docs.setter
+    def docs(self, description):
+        if description is None:
+            self.backend.optimization.variables.docs.delete(self.id)
+        else:
+            self.backend.optimization.variables.docs.set(self.id, description)
+
+    @docs.deleter
+    def docs(self):
+        try:
+            self.backend.optimization.variables.docs.delete(self.id)
+        # TODO: silently failing
+        except DocsModel.NotFound:
+            return None
+
+    def __str__(self) -> str:
+        return f"<Variable {self.id} name={self.name}>"
+
+
+class VariableRepository(BaseFacade):
+    _run: Run
+
+    def __init__(self, _run: Run, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._run = _run
+
+    def create(
+        self,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+    ) -> Variable:
+        model = self.backend.optimization.variables.create(
+            name=name,
+            run_id=self._run.id,
+            constrained_to_indexsets=constrained_to_indexsets,
+            column_names=column_names,
+        )
+        return Variable(_backend=self.backend, _model=model)
+
+    def get(self, name: str) -> Variable:
+        model = self.backend.optimization.variables.get(run_id=self._run.id, name=name)
+        return Variable(_backend=self.backend, _model=model)
+
+    def list(self, name: str | None = None) -> Iterable[Variable]:
+        variables = self.backend.optimization.variables.list(
+            run_id=self._run.id, name=name
+        )
+        return [
+            Variable(
+                _backend=self.backend,
+                _model=i,
+            )
+            for i in variables
+        ]
+
+    def tabulate(self, name: str | None = None) -> pd.DataFrame:
+        return self.backend.optimization.variables.tabulate(name=name)

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -57,10 +57,14 @@ class Variable(BaseModelFacade):
 
     @property
     def constrained_to_indexsets(self) -> list[str]:
-        return [column.indexset.name for column in self._model.columns]
+        return (
+            [column.indexset.name for column in self._model.columns]
+            if self._model.columns
+            else []
+        )
 
     @property
-    def columns(self) -> list[Column]:
+    def columns(self) -> list[Column] | None:
         return self._model.columns
 
     @property

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -1,5 +1,6 @@
+import sys
 from datetime import datetime
-from typing import Any, ClassVar, Iterable, Never
+from typing import Any, ClassVar, Iterable
 
 import pandas as pd
 
@@ -8,6 +9,11 @@ from ixmp4.data.abstract import Docs as DocsModel
 from ixmp4.data.abstract import OptimizationVariable as VariableModel
 from ixmp4.data.abstract import Run
 from ixmp4.data.abstract.optimization import Column
+
+if sys.version_info >= (3, 11):
+    from typing import Never
+else:
+    from typing import NoReturn as Never
 
 
 class Variable(BaseModelFacade):

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -40,6 +40,13 @@ class Variable(BaseModelFacade):
             run_id=self._model.run__id, name=self._model.name
         ).data
 
+    def remove_data(self) -> None:
+        """Removes data from an existing Variable."""
+        self.backend.optimization.variables.remove_data(variable_id=self._model.id)
+        self._model.data = self.backend.optimization.variables.get(
+            run_id=self._model.run__id, name=self._model.name
+        ).data
+
     @property
     def levels(self) -> list:
         return self._model.data.get("levels", [])

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from typing import Any, ClassVar, Iterable
 
@@ -9,11 +8,6 @@ from ixmp4.data.abstract import Docs as DocsModel
 from ixmp4.data.abstract import OptimizationVariable as VariableModel
 from ixmp4.data.abstract import Run
 from ixmp4.data.abstract.optimization import Column
-
-if sys.version_info >= (3, 11):
-    from typing import Never
-else:
-    from typing import NoReturn as Never
 
 
 class Variable(BaseModelFacade):
@@ -55,11 +49,11 @@ class Variable(BaseModelFacade):
         return self._model.data.get("marginals", [])
 
     @property
-    def constrained_to_indexsets(self) -> list[str | Never]:
+    def constrained_to_indexsets(self) -> list[str]:
         return [column.indexset.name for column in self._model.columns]
 
     @property
-    def columns(self) -> list[Column | Never]:
+    def columns(self) -> list[Column]:
         return self._model.columns
 
     @property

--- a/ixmp4/data/abstract/__init__.py
+++ b/ixmp4/data/abstract/__init__.py
@@ -38,6 +38,10 @@ from .optimization import (
     Table,
     TableRepository,
 )
+
+# TODO for PR: avoiding name conflict here Is that okay?
+from .optimization import Variable as OptimizationVariable
+from .optimization import VariableRepository as OptimizationVariableRepository
 from .region import Region, RegionRepository
 from .run import Run, RunRepository
 from .scenario import Scenario, ScenarioRepository

--- a/ixmp4/data/abstract/optimization/__init__.py
+++ b/ixmp4/data/abstract/optimization/__init__.py
@@ -3,3 +3,4 @@ from .indexset import IndexSet, IndexSetRepository
 from .parameter import Parameter, ParameterRepository
 from .scalar import Scalar, ScalarRepository
 from .table import Table, TableRepository
+from .variable import Variable, VariableRepository

--- a/ixmp4/data/abstract/optimization/column.py
+++ b/ixmp4/data/abstract/optimization/column.py
@@ -18,6 +18,8 @@ class Column(base.BaseModel, Protocol):
     """Foreign unique integer id of a Table."""
     parameter__id: types.Mapped[int | None]
     """Foreign unique integer id of a Parameter."""
+    variable__id: types.Mapped[int | None]
+    """Foreign unique integer id of a Variable."""
     indexset: types.Mapped[IndexSet]
     """Associated IndexSet."""
     constrained_to_indexset: types.Integer

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -1,0 +1,201 @@
+from typing import Any, Iterable, Protocol
+
+import pandas as pd
+
+from ixmp4.data import types
+
+from .. import base
+from ..docs import DocsRepository
+from .column import Column
+
+
+class Variable(base.BaseModel, Protocol):
+    """Variable data model."""
+
+    name: types.String
+    """Unique name of the Variable."""
+    data: types.JsonDict
+    """Data stored in the Variable."""
+    columns: types.Mapped[list[Column]]
+    """Data specifying this Variable's Columns."""
+
+    run__id: types.Integer
+    "Foreign unique integer id of a run."
+
+    created_at: types.DateTime
+    "Creation date/time. TODO"
+    created_by: types.String
+    "Creator. TODO"
+
+    def __str__(self) -> str:
+        return f"<Variable {self.id} name={self.name}>"
+
+
+class VariableRepository(
+    base.Creator,
+    base.Retriever,
+    base.Enumerator,
+    Protocol,
+):
+    docs: DocsRepository
+
+    def create(
+        self,
+        run_id: int,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+    ) -> Variable:
+        """Creates a Variable.
+        Each column of the Variable needs to be constrained to an existing
+        :class:ixmp4.data.abstract.optimization.IndexSet. These are specified by name
+        and per default, these will be the column names. They can be overwritten by
+        specifying `column_names`, which needs to specify a unique name for each column.
+
+        Parameters
+        ----------
+        run_id : int
+            The id of the :class:`ixmp4.data.abstract.Run` for which this Variable is
+            defined.
+        name : str
+            The unique name of the Variable.
+        constrained_to_indexsets : list[str]
+            List of :class:`ixmp4.data.abstract.optimization.IndexSet` names that define
+            the allowed contents of the Variable's columns.
+        column_names: list[str] | None = None
+            Optional list of names to use as column names. If given, overwrites the
+            names inferred from `constrained_to_indexsets`.
+
+        Raises
+        ------
+        :class:`ixmp4.data.abstract.optimization.Variable.NotUnique`:
+            If the Variable with `name` already exists for the Run with `run_id`.
+        ValueError
+            If `column_names` are not unique or not enough names are given.
+
+        Returns
+        -------
+        :class:`ixmp4.data.abstract.optimization.Variable`:
+            The created Variable.
+        """
+        ...
+
+    def get(self, run_id: int, name: str) -> Variable:
+        """Retrieves a Variable.
+
+        Parameters
+        ----------
+        run_id : int
+            The id of the :class:`ixmp4.data.abstract.Run` for which this Variable is
+            defined.
+        name : str
+            The name of the Variable.
+
+        Raises
+        ------
+        :class:`ixmp4.data.abstract.optimization.Variable.NotFound`:
+            If the Variable with `name` does not exist.
+
+        Returns
+        -------
+        :class:`ixmp4.data.abstract.optimization.Variable`:
+            The retrieved Variable.
+        """
+        ...
+
+    def get_by_id(self, id: int) -> Variable:
+        """Retrieves a Variable by its id.
+
+        Parameters
+        ----------
+        id : int
+            Unique integer id.
+
+        Raises
+        ------
+        :class:`ixmp4.data.abstract.optimization.Variable.NotFound`.
+            If the Variable with `id` does not exist.
+
+        Returns
+        -------
+        :class:`ixmp4.data.abstract.optimization.Variable`:
+            The retrieved Variable.
+        """
+        ...
+
+    def list(self, *, name: str | None = None, **kwargs) -> Iterable[Variable]:
+        r"""Lists Variables by specified criteria.
+
+        Parameters
+        ----------
+        name : str
+            The name of a Variable. If supplied only one result will be returned.
+        # TODO: Update kwargs
+        \*\*kwargs: any
+            More filter Variables as specified in
+            `ixmp4.data.db.iamc.variable.filters.VariableFilter`.
+
+        Returns
+        -------
+        Iterable[:class:`ixmp4.data.abstract.optimization.Variable`]:
+            List of Variables.
+        """
+        ...
+
+    def tabulate(self, *, name: str | None = None, **kwargs) -> pd.DataFrame:
+        r"""Tabulate Variables by specified criteria.
+
+        Parameters
+        ----------
+        name : str
+            The name of a Variable. If supplied only one result will be returned.
+        # TODO: Update kwargs
+        \*\*kwargs: any
+            More filter variables as specified in
+            `ixmp4.data.db.iamc.variable.filters.VariableFilter`.
+
+        Returns
+        -------
+        :class:`pandas.DataFrame`:
+            A data frame with the columns:
+                - id
+                - name
+                - data
+                - run__id
+                - created_at
+                - created_by
+        """
+        ...
+
+    # TODO Question for Daniel: do variables need to allow adding data manually?
+    # TODO Once present, state how to check which IndexSets are linked and which values
+    # they permit
+    def add_data(self, variable_id: int, data: dict[str, Any] | pd.DataFrame) -> None:
+        r"""Adds data to a Variable.
+        The data will be validated with the linked constrained
+        :class:`ixmp4.data.abstract.optimization.IndexSet`s. For that, `data.keys()`
+        must correspond to the names of the Variable's columns. Each column can only
+        contain values that are in the linked `IndexSet.elements`. Each row of entries
+        must be unique. No values can be missing, `None`, or `NaN`. If `data.keys()`
+        contains names already present in `Variable.data`, existing values will be
+        overwritten.
+
+        Parameters
+        ----------
+        variable_id : int
+            The id of the :class:`ixmp4.data.abstract.optimization.Variable`.
+        data : dict[str, Any] | pandas.DataFrame
+            The data to be added.
+
+        Raises
+        ------
+        ValueError:
+            - If values are missing, `None`, or `NaN`
+            - If values are not allowed based on constraints to `Indexset`s
+            - If rows are not unique
+
+        Returns
+        -------
+        None
+        """
+        ...

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Iterable, Protocol
 
 import pandas as pd
@@ -9,11 +8,6 @@ from .. import base
 from ..docs import DocsRepository
 from .column import Column
 
-if sys.version_info >= (3, 11):
-    from typing import Never
-else:
-    from typing import NoReturn as Never
-
 
 class Variable(base.BaseModel, Protocol):
     """Variable data model."""
@@ -22,7 +16,7 @@ class Variable(base.BaseModel, Protocol):
     """Unique name of the Variable."""
     data: types.JsonDict
     """Data stored in the Variable."""
-    columns: types.Mapped[list[Column | Never]]
+    columns: types.Mapped[list[Column] | None]
     """Data specifying this Variable's Columns."""
 
     run__id: types.Integer

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Protocol
+from typing import Any, Iterable, Never, Protocol
 
 import pandas as pd
 
@@ -16,7 +16,7 @@ class Variable(base.BaseModel, Protocol):
     """Unique name of the Variable."""
     data: types.JsonDict
     """Data stored in the Variable."""
-    columns: types.Mapped[list[Column]]
+    columns: types.Mapped[list[Column | Never]]
     """Data specifying this Variable's Columns."""
 
     run__id: types.Integer
@@ -43,7 +43,7 @@ class VariableRepository(
         self,
         run_id: int,
         name: str,
-        constrained_to_indexsets: list[str],
+        constrained_to_indexsets: str | list[str] | None = None,
         column_names: list[str] | None = None,
     ) -> Variable:
         """Creates a Variable.
@@ -60,9 +60,10 @@ class VariableRepository(
             defined.
         name : str
             The unique name of the Variable.
-        constrained_to_indexsets : list[str]
-            List of :class:`ixmp4.data.abstract.optimization.IndexSet` names that define
-            the allowed contents of the Variable's columns.
+        constrained_to_indexsets : str | list[str] | None = None
+            One or a List of :class:`ixmp4.data.abstract.optimization.IndexSet` names
+            that define the allowed contents of the Variable's columns. If None, no data
+            can be added beyond `levels` and `marginals`!
         column_names: list[str] | None = None
             Optional list of names to use as column names. If given, overwrites the
             names inferred from `constrained_to_indexsets`.

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -178,6 +178,7 @@ class VariableRepository(
     # TODO Question for Daniel: do variables need to allow adding data manually?
     # TODO Once present, state how to check which IndexSets are linked and which values
     # they permit
+    # TODO Can we remove the r-marker?
     def add_data(self, variable_id: int, data: dict[str, Any] | pd.DataFrame) -> None:
         r"""Adds data to a Variable.
 
@@ -202,6 +203,20 @@ class VariableRepository(
             - If values are missing, `None`, or `NaN`
             - If values are not allowed based on constraints to `Indexset`s
             - If rows are not unique
+
+        Returns
+        -------
+        None
+        """
+        ...
+
+    def remove_data(self, variable_id: int) -> None:
+        """Removes data from a Variable.
+
+        Parameters
+        ----------
+        variable_id : int
+            The id of the :class:`ixmp4.data.abstract.optimization.Variable`.
 
         Returns
         -------

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -47,6 +47,7 @@ class VariableRepository(
         column_names: list[str] | None = None,
     ) -> Variable:
         """Creates a Variable.
+
         Each column of the Variable needs to be constrained to an existing
         :class:ixmp4.data.abstract.optimization.IndexSet. These are specified by name
         and per default, these will be the column names. They can be overwritten by
@@ -133,7 +134,7 @@ class VariableRepository(
         # TODO: Update kwargs
         \*\*kwargs: any
             More filter Variables as specified in
-            `ixmp4.data.db.iamc.variable.filters.VariableFilter`.
+            `ixmp4.data.db.optimization.variable.filter.OptimizationVariableFilter`.
 
         Returns
         -------
@@ -152,7 +153,7 @@ class VariableRepository(
         # TODO: Update kwargs
         \*\*kwargs: any
             More filter variables as specified in
-            `ixmp4.data.db.iamc.variable.filters.VariableFilter`.
+            `ixmp4.data.db.optimization.variable.filter.OptimizationVariableFilter`.
 
         Returns
         -------
@@ -172,6 +173,7 @@ class VariableRepository(
     # they permit
     def add_data(self, variable_id: int, data: dict[str, Any] | pd.DataFrame) -> None:
         r"""Adds data to a Variable.
+
         The data will be validated with the linked constrained
         :class:`ixmp4.data.abstract.optimization.IndexSet`s. For that, `data.keys()`
         must correspond to the names of the Variable's columns. Each column can only

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Never, Protocol
+import sys
+from typing import Any, Iterable, Protocol
 
 import pandas as pd
 
@@ -7,6 +8,11 @@ from ixmp4.data import types
 from .. import base
 from ..docs import DocsRepository
 from .column import Column
+
+if sys.version_info >= (3, 11):
+    from typing import Never
+else:
+    from typing import NoReturn as Never
 
 
 class Variable(base.BaseModel, Protocol):

--- a/ixmp4/data/api/__init__.py
+++ b/ixmp4/data/api/__init__.py
@@ -20,6 +20,10 @@ from .optimization import (
     Table,
     TableRepository,
 )
+
+# TODO for PR: avoiding name conflict here Is that okay?
+from .optimization import Variable as OptimizationVariable
+from .optimization import VariableRepository as OptimizationVariableRepository
 from .region import Region, RegionParent, RegionRepository
 from .run import Run, RunRepository
 from .scenario import Scenario, ScenarioRepository

--- a/ixmp4/data/api/optimization/__init__.py
+++ b/ixmp4/data/api/optimization/__init__.py
@@ -2,3 +2,4 @@ from .indexset import IndexSet, IndexSetRepository
 from .parameter import Parameter, ParameterRepository
 from .scalar import Scalar, ScalarRepository
 from .table import Table, TableRepository
+from .variable import Variable, VariableRepository

--- a/ixmp4/data/api/optimization/column.py
+++ b/ixmp4/data/api/optimization/column.py
@@ -16,6 +16,7 @@ class Column(base.BaseModel):
     dtype: str
     table__id: int | None
     parameter__id: int | None
+    variable__id: int | None
     indexset: IndexSet
     constrained_to_indexset: int
     unique: bool

--- a/ixmp4/data/api/optimization/variable.py
+++ b/ixmp4/data/api/optimization/variable.py
@@ -47,7 +47,7 @@ class VariableRepository(
         self,
         run_id: int,
         name: str,
-        constrained_to_indexsets: list[str],
+        constrained_to_indexsets: str | list[str] | None = None,
         column_names: list[str] | None = None,
     ) -> Variable:
         return super().create(

--- a/ixmp4/data/api/optimization/variable.py
+++ b/ixmp4/data/api/optimization/variable.py
@@ -66,6 +66,9 @@ class VariableRepository(
             method="PATCH", path=self.prefix + str(variable_id) + "/data/", json=kwargs
         )
 
+    def remove_data(self, variable_id: int) -> None:
+        self._request(method="DELETE", path=self.prefix + str(variable_id) + "/data/")
+
     def get(self, run_id: int, name: str) -> Variable:
         return super().get(run_id=run_id, name=name)
 

--- a/ixmp4/data/api/optimization/variable.py
+++ b/ixmp4/data/api/optimization/variable.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from typing import Any, ClassVar, Iterable
+
+import pandas as pd
+
+from ixmp4.data import abstract
+
+from .. import base
+from ..docs import Docs, DocsRepository
+from .column import Column
+
+
+class Variable(base.BaseModel):
+    NotFound: ClassVar = abstract.OptimizationVariable.NotFound
+    NotUnique: ClassVar = abstract.OptimizationVariable.NotUnique
+    DeletionPrevented: ClassVar = abstract.OptimizationVariable.DeletionPrevented
+
+    id: int
+    name: str
+    data: dict[str, Any]
+    columns: list["Column"]
+    run__id: int
+
+    created_at: datetime | None
+    created_by: str | None
+
+
+class VariableDocsRepository(DocsRepository):
+    model_class = Docs
+    prefix = "docs/optimization/variables/"
+
+
+class VariableRepository(
+    base.Creator[Variable],
+    base.Retriever[Variable],
+    base.Enumerator[Variable],
+    abstract.OptimizationVariableRepository,
+):
+    model_class = Variable
+    prefix = "optimization/variables/"
+
+    def __init__(self, backend, *args, **kwargs) -> None:
+        super().__init__(backend, *args, **kwargs)
+        self.docs = VariableDocsRepository(backend)
+
+    def create(
+        self,
+        run_id: int,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+    ) -> Variable:
+        return super().create(
+            name=name,
+            run_id=run_id,
+            constrained_to_indexsets=constrained_to_indexsets,
+            column_names=column_names,
+        )
+
+    def add_data(self, variable_id: int, data: dict[str, Any] | pd.DataFrame) -> None:
+        if isinstance(data, pd.DataFrame):
+            # data will always contains str, not only Hashable
+            data: dict[str, Any] = data.to_dict(orient="list")  # type: ignore
+        kwargs = {"data": data}
+        self._request(
+            method="PATCH", path=self.prefix + str(variable_id) + "/data/", json=kwargs
+        )
+
+    def get(self, run_id: int, name: str) -> Variable:
+        return super().get(run_id=run_id, name=name)
+
+    def get_by_id(self, id: int) -> Variable:
+        res = self._get_by_id(id)
+        return Variable(**res)
+
+    def list(self, *args, **kwargs) -> Iterable[Variable]:
+        return super().list(*args, **kwargs)
+
+    def tabulate(self, *args, **kwargs) -> pd.DataFrame:
+        return super().tabulate(*args, **kwargs)
+
+    def enumerate(self, *args, **kwargs) -> Iterable[Variable] | pd.DataFrame:
+        return super().enumerate(*args, **kwargs)

--- a/ixmp4/data/backend/api.py
+++ b/ixmp4/data/backend/api.py
@@ -13,17 +13,18 @@ from ixmp4.data.api import (
     DataPointRepository,
     IndexSetRepository,
     ModelRepository,
+    OptimizationVariableRepository,
     ParameterRepository,
+    RegionRepository,
     RunMetaEntryRepository,
     RunRepository,
     ScalarRepository,
     ScenarioRepository,
     TableRepository,
     TimeSeriesRepository,
+    UnitRepository,
     VariableRepository,
 )
-from ixmp4.data.api.region import RegionRepository
-from ixmp4.data.api.unit import UnitRepository
 from ixmp4.server import app, v1
 from ixmp4.server.rest import APIInfo, deps
 
@@ -117,6 +118,7 @@ class RestBackend(Backend):
         self.optimization.parameters = ParameterRepository(self)
         self.optimization.scalars = ScalarRepository(self)
         self.optimization.tables = TableRepository(self)
+        self.optimization.variables = OptimizationVariableRepository(self)
         self.regions = RegionRepository(self)
         self.runs = RunRepository(self)
         self.scenarios = ScenarioRepository(self)

--- a/ixmp4/data/backend/base.py
+++ b/ixmp4/data/backend/base.py
@@ -3,6 +3,7 @@ from ixmp4.data.abstract import (
     DataPointRepository,
     IndexSetRepository,
     ModelRepository,
+    OptimizationVariableRepository,
     ParameterRepository,
     RegionRepository,
     RunMetaEntryRepository,
@@ -27,6 +28,7 @@ class OptimizationSubobject(object):
     parameters: ParameterRepository
     scalars: ScalarRepository
     tables: TableRepository
+    variables: OptimizationVariableRepository
 
 
 class Backend(object):

--- a/ixmp4/data/backend/db.py
+++ b/ixmp4/data/backend/db.py
@@ -16,6 +16,7 @@ from ixmp4.data.db import (
     DataPointRepository,
     IndexSetRepository,
     ModelRepository,
+    OptimizationVariableRepository,
     ParameterRepository,
     RegionRepository,
     RunMetaEntryRepository,
@@ -55,6 +56,7 @@ class OptimizationSubobject(BaseOptimizationSubobject):
     parameters: ParameterRepository
     scalars: ScalarRepository
     tables: TableRepository
+    variables: OptimizationVariableRepository
 
 
 class SqlAlchemyBackend(Backend):
@@ -101,6 +103,7 @@ class SqlAlchemyBackend(Backend):
         self.optimization.parameters = ParameterRepository(self)
         self.optimization.scalars = ScalarRepository(self)
         self.optimization.tables = TableRepository(self)
+        self.optimization.variables = OptimizationVariableRepository(self)
         self.regions = RegionRepository(self)
         self.runs = RunRepository(self)
         self.scenarios = ScenarioRepository(self)

--- a/ixmp4/data/db/__init__.py
+++ b/ixmp4/data/db/__init__.py
@@ -29,6 +29,10 @@ from .optimization import (
     Table,
     TableRepository,
 )
+
+# TODO for PR: avoiding name conflict here Is that okay?
+from .optimization import Variable as OptimizationVariable
+from .optimization import VariableRepository as OptimizationVariableRepository
 from .region import Region, RegionRepository
 from .run import Run, RunRepository
 from .scenario import Scenario, ScenarioRepository

--- a/ixmp4/data/db/filters/__init__.py
+++ b/ixmp4/data/db/filters/__init__.py
@@ -5,6 +5,7 @@ from .optimizationindexset import OptimizationIndexSetFilter
 from .optimizationparameter import OptimizationParameterFilter
 from .optimizationscalar import OptimizationScalarFilter
 from .optimizationtable import OptimizationTableFilter
+from .optimizationvariable import OptimizationVariableFilter
 from .region import RegionFilter
 from .run import RunFilter
 from .scenario import ScenarioFilter

--- a/ixmp4/data/db/filters/optimizationvariable.py
+++ b/ixmp4/data/db/filters/optimizationvariable.py
@@ -1,0 +1,17 @@
+from typing import ClassVar
+
+from ixmp4.db import filters
+
+from .. import OptimizationVariable, Run
+
+
+class OptimizationVariableFilter(filters.BaseFilter, metaclass=filters.FilterMeta):
+    id: filters.Id
+    name: filters.String
+    run__id: filters.Integer = filters.Field(None, alias="run_id")
+
+    sqla_model: ClassVar[type] = OptimizationVariable
+
+    def join(self, exc, **kwargs):
+        exc = exc.join(Run, onclause=OptimizationVariable.run__id == Run.id)
+        return exc

--- a/ixmp4/data/db/optimization/__init__.py
+++ b/ixmp4/data/db/optimization/__init__.py
@@ -3,3 +3,4 @@ from .indexset import IndexSet, IndexSetRepository
 from .parameter import Parameter, ParameterRepository
 from .scalar import Scalar, ScalarRepository
 from .table import Table, TableRepository
+from .variable import Variable, VariableRepository

--- a/ixmp4/data/db/optimization/column/model.py
+++ b/ixmp4/data/db/optimization/column/model.py
@@ -24,6 +24,10 @@ class Column(base.BaseModel):
     parameter__id: types.Mapped[int | None] = db.Column(
         db.Integer, db.ForeignKey("optimization_parameter.id"), nullable=True
     )
+    # TODO ...
+    variable__id: types.Mapped[int | None] = db.Column(
+        db.Integer, db.ForeignKey("optimization_optimizationvariable.id"), nullable=True
+    )
     indexset: types.Mapped[IndexSet] = db.relationship(single_parent=True)
     constrained_to_indexset: types.Integer = db.Column(
         db.Integer, db.ForeignKey("optimization_indexset.id"), index=True

--- a/ixmp4/data/db/optimization/column/repository.py
+++ b/ixmp4/data/db/optimization/column/repository.py
@@ -26,6 +26,7 @@ class ColumnRepository(
         dtype: str,
         parameter_id: int,
         table_id: int,
+        variable_id: int,
         unique: bool,
     ) -> Column:
         column = Column(
@@ -34,6 +35,7 @@ class ColumnRepository(
             dtype=dtype,
             parameter__id=parameter_id,
             table__id=table_id,
+            variable__id=variable_id,
             unique=unique,
         )
         self.session.add(column)
@@ -47,6 +49,7 @@ class ColumnRepository(
         dtype: str,
         parameter_id: int | None = None,
         table_id: int | None = None,
+        variable_id: int | None = None,
         unique: bool = True,
         **kwargs,
     ) -> Column:
@@ -68,6 +71,10 @@ class ColumnRepository(
         table_id : int | None, default None
             The unique integer id of the :class:`ixmp4.data.abstract.optimization.Table`
             this Column belongs to, if it belongs to a `Table`.
+        variable_id : int | None, default None
+            The unique integer id of the
+            :class:`ixmp4.data.abstract.optimization.Variable` this Column belongs to,
+            if it belongs to a `Variable`.
         unique : bool
             A bool to determine whether entries in this Column should be considered for
             evaluating uniqueness of keys. Defaults to True.
@@ -89,6 +96,7 @@ class ColumnRepository(
             dtype=dtype,
             parameter_id=parameter_id,
             table_id=table_id,
+            variable_id=variable_id,
             unique=unique,
             **kwargs,
         )

--- a/ixmp4/data/db/optimization/variable/__init__.py
+++ b/ixmp4/data/db/optimization/variable/__init__.py
@@ -1,0 +1,2 @@
+from .model import OptimizationVariable as Variable
+from .repository import VariableRepository

--- a/ixmp4/data/db/optimization/variable/docs.py
+++ b/ixmp4/data/db/optimization/variable/docs.py
@@ -1,0 +1,8 @@
+from ixmp4.data.db.docs import BaseDocsRepository, docs_model
+
+from .model import OptimizationVariable as Variable
+
+
+class OptimizationVariableDocsRepository(BaseDocsRepository):
+    model_class = docs_model(Variable)  # VariableDocs
+    dimension_model_class = Variable

--- a/ixmp4/data/db/optimization/variable/filter.py
+++ b/ixmp4/data/db/optimization/variable/filter.py
@@ -1,0 +1,19 @@
+from ixmp4.data.db import filters as base
+from ixmp4.data.db.run import Run
+from ixmp4.db import filters, utils
+
+from .model import OptimizationVariable as Variable
+
+
+class RunFilter(base.RunFilter, metaclass=filters.FilterMeta):
+    def join(self, exc, **kwargs):
+        if not utils.is_joined(exc, Run):
+            exc = exc.join(Run, onclause=Variable.run__id == Run.id)
+        return exc
+
+
+class OptimizationVariableFilter(
+    base.OptimizationVariableFilter, metaclass=filters.FilterMeta
+):
+    def join(self, exc, session=None):
+        return exc

--- a/ixmp4/data/db/optimization/variable/model.py
+++ b/ixmp4/data/db/optimization/variable/model.py
@@ -1,0 +1,38 @@
+import copy
+from typing import Any, ClassVar
+
+from sqlalchemy.orm import validates
+
+from ixmp4 import db
+from ixmp4.data import types
+from ixmp4.data.abstract import optimization as abstract
+
+from .. import Column, base, utils
+
+
+# TODO This looks like the table name is going to be weird
+class OptimizationVariable(base.BaseModel):
+    # NOTE: These might be mixin-able, but would require some abstraction
+    NotFound: ClassVar = abstract.Variable.NotFound
+    NotUnique: ClassVar = abstract.Variable.NotUnique
+    DeletionPrevented: ClassVar = abstract.Variable.DeletionPrevented
+
+    # constrained_to_indexsets: ClassVar[list[str] | None] = None
+
+    run__id: types.RunId
+    columns: types.Mapped[list["Column"]] = db.relationship()
+    data: types.JsonDict = db.Column(db.JsonType, nullable=False, default={})
+
+    @validates("data")
+    def validate_data(self, key, data: dict[str, Any]):
+        data_to_validate = copy.deepcopy(data)
+        del data_to_validate["levels"]
+        del data_to_validate["marginals"]
+        _ = utils.validate_data(
+            key=key,
+            data=data_to_validate,
+            columns=self.columns,
+        )
+        return data
+
+    __table_args__ = (db.UniqueConstraint("name", "run__id"),)

--- a/ixmp4/data/db/optimization/variable/model.py
+++ b/ixmp4/data/db/optimization/variable/model.py
@@ -25,6 +25,8 @@ class OptimizationVariable(base.BaseModel):
 
     @validates("data")
     def validate_data(self, key, data: dict[str, Any]):
+        if data == {}:
+            return data
         data_to_validate = copy.deepcopy(data)
         del data_to_validate["levels"]
         del data_to_validate["marginals"]

--- a/ixmp4/data/db/optimization/variable/model.py
+++ b/ixmp4/data/db/optimization/variable/model.py
@@ -4,6 +4,7 @@ from typing import Any, ClassVar
 from sqlalchemy.orm import validates
 
 from ixmp4 import db
+from ixmp4.core.exceptions import OptimizationDataValidationError
 from ixmp4.data import types
 from ixmp4.data.abstract import optimization as abstract
 
@@ -15,6 +16,7 @@ class OptimizationVariable(base.BaseModel):
     # NOTE: These might be mixin-able, but would require some abstraction
     NotFound: ClassVar = abstract.Variable.NotFound
     NotUnique: ClassVar = abstract.Variable.NotUnique
+    DataInvalid: ClassVar = OptimizationDataValidationError
     DeletionPrevented: ClassVar = abstract.Variable.DeletionPrevented
 
     # constrained_to_indexsets: ClassVar[list[str] | None] = None
@@ -31,7 +33,7 @@ class OptimizationVariable(base.BaseModel):
         del data_to_validate["levels"]
         del data_to_validate["marginals"]
         _ = utils.validate_data(
-            key=key,
+            host=self,
             data=data_to_validate,
             columns=self.columns,
         )

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -1,0 +1,164 @@
+from typing import Any, Iterable
+
+import pandas as pd
+
+from ixmp4 import db
+from ixmp4.data.abstract import optimization as abstract
+from ixmp4.data.auth.decorators import guard
+
+from .. import ColumnRepository, base
+from .docs import OptimizationVariableDocsRepository
+from .model import OptimizationVariable as Variable
+
+
+class VariableRepository(
+    base.Creator[Variable],
+    base.Retriever[Variable],
+    base.Enumerator[Variable],
+    abstract.VariableRepository,
+):
+    model_class = Variable
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.docs = OptimizationVariableDocsRepository(*args, **kwargs)
+        self.columns = ColumnRepository(*args, **kwargs)
+
+        from .filter import OptimizationVariableFilter
+
+        self.filter_class = OptimizationVariableFilter
+
+    def _add_column(
+        self,
+        run_id: int,
+        variable_id: int,
+        column_name: str,
+        indexset_name: str,
+        **kwargs,
+    ) -> None:
+        r"""Adds a Column to a Variable.
+
+        Parameters
+        ----------
+        run_id : int
+            The id of the :class:`ixmp4.data.abstract.Run` for which the
+            :class:`ixmp4.data.abstract.optimization.Variable` is defined.
+        variable_id : int
+            The id of the :class:`ixmp4.data.abstract.optimization.Variable`.
+        column_name : str
+            The name of the Column, which must be unique in connection with the names of
+            :class:`ixmp4.data.abstract.Run` and
+            :class:`ixmp4.data.abstract.optimization.Variable`.
+        indexset_name : str
+            The name of the :class:`ixmp4.data.abstract.optimization.IndexSet` the
+            Column will be linked to.
+        \*\*kwargs: any
+            Keyword arguments to be passed to
+            :func:`ixmp4.data.abstract.optimization.Column.create`.
+        """
+        indexset = self.backend.optimization.indexsets.get(
+            run_id=run_id, name=indexset_name
+        )
+        self.columns.create(
+            name=column_name,
+            constrained_to_indexset=indexset.id,
+            dtype=pd.Series(indexset.elements).dtype.name,
+            variable_id=variable_id,
+            unique=True,
+            **kwargs,
+        )
+
+    def add(
+        self,
+        run_id: int,
+        name: str,
+    ) -> Variable:
+        variable = Variable(name=name, run__id=run_id)
+        variable.set_creation_info(auth_context=self.backend.auth_context)
+        self.session.add(variable)
+
+        return variable
+
+    @guard("view")
+    def get(self, run_id: int, name: str) -> Variable:
+        exc = db.select(Variable).where(
+            (Variable.name == name) & (Variable.run__id == run_id)
+        )
+        try:
+            return self.session.execute(exc).scalar_one()
+        except db.NoResultFound:
+            raise Variable.NotFound
+
+    @guard("view")
+    def get_by_id(self, id: int) -> Variable:
+        obj = self.session.get(self.model_class, id)
+
+        if obj is None:
+            raise Variable.NotFound(id=id)
+
+        return obj
+
+    @guard("edit")
+    def create(
+        self,
+        run_id: int,
+        name: str,
+        constrained_to_indexsets: list[str],
+        column_names: list[str] | None = None,
+        **kwargs,
+    ) -> Variable:
+        # Convert to list to avoid enumerate() splitting strings to letters
+        if isinstance(constrained_to_indexsets, str):
+            constrained_to_indexsets = list(constrained_to_indexsets)
+        if column_names and len(column_names) != len(constrained_to_indexsets):
+            raise ValueError(
+                "`constrained_to_indexsets` and `column_names` not equal in length! "
+                "Please provide the same number of entries for both!"
+            )
+        # TODO: activate something like this if each column must be indexed by a unique
+        # indexset
+        # if len(constrained_to_indexsets) != len(set(constrained_to_indexsets)):
+        #     raise ValueError("Each dimension must be constrained to a unique indexset!") # noqa
+        if column_names and len(column_names) != len(set(column_names)):
+            raise ValueError("The given `column_names` are not unique!")
+
+        variable = super().create(
+            run_id=run_id,
+            name=name,
+            **kwargs,
+        )
+        for i, name in enumerate(constrained_to_indexsets):
+            self._add_column(
+                run_id=run_id,
+                variable_id=variable.id,
+                column_name=column_names[i] if column_names else name,
+                indexset_name=name,
+            )
+
+        return variable
+
+    @guard("view")
+    def list(self, *args, **kwargs) -> Iterable[Variable]:
+        return super().list(*args, **kwargs)
+
+    @guard("view")
+    def tabulate(self, *args, **kwargs) -> pd.DataFrame:
+        return super().tabulate(*args, **kwargs)
+
+    @guard("edit")
+    def add_data(self, variable_id: int, data: dict[str, Any] | pd.DataFrame) -> None:
+        if isinstance(data, dict):
+            data = pd.DataFrame.from_dict(data=data)
+        variable = self.get_by_id(id=variable_id)
+
+        missing_columns = set(["levels", "marginals"]) - set(data.columns)
+        assert (
+            not missing_columns
+        ), f"Variable.data must include the column(s): {', '.join(missing_columns)}!"
+
+        variable.data = pd.concat(
+            [pd.DataFrame.from_dict(variable.data), data]
+        ).to_dict(orient="list")
+
+        self.session.add(variable)
+        self.session.commit()

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -167,8 +167,12 @@ class VariableRepository(
             not missing_columns
         ), f"Variable.data must include the column(s): {', '.join(missing_columns)}!"
 
-        variable.data = pd.concat(
-            [pd.DataFrame.from_dict(variable.data), data]
+        index_list = [column.name for column in variable.columns]
+        existing_data = pd.DataFrame(variable.data)
+        if not existing_data.empty:
+            existing_data.set_index(index_list, inplace=True)
+        variable.data = (
+            data.set_index(index_list).combine_first(existing_data).reset_index()
         ).to_dict(orient="list")
 
         self.session.commit()

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -171,7 +171,6 @@ class VariableRepository(
             [pd.DataFrame.from_dict(variable.data), data]
         ).to_dict(orient="list")
 
-        self.session.add(variable)
         self.session.commit()
 
     @guard("edit")
@@ -179,5 +178,4 @@ class VariableRepository(
         variable = self.get_by_id(id=variable_id)
         # TODO Is there a better way to reset .data?
         variable.data = {}
-        self.session.add(variable)
         self.session.commit()

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -173,3 +173,11 @@ class VariableRepository(
 
         self.session.add(variable)
         self.session.commit()
+
+    @guard("edit")
+    def remove_data(self, variable_id: int) -> None:
+        variable = self.get_by_id(id=variable_id)
+        # TODO Is there a better way to reset .data?
+        variable.data = {}
+        self.session.add(variable)
+        self.session.commit()

--- a/ixmp4/data/db/run/model.py
+++ b/ixmp4/data/db/run/model.py
@@ -7,6 +7,7 @@ from ixmp4.data.db.optimization.indexset import IndexSet
 from ixmp4.data.db.optimization.parameter import Parameter
 from ixmp4.data.db.optimization.scalar import Scalar
 from ixmp4.data.db.optimization.table import Table
+from ixmp4.data.db.optimization.variable import Variable
 from ixmp4.data.db.scenario.model import Scenario
 
 from .. import base, mixins
@@ -45,6 +46,7 @@ class Run(base.BaseModel, mixins.HasUpdateInfo):
     parameters: types.Mapped[list["Parameter"]] = db.relationship()
     scalars: types.Mapped[list["Scalar"]] = db.relationship()
     tables: types.Mapped[list["Table"]] = db.relationship()
+    variables: types.Mapped[list["Variable"]] = db.relationship()
 
     version: types.Integer = db.Column(db.Integer, nullable=False)
     is_default: types.Boolean = db.Column(db.Boolean, default=False, nullable=False)

--- a/ixmp4/data/db/run/model.py
+++ b/ixmp4/data/db/run/model.py
@@ -7,7 +7,7 @@ from ixmp4.data.db.optimization.indexset import IndexSet
 from ixmp4.data.db.optimization.parameter import Parameter
 from ixmp4.data.db.optimization.scalar import Scalar
 from ixmp4.data.db.optimization.table import Table
-from ixmp4.data.db.optimization.variable import Variable
+from ixmp4.data.db.optimization.variable import Variable as OptimizationVariable
 from ixmp4.data.db.scenario.model import Scenario
 
 from .. import base, mixins
@@ -46,7 +46,7 @@ class Run(base.BaseModel, mixins.HasUpdateInfo):
     parameters: types.Mapped[list["Parameter"]] = db.relationship()
     scalars: types.Mapped[list["Scalar"]] = db.relationship()
     tables: types.Mapped[list["Table"]] = db.relationship()
-    variables: types.Mapped[list["Variable"]] = db.relationship()
+    variables: types.Mapped[list["OptimizationVariable"]] = db.relationship()
 
     version: types.Integer = db.Column(db.Integer, nullable=False)
     is_default: types.Boolean = db.Column(db.Boolean, default=False, nullable=False)

--- a/ixmp4/server/rest/__init__.py
+++ b/ixmp4/server/rest/__init__.py
@@ -21,6 +21,7 @@ from .optimization import indexset as optimization_indexset
 from .optimization import parameter as optimization_parameter
 from .optimization import scalar as optimization_scalar
 from .optimization import table as optimization_table
+from .optimization import variable as optimization_variable
 
 v1 = FastAPI(
     servers=[{"url": "/v1", "description": "v1"}],
@@ -54,6 +55,7 @@ v1.include_router(optimization_indexset.router, prefix="/optimization")
 v1.include_router(optimization_parameter.router, prefix="/optimization")
 v1.include_router(optimization_scalar.router, prefix="/optimization")
 v1.include_router(optimization_table.router, prefix="/optimization")
+v1.include_router(optimization_variable.router, prefix="/optimization")
 v1.include_router(region.router)
 v1.include_router(run.router)
 v1.include_router(scenario.router)

--- a/ixmp4/server/rest/docs.py
+++ b/ixmp4/server/rest/docs.py
@@ -261,3 +261,27 @@ def delete_parameters(
     backend: Backend = Depends(deps.get_backend),
 ):
     return backend.optimization.parameters.docs.delete(dimension_id)
+
+
+@router.get("/optimization/variables/", response_model=list[api.Docs])
+def list_optimization_variables(
+    dimension_id: int | None = Query(None),
+    backend: Backend = Depends(deps.get_backend),
+):
+    return backend.optimization.variables.docs.list(dimension_id=dimension_id)
+
+
+@router.post("/optimization/variables/", response_model=api.Docs)
+def set_optimization_variables(
+    docs: DocsInput,
+    backend: Backend = Depends(deps.get_backend),
+):
+    return backend.optimization.variables.docs.set(**docs.model_dump())
+
+
+@router.delete("/optimization/variables/{dimension_id}/")
+def delete_optimization_variables(
+    dimension_id: int = Path(),
+    backend: Backend = Depends(deps.get_backend),
+):
+    return backend.optimization.variables.docs.delete(dimension_id)

--- a/ixmp4/server/rest/optimization/__init__.py
+++ b/ixmp4/server/rest/optimization/__init__.py
@@ -1,1 +1,1 @@
-from . import indexset, parameter, scalar, table
+from . import indexset, parameter, scalar, table, variable

--- a/ixmp4/server/rest/optimization/variable.py
+++ b/ixmp4/server/rest/optimization/variable.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, Query
+
+from ixmp4.data import api
+from ixmp4.data.backend.db import SqlAlchemyBackend as Backend
+from ixmp4.data.db.optimization.variable.filter import OptimizationVariableFilter
+
+from .. import deps
+from ..base import BaseModel, EnumerationOutput, Pagination
+from ..decorators import autodoc
+
+router: APIRouter = APIRouter(
+    prefix="/variables",
+    tags=["optimization", "variables"],
+)
+
+
+class VariableCreateInput(BaseModel):
+    run_id: int
+    name: str
+    constrained_to_indexsets: list[str]
+    column_names: list[str] | None
+
+
+class DataInput(BaseModel):
+    data: dict[str, Any]
+
+
+@autodoc
+@router.get("/{id}/", response_model=api.OptimizationVariable)
+def get_by_id(
+    id: int,
+    backend: Backend = Depends(deps.get_backend),
+):
+    return backend.optimization.variables.get_by_id(id)
+
+
+@autodoc
+@router.patch("/", response_model=EnumerationOutput[api.OptimizationVariable])
+def query(
+    filter: OptimizationVariableFilter = Body(
+        OptimizationVariableFilter(id=None, name=None)
+    ),
+    table: bool = Query(False),
+    pagination: Pagination = Depends(),
+    backend: Backend = Depends(deps.get_backend),
+):
+    return EnumerationOutput(
+        results=backend.optimization.variables.paginate(
+            _filter=filter,
+            limit=pagination.limit,
+            offset=pagination.offset,
+            table=bool(table),
+        ),
+        total=backend.optimization.variables.count(_filter=filter),
+        pagination=pagination,
+    )
+
+
+@autodoc
+@router.patch("/{variable_id}/data/")
+def add_data(
+    variable_id: int,
+    data: DataInput,
+    backend: Backend = Depends(deps.get_backend),
+):
+    return backend.optimization.variables.add_data(
+        variable_id=variable_id, **data.model_dump()
+    )
+
+
+@autodoc
+@router.post("/", response_model=api.OptimizationVariable)
+def create(
+    variable: VariableCreateInput,
+    backend: Backend = Depends(deps.get_backend),
+):
+    return backend.optimization.variables.create(**variable.model_dump())

--- a/ixmp4/server/rest/optimization/variable.py
+++ b/ixmp4/server/rest/optimization/variable.py
@@ -71,6 +71,15 @@ def add_data(
 
 
 @autodoc
+@router.delete("/{variable_id}/data/")
+def remove_data(
+    variable_id: int,
+    backend: Backend = Depends(deps.get_backend),
+):
+    backend.optimization.variables.remove_data(variable_id=variable_id)
+
+
+@autodoc
 @router.post("/", response_model=api.OptimizationVariable)
 def create(
     variable: VariableCreateInput,

--- a/ixmp4/server/rest/optimization/variable.py
+++ b/ixmp4/server/rest/optimization/variable.py
@@ -19,7 +19,7 @@ router: APIRouter = APIRouter(
 class VariableCreateInput(BaseModel):
     run_id: int
     name: str
-    constrained_to_indexsets: list[str]
+    constrained_to_indexsets: str | list[str] | None
     column_names: list[str] | None
 
 

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -249,6 +249,25 @@ class TestCoreVariable:
         assert variable_3.levels == test_data_5["levels"]
         assert variable_3.marginals == test_data_5["marginals"]
 
+    def test_variable_remove_data(self, platform: ixmp4.Platform):
+        run = platform.runs.create("Model", "Scenario")
+        indexset = run.optimization.indexsets.create("Indexset")
+        indexset.add(elements=["foo", "bar"])
+        test_data = {
+            "Indexset": ["bar", "foo"],
+            "levels": [2.0, 1],
+            "marginals": [0, "test"],
+        }
+        variable = run.optimization.variables.create(
+            "Variable",
+            constrained_to_indexsets=[indexset.name],
+        )
+        variable.add(test_data)
+        assert variable.data == test_data
+
+        variable.remove_data()
+        assert variable.data == {}
+
     def test_list_variable(self, platform: ixmp4.Platform):
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = create_indexsets_for_run(

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -250,8 +250,6 @@ class TestCoreVariable:
     def test_list_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        # Per default, list() lists scalars for `default` version runs:
-        run.set_as_default()
         _ = run.optimization.indexsets.create("Indexset")
         _ = run.optimization.indexsets.create("Indexset 2")
         variable = run.optimization.variables.create(
@@ -271,11 +269,22 @@ class TestCoreVariable:
         ]
         assert not (set(expected_id) ^ set(list_id))
 
+        # Test listing Variables for specific Run
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        indexset = run_2.optimization.indexsets.create("Indexset")
+        variable_3 = run_2.optimization.variables.create(
+            "Variable", constrained_to_indexsets=[indexset.name]
+        )
+        variable_4 = run_2.optimization.variables.create(
+            "Variable 2", constrained_to_indexsets=[indexset.name]
+        )
+        expected_ids = [variable_3.id, variable_4.id]
+        list_ids = [variable.id for variable in run_2.optimization.variables.list()]
+        assert not (set(expected_ids) ^ set(list_ids))
+
     def test_tabulate_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        # Per default, tabulate() lists scalars for `default` version runs:
-        run.set_as_default()
         indexset = run.optimization.indexsets.create("Indexset")
         indexset_2 = run.optimization.indexsets.create("Indexset 2")
         variable = run.optimization.variables.create(
@@ -311,6 +320,20 @@ class TestCoreVariable:
         pd.testing.assert_frame_equal(
             df_from_list([variable, variable_2]),
             run.optimization.variables.tabulate(),
+        )
+
+        # Test tabulation of Variables for specific Run
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        indexset = run_2.optimization.indexsets.create("Indexset")
+        variable_3 = run_2.optimization.variables.create(
+            "Variable", constrained_to_indexsets=[indexset.name]
+        )
+        variable_4 = run_2.optimization.variables.create(
+            "Variable 2", constrained_to_indexsets=[indexset.name]
+        )
+        pd.testing.assert_frame_equal(
+            df_from_list([variable_3, variable_4]),
+            run_2.optimization.variables.tabulate(),
         )
 
     def test_variable_docs(self, test_mp, request):

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -263,6 +263,14 @@ class TestCoreVariable:
         variable_2 = run.optimization.variables.create(
             "Variable 2", constrained_to_indexsets=[indexset_2.name]
         )
+        # Create new run to test listing variables for specific run
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, amount=1
+        )
+        run_2.optimization.variables.create(
+            "Variable", constrained_to_indexsets=[indexset.name]
+        )
         expected_ids = [variable.id, variable_2.id]
         list_ids = [variable.id for variable in run.optimization.variables.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -273,21 +281,6 @@ class TestCoreVariable:
             variable.id for variable in run.optimization.variables.list(name="Variable")
         ]
         assert not (set(expected_id) ^ set(list_id))
-
-        # Test listing Variables for specific Run
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        (indexset,) = create_indexsets_for_run(
-            platform=test_mp, run_id=run_2.id, amount=1
-        )
-        variable_3 = run_2.optimization.variables.create(
-            "Variable", constrained_to_indexsets=[indexset.name]
-        )
-        variable_4 = run_2.optimization.variables.create(
-            "Variable 2", constrained_to_indexsets=[indexset.name]
-        )
-        expected_ids = [variable_3.id, variable_4.id]
-        list_ids = [variable.id for variable in run_2.optimization.variables.list()]
-        assert not (set(expected_ids) ^ set(list_ids))
 
     def test_tabulate_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
@@ -303,6 +296,14 @@ class TestCoreVariable:
         variable_2 = run.optimization.variables.create(
             name="Variable 2",
             constrained_to_indexsets=[indexset.name, indexset_2.name],
+        )
+        # Create new run to test tabulating variables for specific run
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        (indexset_3,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, amount=1
+        )
+        run_2.optimization.variables.create(
+            "Variable", constrained_to_indexsets=[indexset_3.name]
         )
         pd.testing.assert_frame_equal(
             df_from_list([variable_2]),
@@ -329,22 +330,6 @@ class TestCoreVariable:
         pd.testing.assert_frame_equal(
             df_from_list([variable, variable_2]),
             run.optimization.variables.tabulate(),
-        )
-
-        # Test tabulation of Variables for specific Run
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        (indexset,) = create_indexsets_for_run(
-            platform=test_mp, run_id=run_2.id, amount=1
-        )
-        variable_3 = run_2.optimization.variables.create(
-            "Variable", constrained_to_indexsets=[indexset.name]
-        )
-        variable_4 = run_2.optimization.variables.create(
-            "Variable 2", constrained_to_indexsets=[indexset.name]
-        )
-        pd.testing.assert_frame_equal(
-            df_from_list([variable_3, variable_4]),
-            run_2.optimization.variables.tabulate(),
         )
 
     def test_variable_docs(self, test_mp, request):

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -32,7 +32,7 @@ def df_from_list(variables: list):
 
 
 @all_platforms
-class TestDataOptimizationVariable:
+class TestCoreVariable:
     def test_create_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -2,9 +2,9 @@ import pandas as pd
 import pytest
 
 from ixmp4 import Platform
-from ixmp4.core import OptimizationVariable
+from ixmp4.core import IndexSet, OptimizationVariable
 
-from ..utils import all_platforms
+from ..utils import all_platforms, create_indexsets_for_run
 
 
 def df_from_list(variables: list):
@@ -48,38 +48,41 @@ class TestCoreVariable:
         assert variable.marginals == []
 
         # Test creation with indexset
-        indexset_1 = run.optimization.indexsets.create("Indexset")
+        indexset, indexset_2 = tuple(
+            IndexSet(_backend=test_mp.backend, _model=model)
+            for model in create_indexsets_for_run(platform=test_mp, run_id=run.id)
+        )
         variable_2 = run.optimization.variables.create(
             name="Variable 2",
-            constrained_to_indexsets=["Indexset"],
+            constrained_to_indexsets=[indexset.name],
         )
 
         assert variable_2.run_id == run.id
         assert variable_2.name == "Variable 2"
         assert variable_2.data == {}  # JsonDict type currently requires dict, not None
-        assert variable_2.columns[0].name == "Indexset"
-        assert variable_2.constrained_to_indexsets == [indexset_1.name]
+        assert variable_2.columns[0].name == indexset.name
+        assert variable_2.constrained_to_indexsets == [indexset.name]
         assert variable_2.levels == []
         assert variable_2.marginals == []
 
         # Test duplicate name raises
         with pytest.raises(OptimizationVariable.NotUnique):
             _ = run.optimization.variables.create(
-                "Variable", constrained_to_indexsets=["Indexset"]
+                "Variable", constrained_to_indexsets=[indexset.name]
             )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
         with pytest.raises(ValueError, match="not equal in length"):
             _ = run.optimization.variables.create(
                 "Variable 0",
-                constrained_to_indexsets=["Indexset"],
+                constrained_to_indexsets=[indexset.name],
                 column_names=["Dimension 1", "Dimension 2"],
             )
 
         # Test columns_names are used for names if given
         variable_3 = run.optimization.variables.create(
             "Variable 3",
-            constrained_to_indexsets=[indexset_1.name],
+            constrained_to_indexsets=[indexset.name],
             column_names=["Column 1"],
         )
         assert variable_3.columns[0].name == "Column 1"
@@ -88,16 +91,15 @@ class TestCoreVariable:
         with pytest.raises(ValueError, match="`column_names` are not unique"):
             _ = run.optimization.variables.create(
                 name="Variable 0",
-                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                constrained_to_indexsets=[indexset.name, indexset.name],
                 column_names=["Column 1", "Column 1"],
             )
 
         # Test column.dtype is registered correctly
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
         indexset_2.add(elements=2024)
         variable_4 = run.optimization.variables.create(
             "Variable 4",
-            constrained_to_indexsets=["Indexset", indexset_2.name],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         # If indexset doesn't have elements, a generic dtype is registered
         assert variable_4.columns[0].dtype == "object"
@@ -106,9 +108,11 @@ class TestCoreVariable:
     def test_get_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id, amount=1
+        )
         _ = run.optimization.variables.create(
-            name="Variable", constrained_to_indexsets=["Indexset"]
+            name="Variable", constrained_to_indexsets=[indexset.name]
         )
         variable = run.optimization.variables.get(name="Variable")
         assert variable.run_id == run.id
@@ -126,9 +130,11 @@ class TestCoreVariable:
     def test_variable_add_data(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset_1 = run.optimization.indexsets.create("Indexset")
-        indexset_1.add(elements=["foo", "bar", ""])
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        indexset, indexset_2 = tuple(
+            IndexSet(_backend=test_mp.backend, _model=model)
+            for model in create_indexsets_for_run(platform=test_mp, run_id=run.id)
+        )
+        indexset.add(elements=["foo", "bar", ""])
         indexset_2.add(elements=[1, 2, 3])
         # pandas can only convert dicts to dataframes if the values are lists
         # or if index is given. But maybe using read_json instead of from_dict
@@ -136,14 +142,14 @@ class TestCoreVariable:
         # "ValueError: If using all scalar values, you must pass an index" and
         # reraise a custom informative error?
         test_data_1 = {
-            "Indexset": ["foo"],
-            "Indexset 2": [1],
+            indexset.name: ["foo"],
+            indexset_2.name: [1],
             "levels": [3.14],
             "marginals": [0.000314],
         }
         variable = run.optimization.variables.create(
             "Variable",
-            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         variable.add(data=test_data_1)
         assert variable.data == test_data_1
@@ -152,7 +158,7 @@ class TestCoreVariable:
 
         variable_2 = run.optimization.variables.create(
             name="Variable 2",
-            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
 
         with pytest.raises(
@@ -161,8 +167,8 @@ class TestCoreVariable:
             variable_2.add(
                 pd.DataFrame(
                     {
-                        "Indexset": [None],
-                        "Indexset 2": [2],
+                        indexset.name: [None],
+                        indexset_2.name: [2],
                         "levels": [1],
                     }
                 ),
@@ -174,8 +180,8 @@ class TestCoreVariable:
             variable_2.add(
                 data=pd.DataFrame(
                     {
-                        "Indexset": [None],
-                        "Indexset 2": [2],
+                        indexset.name: [None],
+                        indexset_2.name: [2],
                         "marginals": [0],
                     }
                 ),
@@ -186,8 +192,8 @@ class TestCoreVariable:
         with pytest.raises(ValueError, match="All arrays must be of the same length"):
             variable_2.add(
                 data={
-                    "Indexset": ["foo", "foo"],
-                    "Indexset 2": [2, 2],
+                    indexset.name: ["foo", "foo"],
+                    indexset_2.name: [2, 2],
                     "levels": [1, 2],
                     "marginals": [3],
                 },
@@ -196,8 +202,8 @@ class TestCoreVariable:
         with pytest.raises(ValueError, match="contains duplicate rows"):
             variable_2.add(
                 data={
-                    "Indexset": ["foo", "foo"],
-                    "Indexset 2": [2, 2],
+                    indexset.name: ["foo", "foo"],
+                    indexset_2.name: [2, 2],
                     "levels": [1, 2],
                     "marginals": [3.4, 5.6],
                 },
@@ -205,8 +211,8 @@ class TestCoreVariable:
 
         # Test that order is conserved
         test_data_2 = {
-            "Indexset": ["", "", "foo", "foo", "bar", "bar"],
-            "Indexset 2": [3, 1, 2, 1, 2, 3],
+            indexset.name: ["", "", "foo", "foo", "bar", "bar"],
+            indexset_2.name: [3, 1, 2, 1, 2, 3],
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [1, 3, 5, 6, 4, 2],
         }
@@ -218,7 +224,7 @@ class TestCoreVariable:
         # Test order is conserved with varying types and upon later addition of data
         variable_3 = run.optimization.variables.create(
             name="Variable 3",
-            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
             column_names=["Column 1", "Column 2"],
         )
 
@@ -250,13 +256,12 @@ class TestCoreVariable:
     def test_list_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        _ = run.optimization.indexsets.create("Indexset")
-        _ = run.optimization.indexsets.create("Indexset 2")
+        indexset, indexset_2 = create_indexsets_for_run(platform=test_mp, run_id=run.id)
         variable = run.optimization.variables.create(
-            "Variable", constrained_to_indexsets=["Indexset"]
+            "Variable", constrained_to_indexsets=[indexset.name]
         )
         variable_2 = run.optimization.variables.create(
-            "Variable 2", constrained_to_indexsets=["Indexset 2"]
+            "Variable 2", constrained_to_indexsets=[indexset_2.name]
         )
         expected_ids = [variable.id, variable_2.id]
         list_ids = [variable.id for variable in run.optimization.variables.list()]
@@ -271,7 +276,9 @@ class TestCoreVariable:
 
         # Test listing Variables for specific Run
         run_2 = test_mp.runs.create("Model", "Scenario")
-        indexset = run_2.optimization.indexsets.create("Indexset")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, amount=1
+        )
         variable_3 = run_2.optimization.variables.create(
             "Variable", constrained_to_indexsets=[indexset.name]
         )
@@ -285,15 +292,17 @@ class TestCoreVariable:
     def test_tabulate_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        indexset, indexset_2 = tuple(
+            IndexSet(_backend=test_mp.backend, _model=model)
+            for model in create_indexsets_for_run(platform=test_mp, run_id=run.id)
+        )
         variable = run.optimization.variables.create(
             name="Variable",
-            constrained_to_indexsets=["Indexset", "Indexset 2"],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         variable_2 = run.optimization.variables.create(
             name="Variable 2",
-            constrained_to_indexsets=["Indexset", "Indexset 2"],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         pd.testing.assert_frame_equal(
             df_from_list([variable_2]),
@@ -303,16 +312,16 @@ class TestCoreVariable:
         indexset.add(elements=["foo", "bar"])
         indexset_2.add(elements=[1, 2, 3])
         test_data_1 = {
-            "Indexset": ["foo"],
-            "Indexset 2": [1],
+            indexset.name: ["foo"],
+            indexset_2.name: [1],
             "levels": [314],
             "marginals": [2.0],
         }
         variable.add(data=test_data_1)
 
         test_data_2 = {
-            "Indexset 2": [2, 3],
-            "Indexset": ["foo", "bar"],
+            indexset_2.name: [2, 3],
+            indexset.name: ["foo", "bar"],
             "levels": [1, -2.0],
             "marginals": [0, 10],
         }
@@ -324,7 +333,9 @@ class TestCoreVariable:
 
         # Test tabulation of Variables for specific Run
         run_2 = test_mp.runs.create("Model", "Scenario")
-        indexset = run_2.optimization.indexsets.create("Indexset")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, amount=1
+        )
         variable_3 = run_2.optimization.variables.create(
             "Variable", constrained_to_indexsets=[indexset.name]
         )
@@ -339,7 +350,9 @@ class TestCoreVariable:
     def test_variable_docs(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id, amount=1
+        )
         variable_1 = run.optimization.variables.create(
             "Variable 1", constrained_to_indexsets=[indexset.name]
         )

--- a/tests/core/test_optimizationvariable.py
+++ b/tests/core/test_optimizationvariable.py
@@ -1,0 +1,318 @@
+import pandas as pd
+import pytest
+
+from ixmp4 import Platform
+from ixmp4.core import OptimizationVariable
+
+from ..utils import all_platforms
+
+
+def df_from_list(variables: list):
+    return pd.DataFrame(
+        [
+            [
+                variable.run_id,
+                variable.data,
+                variable.name,
+                variable.id,
+                variable.created_at,
+                variable.created_by,
+            ]
+            for variable in variables
+        ],
+        columns=[
+            "run__id",
+            "data",
+            "name",
+            "id",
+            "created_at",
+            "created_by",
+        ],
+    )
+
+
+@all_platforms
+class TestDataOptimizationVariable:
+    def test_create_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.runs.create("Model", "Scenario")
+
+        # Test normal creation
+        indexset_1 = run.optimization.indexsets.create("Indexset")
+        variable = run.optimization.variables.create(
+            name="Variable",
+            constrained_to_indexsets=["Indexset"],
+        )
+
+        assert variable.run_id == run.id
+        assert variable.name == "Variable"
+        assert variable.data == {}  # JsonDict type currently requires a dict, not None
+        assert variable.columns[0].name == "Indexset"
+        assert variable.constrained_to_indexsets == [indexset_1.name]
+        assert variable.levels == []
+        assert variable.marginals == []
+
+        # Test duplicate name raises
+        with pytest.raises(OptimizationVariable.NotUnique):
+            _ = run.optimization.variables.create(
+                "Variable", constrained_to_indexsets=["Indexset"]
+            )
+
+        # Test mismatch in constrained_to_indexsets and column_names raises
+        with pytest.raises(ValueError, match="not equal in length"):
+            _ = run.optimization.variables.create(
+                "Variable 2",
+                constrained_to_indexsets=["Indexset"],
+                column_names=["Dimension 1", "Dimension 2"],
+            )
+
+        # Test columns_names are used for names if given
+        variable_2 = run.optimization.variables.create(
+            "Variable 2",
+            constrained_to_indexsets=[indexset_1.name],
+            column_names=["Column 1"],
+        )
+        assert variable_2.columns[0].name == "Column 1"
+
+        # Test duplicate column_names raise
+        with pytest.raises(ValueError, match="`column_names` are not unique"):
+            _ = run.optimization.variables.create(
+                name="Variable 3",
+                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                column_names=["Column 1", "Column 1"],
+            )
+
+        # Test column.dtype is registered correctly
+        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        indexset_2.add(elements=2024)
+        variable_3 = run.optimization.variables.create(
+            "Variable 5",
+            constrained_to_indexsets=["Indexset", indexset_2.name],
+        )
+        # If indexset doesn't have elements, a generic dtype is registered
+        assert variable_3.columns[0].dtype == "object"
+        assert variable_3.columns[1].dtype == "int64"
+
+    def test_get_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.runs.create("Model", "Scenario")
+        indexset = run.optimization.indexsets.create("Indexset")
+        _ = run.optimization.variables.create(
+            name="Variable", constrained_to_indexsets=["Indexset"]
+        )
+        variable = run.optimization.variables.get(name="Variable")
+        assert variable.run_id == run.id
+        assert variable.id == 1
+        assert variable.name == "Variable"
+        assert variable.data == {}
+        assert variable.levels == []
+        assert variable.marginals == []
+        assert variable.columns[0].name == indexset.name
+        assert variable.constrained_to_indexsets == [indexset.name]
+
+        with pytest.raises(OptimizationVariable.NotFound):
+            _ = run.optimization.variables.get("Variable 2")
+
+    def test_variable_add_data(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.runs.create("Model", "Scenario")
+        indexset_1 = run.optimization.indexsets.create("Indexset")
+        indexset_1.add(elements=["foo", "bar", ""])
+        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        indexset_2.add(elements=[1, 2, 3])
+        # pandas can only convert dicts to dataframes if the values are lists
+        # or if index is given. But maybe using read_json instead of from_dict
+        # can remedy this. Or maybe we want to catch the resulting
+        # "ValueError: If using all scalar values, you must pass an index" and
+        # reraise a custom informative error?
+        test_data_1 = {
+            "Indexset": ["foo"],
+            "Indexset 2": [1],
+            "levels": [3.14],
+            "marginals": [0.000314],
+        }
+        variable = run.optimization.variables.create(
+            "Variable",
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+        )
+        variable.add(data=test_data_1)
+        assert variable.data == test_data_1
+        assert variable.levels == test_data_1["levels"]
+        assert variable.marginals == test_data_1["marginals"]
+
+        variable_2 = run.optimization.variables.create(
+            name="Variable 2",
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+        )
+
+        with pytest.raises(
+            AssertionError, match=r"must include the column\(s\): marginals!"
+        ):
+            variable_2.add(
+                pd.DataFrame(
+                    {
+                        "Indexset": [None],
+                        "Indexset 2": [2],
+                        "levels": [1],
+                    }
+                ),
+            )
+
+        with pytest.raises(
+            AssertionError, match=r"must include the column\(s\): levels!"
+        ):
+            variable_2.add(
+                data=pd.DataFrame(
+                    {
+                        "Indexset": [None],
+                        "Indexset 2": [2],
+                        "marginals": [0],
+                    }
+                ),
+            )
+
+        # By converting data to pd.DataFrame, we automatically enforce equal length
+        # of new columns, raises All arrays must be of the same length otherwise:
+        with pytest.raises(ValueError, match="All arrays must be of the same length"):
+            variable_2.add(
+                data={
+                    "Indexset": ["foo", "foo"],
+                    "Indexset 2": [2, 2],
+                    "levels": [1, 2],
+                    "marginals": [3],
+                },
+            )
+
+        with pytest.raises(ValueError, match="contains duplicate rows"):
+            variable_2.add(
+                data={
+                    "Indexset": ["foo", "foo"],
+                    "Indexset 2": [2, 2],
+                    "levels": [1, 2],
+                    "marginals": [3.4, 5.6],
+                },
+            )
+
+        # Test that order is conserved
+        test_data_2 = {
+            "Indexset": ["", "", "foo", "foo", "bar", "bar"],
+            "Indexset 2": [3, 1, 2, 1, 2, 3],
+            "levels": [6, 5, 4, 3, 2, 1],
+            "marginals": [1, 3, 5, 6, 4, 2],
+        }
+        variable_2.add(test_data_2)
+        assert variable_2.data == test_data_2
+        assert variable_2.levels == test_data_2["levels"]
+        assert variable_2.marginals == test_data_2["marginals"]
+
+        # Test order is conserved with varying types and upon later addition of data
+        variable_3 = run.optimization.variables.create(
+            name="Variable 3",
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+
+        test_data_3 = {
+            "Column 1": ["bar", "foo", ""],
+            "Column 2": [2, 3, 1],
+            "levels": [3, 2.0, 1],
+            "marginals": [100000, 1, 0.00001],
+        }
+        variable_3.add(data=test_data_3)
+        assert variable_3.data == test_data_3
+        assert variable_3.levels == test_data_3["levels"]
+        assert variable_3.marginals == test_data_3["marginals"]
+
+        test_data_4 = {
+            "Column 1": ["foo", "", "bar"],
+            "Column 2": [2, 3, 1],
+            "levels": [3.14, 2, 1.0],
+            "marginals": [1, 0.00001, 100000],
+        }
+        variable_3.add(data=test_data_4)
+        test_data_5 = test_data_3.copy()
+        for key, value in test_data_4.items():
+            test_data_5[key].extend(value)
+        assert variable_3.data == test_data_5
+        assert variable_3.levels == test_data_5["levels"]
+        assert variable_3.marginals == test_data_5["marginals"]
+
+    def test_list_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.runs.create("Model", "Scenario")
+        # Per default, list() lists scalars for `default` version runs:
+        run.set_as_default()
+        _ = run.optimization.indexsets.create("Indexset")
+        _ = run.optimization.indexsets.create("Indexset 2")
+        variable = run.optimization.variables.create(
+            "Variable", constrained_to_indexsets=["Indexset"]
+        )
+        variable_2 = run.optimization.variables.create(
+            "Variable 2", constrained_to_indexsets=["Indexset 2"]
+        )
+        expected_ids = [variable.id, variable_2.id]
+        list_ids = [variable.id for variable in run.optimization.variables.list()]
+        assert not (set(expected_ids) ^ set(list_ids))
+
+        # Test retrieving just one result by providing a name
+        expected_id = [variable.id]
+        list_id = [
+            variable.id for variable in run.optimization.variables.list(name="Variable")
+        ]
+        assert not (set(expected_id) ^ set(list_id))
+
+    def test_tabulate_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.runs.create("Model", "Scenario")
+        # Per default, tabulate() lists scalars for `default` version runs:
+        run.set_as_default()
+        indexset = run.optimization.indexsets.create("Indexset")
+        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        variable = run.optimization.variables.create(
+            name="Variable",
+            constrained_to_indexsets=["Indexset", "Indexset 2"],
+        )
+        variable_2 = run.optimization.variables.create(
+            name="Variable 2",
+            constrained_to_indexsets=["Indexset", "Indexset 2"],
+        )
+        pd.testing.assert_frame_equal(
+            df_from_list([variable_2]),
+            run.optimization.variables.tabulate(name="Variable 2"),
+        )
+
+        indexset.add(elements=["foo", "bar"])
+        indexset_2.add(elements=[1, 2, 3])
+        test_data_1 = {
+            "Indexset": ["foo"],
+            "Indexset 2": [1],
+            "levels": [314],
+            "marginals": [2.0],
+        }
+        variable.add(data=test_data_1)
+
+        test_data_2 = {
+            "Indexset 2": [2, 3],
+            "Indexset": ["foo", "bar"],
+            "levels": [1, -2.0],
+            "marginals": [0, 10],
+        }
+        variable_2.add(data=test_data_2)
+        pd.testing.assert_frame_equal(
+            df_from_list([variable, variable_2]),
+            run.optimization.variables.tabulate(),
+        )
+
+    def test_variable_docs(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.runs.create("Model", "Scenario")
+        indexset = run.optimization.indexsets.create("Indexset")
+        variable_1 = run.optimization.variables.create(
+            "Variable 1", constrained_to_indexsets=[indexset.name]
+        )
+        docs = "Documentation of Variable 1"
+        variable_1.docs = docs
+        assert variable_1.docs == docs
+
+        variable_1.docs = None
+        assert variable_1.docs is None

--- a/tests/data/test_docs.py
+++ b/tests/data/test_docs.py
@@ -434,3 +434,70 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.parameters.docs.get(parameter.id)
+
+    def test_get_and_set_optimizationvariabledocs(self, platform: ixmp4.Platform):
+        run = platform.backend.runs.create("Model", "Scenario")
+        _ = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        variable = platform.backend.optimization.variables.create(
+            run_id=run.id, name="Variable", constrained_to_indexsets=["Indexset"]
+        )
+        docs_variable = platform.backend.optimization.variables.docs.set(
+            variable.id, "Description of test Variable"
+        )
+        docs_variable1 = platform.backend.optimization.variables.docs.get(variable.id)
+
+        assert docs_variable == docs_variable1
+
+    def test_change_empty_optimizationvariabledocs(self, platform: ixmp4.Platform):
+        run = platform.backend.runs.create("Model", "Scenario")
+        _ = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        variable = platform.backend.optimization.variables.create(
+            run_id=run.id, name="Variable", constrained_to_indexsets=["Indexset"]
+        )
+
+        with pytest.raises(Docs.NotFound):
+            platform.backend.optimization.variables.docs.get(variable.id)
+
+        docs_variable1 = platform.backend.optimization.variables.docs.set(
+            variable.id, "Description of test Variable"
+        )
+
+        assert (
+            platform.backend.optimization.variables.docs.get(variable.id)
+            == docs_variable1
+        )
+
+        docs_variable2 = platform.backend.optimization.variables.docs.set(
+            variable.id, "Different description of test Variable"
+        )
+
+        assert (
+            platform.backend.optimization.variables.docs.get(variable.id)
+            == docs_variable2
+        )
+
+    def test_delete_optimizationvariabledocs(self, platform: ixmp4.Platform):
+        run = platform.backend.runs.create("Model", "Scenario")
+        _ = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        variable = platform.backend.optimization.variables.create(
+            run_id=run.id, name="Variable", constrained_to_indexsets=["Indexset"]
+        )
+        docs_variable = platform.backend.optimization.variables.docs.set(
+            variable.id, "Description of test Variable"
+        )
+
+        assert (
+            platform.backend.optimization.variables.docs.get(variable.id)
+            == docs_variable
+        )
+
+        platform.backend.optimization.variables.docs.delete(variable.id)
+
+        with pytest.raises(Docs.NotFound):
+            platform.backend.optimization.variables.docs.get(variable.id)

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -2,6 +2,10 @@ import pandas as pd
 import pytest
 
 import ixmp4
+from ixmp4.core.exceptions import (
+    OptimizationDataValidationError,
+    OptimizationItemUsageError,
+)
 from ixmp4.data.abstract import OptimizationVariable
 
 from ..utils import assert_unordered_equality, create_indexsets_for_run
@@ -69,7 +73,7 @@ class TestDataOptimizationVariable:
 
         # Test that giving column_names, but not constrained_to_indexsets raises
         with pytest.raises(
-            ValueError,
+            OptimizationItemUsageError,
             match="Received `column_names` to name columns, but no "
             "`constrained_to_indexsets`",
         ):
@@ -80,7 +84,7 @@ class TestDataOptimizationVariable:
             )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
-        with pytest.raises(ValueError, match="not equal in length"):
+        with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
             _ = platform.backend.optimization.variables.create(
                 run_id=run.id,
                 name="Variable 0",
@@ -99,7 +103,9 @@ class TestDataOptimizationVariable:
         assert variable_3.columns[0].name == "Column 1"
 
         # Test duplicate column_names raise
-        with pytest.raises(ValueError, match="`column_names` are not unique"):
+        with pytest.raises(
+            OptimizationItemUsageError, match="`column_names` are not unique"
+        ):
             _ = platform.backend.optimization.variables.create(
                 run_id=run.id,
                 name="Variable 0",
@@ -184,7 +190,7 @@ class TestDataOptimizationVariable:
         )
 
         with pytest.raises(
-            AssertionError, match=r"must include the column\(s\): levels!"
+            OptimizationItemUsageError, match=r"must include the column\(s\): levels!"
         ):
             platform.backend.optimization.variables.add_data(
                 variable_id=variable_2.id,
@@ -198,7 +204,8 @@ class TestDataOptimizationVariable:
             )
 
         with pytest.raises(
-            AssertionError, match=r"must include the column\(s\): marginals!"
+            OptimizationItemUsageError,
+            match=r"must include the column\(s\): marginals!",
         ):
             platform.backend.optimization.variables.add_data(
                 variable_id=variable_2.id,
@@ -213,7 +220,10 @@ class TestDataOptimizationVariable:
 
         # By converting data to pd.DataFrame, we automatically enforce equal length
         # of new columns, raises All arrays must be of the same length otherwise:
-        with pytest.raises(ValueError, match="All arrays must be of the same length"):
+        with pytest.raises(
+            OptimizationDataValidationError,
+            match="All arrays must be of the same length",
+        ):
             platform.backend.optimization.variables.add_data(
                 variable_id=variable_2.id,
                 data={
@@ -224,7 +234,9 @@ class TestDataOptimizationVariable:
                 },
             )
 
-        with pytest.raises(ValueError, match="contains duplicate rows"):
+        with pytest.raises(
+            OptimizationDataValidationError, match="contains duplicate rows"
+        ):
             platform.backend.optimization.variables.add_data(
                 variable_id=variable_2.id,
                 data={

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -1,0 +1,362 @@
+import pandas as pd
+import pytest
+
+from ixmp4 import Platform
+from ixmp4.core import OptimizationVariable
+
+from ..utils import all_platforms
+
+
+def df_from_list(variables: list):
+    return pd.DataFrame(
+        [
+            [
+                variable.run__id,
+                variable.data,
+                variable.name,
+                variable.id,
+                variable.created_at,
+                variable.created_by,
+            ]
+            for variable in variables
+        ],
+        columns=[
+            "run__id",
+            "data",
+            "name",
+            "id",
+            "created_at",
+            "created_by",
+        ],
+    )
+
+
+@all_platforms
+class TestDataOptimizationVariable:
+    def test_create_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.backend.runs.create("Model", "Scenario")
+
+        # Test normal creation
+        indexset_1 = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        variable = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable",
+            constrained_to_indexsets=["Indexset"],
+        )
+
+        assert variable.run__id == run.id
+        assert variable.name == "Variable"
+        assert variable.data == {}  # JsonDict type currently requires a dict, not None
+        assert variable.columns[0].name == "Indexset"
+        assert variable.columns[0].constrained_to_indexset == indexset_1.id
+
+        # Test duplicate name raises
+        with pytest.raises(OptimizationVariable.NotUnique):
+            _ = test_mp.backend.optimization.variables.create(
+                run_id=run.id, name="Variable", constrained_to_indexsets=["Indexset"]
+            )
+
+        # Test mismatch in constrained_to_indexsets and column_names raises
+        with pytest.raises(ValueError, match="not equal in length"):
+            _ = test_mp.backend.optimization.variables.create(
+                run_id=run.id,
+                name="Variable 2",
+                constrained_to_indexsets=["Indexset"],
+                column_names=["Dimension 1", "Dimension 2"],
+            )
+
+        # Test columns_names are used for names if given
+        variable_2 = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable 2",
+            constrained_to_indexsets=[indexset_1.name],
+            column_names=["Column 1"],
+        )
+        assert variable_2.columns[0].name == "Column 1"
+
+        # Test duplicate column_names raise
+        with pytest.raises(ValueError, match="`column_names` are not unique"):
+            _ = test_mp.backend.optimization.variables.create(
+                run_id=run.id,
+                name="Variable 3",
+                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                column_names=["Column 1", "Column 1"],
+            )
+
+        # Test column.dtype is registered correctly
+        indexset_2 = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset 2"
+        )
+        test_mp.backend.optimization.indexsets.add_elements(
+            indexset_2.id, elements=2024
+        )
+        indexset_2 = test_mp.backend.optimization.indexsets.get(run.id, indexset_2.name)
+        variable_3 = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable 5",
+            constrained_to_indexsets=["Indexset", indexset_2.name],
+        )
+        # If indexset doesn't have elements, a generic dtype is registered
+        assert variable_3.columns[0].dtype == "object"
+        assert variable_3.columns[1].dtype == "int64"
+
+    def test_get_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.backend.runs.create("Model", "Scenario")
+        _ = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        variable = test_mp.backend.optimization.variables.create(
+            run_id=run.id, name="Variable", constrained_to_indexsets=["Indexset"]
+        )
+        assert variable == test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable"
+        )
+
+        with pytest.raises(OptimizationVariable.NotFound):
+            _ = test_mp.backend.optimization.variables.get(
+                run_id=run.id, name="Variable 2"
+            )
+
+    def test_variable_add_data(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.backend.runs.create("Model", "Scenario")
+        indexset_1 = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        test_mp.backend.optimization.indexsets.add_elements(
+            indexset_id=indexset_1.id, elements=["foo", "bar", ""]
+        )
+        indexset_2 = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset 2"
+        )
+        test_mp.backend.optimization.indexsets.add_elements(
+            indexset_id=indexset_2.id, elements=[1, 2, 3]
+        )
+        # pandas can only convert dicts to dataframes if the values are lists
+        # or if index is given. But maybe using read_json instead of from_dict
+        # can remedy this. Or maybe we want to catch the resulting
+        # "ValueError: If using all scalar values, you must pass an index" and
+        # reraise a custom informative error?
+        test_data_1 = {
+            "Indexset": ["foo"],
+            "Indexset 2": [1],
+            "levels": [3.14],
+            "marginals": [-3.14],
+        }
+        variable = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable",
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+        )
+        test_mp.backend.optimization.variables.add_data(
+            variable_id=variable.id, data=test_data_1
+        )
+
+        variable = test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable"
+        )
+        assert variable.data == test_data_1
+
+        variable_2 = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable 2",
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+        )
+
+        with pytest.raises(
+            AssertionError, match=r"must include the column\(s\): levels!"
+        ):
+            test_mp.backend.optimization.variables.add_data(
+                variable_id=variable_2.id,
+                data=pd.DataFrame(
+                    {
+                        "Indexset": [None],
+                        "Indexset 2": [2],
+                        "marginals": [1],
+                    }
+                ),
+            )
+
+        with pytest.raises(
+            AssertionError, match=r"must include the column\(s\): marginals!"
+        ):
+            test_mp.backend.optimization.variables.add_data(
+                variable_id=variable_2.id,
+                data=pd.DataFrame(
+                    {
+                        "Indexset": [None],
+                        "Indexset 2": [2],
+                        "levels": [1],
+                    }
+                ),
+            )
+
+        # By converting data to pd.DataFrame, we automatically enforce equal length
+        # of new columns, raises All arrays must be of the same length otherwise:
+        with pytest.raises(ValueError, match="All arrays must be of the same length"):
+            test_mp.backend.optimization.variables.add_data(
+                variable_id=variable_2.id,
+                data={
+                    "Indexset": ["foo", "foo"],
+                    "Indexset 2": [2, 2],
+                    "levels": [1, 2],
+                    "marginals": [1],
+                },
+            )
+
+        with pytest.raises(ValueError, match="contains duplicate rows"):
+            test_mp.backend.optimization.variables.add_data(
+                variable_id=variable_2.id,
+                data={
+                    "Indexset": ["foo", "foo"],
+                    "Indexset 2": [2, 2],
+                    "levels": [1, 2],
+                    "marginals": [-1, -2],
+                },
+            )
+
+        # Test that order is conserved
+        test_data_2 = {
+            "Indexset": ["", "", "foo", "foo", "bar", "bar"],
+            "Indexset 2": [3, 1, 2, 1, 2, 3],
+            "levels": [6, 5, 4, 3, 2, 1],
+            "marginals": [1, 3, 5, 6, 4, 2],
+        }
+        test_mp.backend.optimization.variables.add_data(
+            variable_id=variable_2.id, data=test_data_2
+        )
+        variable_2 = test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable 2"
+        )
+        assert variable_2.data == test_data_2
+
+        # Test order is conserved with varying types and upon later addition of data
+        variable_3 = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable 3",
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+
+        test_data_3 = {
+            "Column 1": ["bar", "foo", ""],
+            "Column 2": [2, 3, 1],
+            "levels": [3, 2.0, -1],
+            "marginals": [100000, 1, 0.00001],
+        }
+        test_mp.backend.optimization.variables.add_data(
+            variable_id=variable_3.id, data=test_data_3
+        )
+        variable_3 = test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable 3"
+        )
+        assert variable_3.data == test_data_3
+
+        test_data_4 = {
+            "Column 1": ["foo", "", "bar"],
+            "Column 2": [2, 3, 1],
+            "levels": [3.14, 2, -1],
+            "marginals": [1, 0.00001, 100000],
+        }
+        test_mp.backend.optimization.variables.add_data(
+            variable_id=variable_3.id, data=test_data_4
+        )
+        variable_3 = test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable 3"
+        )
+        test_data_5 = test_data_3.copy()
+        for key, value in test_data_4.items():
+            test_data_5[key].extend(value)
+        assert variable_3.data == test_data_5
+
+    def test_list_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.backend.runs.create("Model", "Scenario")
+        # Per default, list() lists scalars for `default` version runs:
+        test_mp.backend.runs.set_as_default_version(run.id)
+        _ = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        _ = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset 2"
+        )
+        variable = test_mp.backend.optimization.variables.create(
+            run_id=run.id, name="Variable", constrained_to_indexsets=["Indexset"]
+        )
+        variable_2 = test_mp.backend.optimization.variables.create(
+            run_id=run.id, name="Variable 2", constrained_to_indexsets=["Indexset 2"]
+        )
+        assert [
+            variable,
+            variable_2,
+        ] == test_mp.backend.optimization.variables.list()
+
+        assert [variable] == test_mp.backend.optimization.variables.list(
+            name="Variable"
+        )
+
+    def test_tabulate_variable(self, test_mp, request):
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
+        run = test_mp.backend.runs.create("Model", "Scenario")
+        # Per default, tabulate() lists scalars for `default` version runs:
+        test_mp.backend.runs.set_as_default_version(run.id)
+        indexset = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        indexset_2 = test_mp.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset 2"
+        )
+        variable = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable",
+            constrained_to_indexsets=["Indexset", "Indexset 2"],
+        )
+        variable_2 = test_mp.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable 2",
+            constrained_to_indexsets=["Indexset", "Indexset 2"],
+        )
+        pd.testing.assert_frame_equal(
+            df_from_list([variable_2]),
+            test_mp.backend.optimization.variables.tabulate(name="Variable 2"),
+        )
+
+        test_mp.backend.optimization.indexsets.add_elements(
+            indexset_id=indexset.id, elements=["foo", "bar"]
+        )
+        test_mp.backend.optimization.indexsets.add_elements(
+            indexset_id=indexset_2.id, elements=[1, 2, 3]
+        )
+        test_data_1 = {
+            "Indexset": ["foo"],
+            "Indexset 2": [1],
+            "levels": [32],
+            "marginals": [-0],
+        }
+        test_mp.backend.optimization.variables.add_data(
+            variable_id=variable.id, data=test_data_1
+        )
+        variable = test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable"
+        )
+
+        test_data_2 = {
+            "Indexset 2": [2, 3],
+            "Indexset": ["foo", "bar"],
+            "levels": [1, -3.1],
+            "marginals": [2.0, -4],
+        }
+        test_mp.backend.optimization.variables.add_data(
+            variable_id=variable_2.id, data=test_data_2
+        )
+        variable_2 = test_mp.backend.optimization.variables.get(
+            run_id=run.id, name="Variable 2"
+        )
+        pd.testing.assert_frame_equal(
+            df_from_list([variable, variable_2]),
+            test_mp.backend.optimization.variables.tabulate(),
+        )

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -286,6 +286,34 @@ class TestDataOptimizationVariable:
             test_data_5[key].extend(value)  # type: ignore
         assert variable_3.data == test_data_5
 
+    def test_variable_remove_data(self, platform: ixmp4.Platform):
+        run = platform.backend.runs.create("Model", "Scenario")
+        indexset = platform.backend.optimization.indexsets.create(run.id, "Indexset")
+        platform.backend.optimization.indexsets.add_elements(
+            indexset_id=indexset.id, elements=["foo", "bar"]
+        )
+        test_data = {
+            "Indexset": ["bar", "foo"],
+            "levels": [2.0, 1],
+            "marginals": [0, "test"],
+        }
+        variable = platform.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable",
+            constrained_to_indexsets=[indexset.name],
+        )
+        platform.backend.optimization.variables.add_data(variable.id, test_data)
+        variable = platform.backend.optimization.variables.get(
+            run_id=run.id, name="Variable"
+        )
+        assert variable.data == test_data
+
+        platform.backend.optimization.variables.remove_data(variable_id=variable.id)
+        variable = platform.backend.optimization.variables.get(
+            run_id=run.id, name="Variable"
+        )
+        assert variable.data == {}
+
     def test_list_variable(self, platform: ixmp4.Platform):
         run = platform.backend.runs.create("Model", "Scenario")
         indexset, indexset_2 = create_indexsets_for_run(

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -297,8 +297,6 @@ class TestDataOptimizationVariable:
     def test_list_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        # Per default, list() lists scalars for `default` version runs:
-        test_mp.backend.runs.set_as_default_version(run.id)
         _ = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset"
         )
@@ -320,11 +318,25 @@ class TestDataOptimizationVariable:
             name="Variable"
         )
 
+        # Test listing Variables for specific Run
+        run_2 = test_mp.backend.runs.create("Model", "Scenario")
+        indexset = test_mp.backend.optimization.indexsets.create(
+            run_id=run_2.id, name="Indexset"
+        )
+        variable_3 = test_mp.backend.optimization.variables.create(
+            run_id=run_2.id, name="Variable", constrained_to_indexsets=[indexset.name]
+        )
+        variable_4 = test_mp.backend.optimization.variables.create(
+            run_id=run_2.id, name="Variable 2", constrained_to_indexsets=[indexset.name]
+        )
+        assert [
+            variable_3,
+            variable_4,
+        ] == test_mp.backend.optimization.variables.list(run_id=run_2.id)
+
     def test_tabulate_variable(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        # Per default, tabulate() lists scalars for `default` version runs:
-        test_mp.backend.runs.set_as_default_version(run.id)
         indexset = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset"
         )
@@ -380,4 +392,20 @@ class TestDataOptimizationVariable:
         pd.testing.assert_frame_equal(
             df_from_list([variable, variable_2]),
             test_mp.backend.optimization.variables.tabulate(),
+        )
+
+        # Test tabulation of Variables for specific Run
+        run_2 = test_mp.backend.runs.create("Model", "Scenario")
+        indexset = test_mp.backend.optimization.indexsets.create(
+            run_id=run_2.id, name="Indexset"
+        )
+        variable_3 = test_mp.backend.optimization.variables.create(
+            run_id=run_2.id, name="Variable", constrained_to_indexsets=[indexset.name]
+        )
+        variable_4 = test_mp.backend.optimization.variables.create(
+            run_id=run_2.id, name="Variable 2", constrained_to_indexsets=[indexset.name]
+        )
+        pd.testing.assert_frame_equal(
+            df_from_list([variable_3, variable_4]),
+            test_mp.backend.optimization.variables.tabulate(run_id=run_2.id),
         )


### PR DESCRIPTION
This PR introduces the next item of the message data model: `Variable`. It comes complete with everything the other items already have and only minor changes to `Column` that are required for this to work, so without further DRY improvements, this PR size is as small as it gets (for the remaining `Equation`).

Some questions and notes that come up while working on this:

- We already have a `Variable` of the `iamc` category. This requires awkward naming conventions at times. I usually defaulted to `OptimizationVariable` for this new one, but this leads to a table name of `optimization_optimizationvariable` (because the `docs` table is built on the `model.__tablename__` -- which of course could be changed by overwriting the `__tablename__` locally, and maybe that's preferable) and to `OptimizationVariable` being importable from `ixmp4.core`, which I'm not sure we like. Please let me know what you think.
- How many `level`s and `marginal`s do `Variable`s (and `Equation`s, for that matter) have? At the moment, I'm assuming that every `Key` (one row of entries in `Variable.data`) can have its own `level` and `marginal`, making those two just arbitrary columns in `Variable.data` (though maybe we could limit them to being `float`s or so).
- Similarly, I'm wondering: do `Variable`s need to get `data` added to them manually via an `add()` function? Or is there data sort of filled in automatically by the gdx code? I don't think I remember lots of `variable.create()`, `variable.add_data()` functions from the westeros tutorials.

Working on the transport tutorial, I noticed that I had completely forgotten about adding `variables = db.relationship()` in the `Run` DB-table. I have even run migrations for these other PRs, but no error came up. I'm wondering if we even need these `relationship()` declarations at all.