### PR TITLE
Set sqlalchemy logger to allow query debugging

### DIFF
--- a/ixmp4/conf/logging/debug.json
+++ b/ixmp4/conf/logging/debug.json
@@ -17,5 +17,10 @@
       "level": "NOTSET",
       "formatter": "generic"
     }
+  },
+  "loggers": {
+    "sqlalchemy": {
+      "level": "NOTSET"
+    }
   }
 }


### PR DESCRIPTION
While working at the GAMS transport tutorial, I found an error in the DB layer that I needed to debug by studying the SQL query generated from my code. 
Luckily, @meksor quickly explained how we usually do this (by setting `IXMP4_MODE=debug` before calling our code), but the usual way did not work because of a change in our settings. This PR fixes our settings so that it works again (thanks @meksor for quickly pointing this out).
Here's to hoping it doesn't break anything downstream. 