### PR TITLE
Add pool_pre_ping to engine creation options

### DIFF
--- a/ixmp4/data/backend/db.py
+++ b/ixmp4/data/backend/db.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 @lru_cache()
 def cached_create_engine(dsn: str) -> Engine:
-    return create_engine(dsn)
+    return create_engine(dsn, pool_pre_ping=True)
 
 
 class IamcSubobject(BaseIamcSubobject):


### PR DESCRIPTION
Another stab at the postgres connection timeout problem! This is kind of a hack but pool_pre_ping sends a "ping query" up to three times before trying the actual query, should help with our idle-connection problem at a small cost until this is figured out on the setup side.
https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping