### PR TITLE
Specify ruff check to avoid deprecation

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -63,7 +63,7 @@ hooks = ruff, ruff_format
 # lint with attempts to fix using "ruff"
 ruff.type = exec
 ruff.executable = %(here)s/.venv/bin/ruff
-ruff.options = --fix REVISION_SCRIPT_FILENAME
+ruff.options = check --fix REVISION_SCRIPT_FILENAME
 
 # format using "ruff" - use the exec runner, execute a binary
 ruff_format.type = exec


### PR DESCRIPTION
Just ran some migration locally and was informed that `ruff <path>` is now deprecated, we should use `ruff check <path>` instead. This PR updates our alembic post write hook accordingly.