### PR TITLE
Fix `list()` and `tabulate()` for existing optimization items with specific run-request

### DIFF
--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -94,7 +94,9 @@ class IndexSetRepository(BaseFacade):
         return IndexSet(_backend=self.backend, _model=indexset)
 
     def list(self, name: str | None = None) -> list[IndexSet]:
-        indexsets = self.backend.optimization.indexsets.list(name=name)
+        indexsets = self.backend.optimization.indexsets.list(
+            run_id=self._run.id, name=name
+        )
         return [
             IndexSet(
                 _backend=self.backend,
@@ -104,4 +106,6 @@ class IndexSetRepository(BaseFacade):
         ]
 
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
-        return self.backend.optimization.indexsets.tabulate(name=name)
+        return self.backend.optimization.indexsets.tabulate(
+            run_id=self._run.id, name=name
+        )

--- a/ixmp4/core/optimization/scalar.py
+++ b/ixmp4/core/optimization/scalar.py
@@ -137,4 +137,6 @@ class ScalarRepository(BaseFacade):
         ]
 
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
-        return self.backend.optimization.scalars.tabulate(name=name)
+        return self.backend.optimization.scalars.tabulate(
+            run_id=self._run.id, name=name
+        )

--- a/ixmp4/core/optimization/table.py
+++ b/ixmp4/core/optimization/table.py
@@ -116,4 +116,4 @@ class TableRepository(BaseFacade):
         ]
 
     def tabulate(self, name: str | None = None) -> pd.DataFrame:
-        return self.backend.optimization.tables.tabulate(name=name)
+        return self.backend.optimization.tables.tabulate(run_id=self._run.id, name=name)

--- a/tests/core/test_indexset.py
+++ b/tests/core/test_indexset.py
@@ -51,6 +51,7 @@ class TestCoreIndexSet:
     def test_get_indexset(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
         run = test_mp.runs.create("Model", "Scenario")
+        run.set_as_default()
         _ = run.optimization.indexsets.create("IndexSet 1")
         indexset = run.optimization.indexsets.get("IndexSet 1")
         assert indexset.id == 1
@@ -90,8 +91,6 @@ class TestCoreIndexSet:
     def test_list_indexsets(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
         run = test_mp.runs.create("Model", "Scenario")
-        # Per default, list() lists only `default` version runs:
-        run.set_as_default()
         indexset_1 = run.optimization.indexsets.create("Indexset 1")
         indexset_2 = run.optimization.indexsets.create("Indexset 2")
         expected_ids = [indexset_1.id, indexset_2.id]
@@ -106,11 +105,17 @@ class TestCoreIndexSet:
         ]
         assert not (set(expected_id) ^ set(list_id))
 
+        # Test that only indexsets belonging to this Run are listed
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        indexset_3 = run_2.optimization.indexsets.create("Indexset 1")
+        indexset_4 = run_2.optimization.indexsets.create("Indexset 2")
+        expected_ids = [indexset_3.id, indexset_4.id]
+        list_ids = [indexset.id for indexset in run_2.optimization.indexsets.list()]
+        assert not (set(expected_ids) ^ set(list_ids))
+
     def test_tabulate_indexsets(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
         run = test_mp.runs.create("Model", "Scenario")
-        # Per default, tabulate() lists only `default` version runs:
-        run.set_as_default()
         indexset_1 = run.optimization.indexsets.create("Indexset 1")
         indexset_2 = run.optimization.indexsets.create("Indexset 2")
         expected = df_from_list(indexsets=[indexset_1, indexset_2])
@@ -121,6 +126,16 @@ class TestCoreIndexSet:
 
         expected = df_from_list(indexsets=[indexset_2])
         result = run.optimization.indexsets.tabulate(name="Indexset 2")
+        pdt.assert_frame_equal(expected, result)
+
+        # Test that only IndexSets belonging to this Run are tabulated
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        indexset_3 = run_2.optimization.indexsets.create("Indexset 1")
+        indexset_4 = run_2.optimization.indexsets.create("Indexset 2")
+        expected = df_from_list(indexsets=[indexset_3, indexset_4])
+        result = run_2.optimization.indexsets.tabulate()
+        # utils.assert_unordered_equality doesn't like lists, so make sure the order in
+        # df_from_list() is correct!
         pdt.assert_frame_equal(expected, result)
 
     def test_indexset_docs(self, test_mp, request):

--- a/tests/core/test_indexset.py
+++ b/tests/core/test_indexset.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from ixmp4 import IndexSet
+from ixmp4.core import IndexSet, Platform
 
 from ..utils import all_platforms
 
@@ -36,7 +36,7 @@ def df_from_list(indexsets: list[IndexSet]):
 @all_platforms
 class TestCoreIndexSet:
     def test_create_indexset(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         indexset_1 = run.optimization.indexsets.create("IndexSet 1")
         assert indexset_1.id == 1
@@ -49,7 +49,7 @@ class TestCoreIndexSet:
             _ = run.optimization.indexsets.create("IndexSet 1")
 
     def test_get_indexset(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         run.set_as_default()
         _ = run.optimization.indexsets.create("IndexSet 1")
@@ -61,7 +61,7 @@ class TestCoreIndexSet:
             _ = run.optimization.indexsets.get("Foo")
 
     def test_add_elements(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         test_elements = ["foo", "bar"]
         indexset_1 = run.optimization.indexsets.create("IndexSet 1")
@@ -89,10 +89,15 @@ class TestCoreIndexSet:
         assert indexset_5.elements == test_elements_2
 
     def test_list_indexsets(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         indexset_1 = run.optimization.indexsets.create("Indexset 1")
         indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        # Create indexset in another run to test listing indexsets for specific run
+        test_mp.runs.create("Model", "Scenario").optimization.indexsets.create(
+            "Indexset 1"
+        )
+
         expected_ids = [indexset_1.id, indexset_2.id]
         list_ids = [indexset.id for indexset in run.optimization.indexsets.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -105,19 +110,16 @@ class TestCoreIndexSet:
         ]
         assert not (set(expected_id) ^ set(list_id))
 
-        # Test that only indexsets belonging to this Run are listed
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        indexset_3 = run_2.optimization.indexsets.create("Indexset 1")
-        indexset_4 = run_2.optimization.indexsets.create("Indexset 2")
-        expected_ids = [indexset_3.id, indexset_4.id]
-        list_ids = [indexset.id for indexset in run_2.optimization.indexsets.list()]
-        assert not (set(expected_ids) ^ set(list_ids))
-
     def test_tabulate_indexsets(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         indexset_1 = run.optimization.indexsets.create("Indexset 1")
         indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        # Create indexset in another run to test tabulating indexsets for specific run
+        test_mp.runs.create("Model", "Scenario").optimization.indexsets.create(
+            "Indexset 1"
+        )
+
         expected = df_from_list(indexsets=[indexset_1, indexset_2])
         result = run.optimization.indexsets.tabulate()
         # utils.assert_unordered_equality doesn't like lists, so make sure the order in
@@ -128,18 +130,8 @@ class TestCoreIndexSet:
         result = run.optimization.indexsets.tabulate(name="Indexset 2")
         pdt.assert_frame_equal(expected, result)
 
-        # Test that only IndexSets belonging to this Run are tabulated
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        indexset_3 = run_2.optimization.indexsets.create("Indexset 1")
-        indexset_4 = run_2.optimization.indexsets.create("Indexset 2")
-        expected = df_from_list(indexsets=[indexset_3, indexset_4])
-        result = run_2.optimization.indexsets.tabulate()
-        # utils.assert_unordered_equality doesn't like lists, so make sure the order in
-        # df_from_list() is correct!
-        pdt.assert_frame_equal(expected, result)
-
     def test_indexset_docs(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         indexset_1 = run.optimization.indexsets.create("IndexSet 1")
         docs = "Documentation of IndexSet 1"

--- a/tests/core/test_scalar.py
+++ b/tests/core/test_scalar.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from ixmp4 import Scalar
+from ixmp4.core import Platform, Scalar
 
 from ..utils import all_platforms, assert_unordered_equality
 
@@ -35,7 +35,7 @@ def df_from_list(scalars: list[Scalar]):
 @all_platforms
 class TestCoreScalar:
     def test_create_scalar(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         unit = test_mp.units.create("Test Unit")
         scalar_1 = run.optimization.scalars.create(
@@ -63,7 +63,7 @@ class TestCoreScalar:
         assert scalar_3.unit.name == ""
 
     def test_get_scalar(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         unit = test_mp.units.create("Test Unit")
         scalar = run.optimization.scalars.create("Scalar", value=10, unit=unit.name)
@@ -77,7 +77,7 @@ class TestCoreScalar:
             _ = run.optimization.scalars.get("Foo")
 
     def test_update_scalar(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         unit = test_mp.units.create("Test Unit")
         unit2 = test_mp.units.create("Test Unit 2")
@@ -100,10 +100,8 @@ class TestCoreScalar:
         assert scalar.unit.id == result.unit.id == 1
 
     def test_list_scalars(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        # Per default, list() lists only `default` version runs:
-        run.set_as_default()
         unit = test_mp.units.create("Test Unit")
         scalar_1 = run.optimization.scalars.create(
             "Scalar 1", value=1, unit="Test Unit"
@@ -120,11 +118,21 @@ class TestCoreScalar:
         ]
         assert not (set(expected_id) ^ set(list_id))
 
+        # Test that only Scalars belonging to this Run are listed
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        scalar_3 = run_2.optimization.scalars.create(
+            "Scalar 1", value=1, unit="Test Unit"
+        )
+        scalar_4 = run_2.optimization.scalars.create(
+            "Scalar 2", value=2, unit=unit.name
+        )
+        expected_ids = [scalar_3.id, scalar_4.id]
+        list_ids = [scalar.id for scalar in run_2.optimization.scalars.list()]
+        assert not (set(expected_ids) ^ set(list_ids))
+
     def test_tabulate_scalars(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        # Per default, tabulate() lists only `default` version runs:
-        run.set_as_default()
         unit = test_mp.units.create("Test Unit")
         scalar_1 = run.optimization.scalars.create("Scalar 1", value=1, unit=unit.name)
         scalar_2 = run.optimization.scalars.create("Scalar 2", value=2, unit=unit.name)
@@ -136,8 +144,20 @@ class TestCoreScalar:
         result = run.optimization.scalars.tabulate(name="Scalar 2")
         assert_unordered_equality(expected, result, check_dtype=False)
 
+        # Test that only Scalars belonging to this Run are tabulated
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        scalar_3 = run_2.optimization.scalars.create(
+            "Scalar 1", value=1, unit=unit.name
+        )
+        scalar_4 = run_2.optimization.scalars.create(
+            "Scalar 2", value=2, unit=unit.name
+        )
+        expected = df_from_list(scalars=[scalar_3, scalar_4])
+        result = run_2.optimization.scalars.tabulate()
+        assert_unordered_equality(expected, result, check_dtype=False)
+
     def test_scalar_docs(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         unit = test_mp.units.create("Test Unit")
         scalar = run.optimization.scalars.create("Scalar 1", value=4, unit=unit.name)

--- a/tests/core/test_scalar.py
+++ b/tests/core/test_scalar.py
@@ -107,6 +107,11 @@ class TestCoreScalar:
             "Scalar 1", value=1, unit="Test Unit"
         )
         scalar_2 = run.optimization.scalars.create("Scalar 2", value=2, unit=unit.name)
+        # Create scalar in another run to test listing scalars for specific run
+        test_mp.runs.create("Model", "Scenario").optimization.scalars.create(
+            "Scalar 1", value=1, unit=unit
+        )
+
         expected_ids = [scalar_1.id, scalar_2.id]
         list_ids = [scalar.id for scalar in run.optimization.scalars.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -118,42 +123,23 @@ class TestCoreScalar:
         ]
         assert not (set(expected_id) ^ set(list_id))
 
-        # Test that only Scalars belonging to this Run are listed
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        scalar_3 = run_2.optimization.scalars.create(
-            "Scalar 1", value=1, unit="Test Unit"
-        )
-        scalar_4 = run_2.optimization.scalars.create(
-            "Scalar 2", value=2, unit=unit.name
-        )
-        expected_ids = [scalar_3.id, scalar_4.id]
-        list_ids = [scalar.id for scalar in run_2.optimization.scalars.list()]
-        assert not (set(expected_ids) ^ set(list_ids))
-
     def test_tabulate_scalars(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
         unit = test_mp.units.create("Test Unit")
         scalar_1 = run.optimization.scalars.create("Scalar 1", value=1, unit=unit.name)
         scalar_2 = run.optimization.scalars.create("Scalar 2", value=2, unit=unit.name)
+        # Create scalar in another run to test tabulating scalars for specific run
+        test_mp.runs.create("Model", "Scenario").optimization.scalars.create(
+            "Scalar 1", value=1, unit=unit
+        )
+
         expected = df_from_list(scalars=[scalar_1, scalar_2])
         result = run.optimization.scalars.tabulate()
         assert_unordered_equality(expected, result, check_dtype=False)
 
         expected = df_from_list(scalars=[scalar_2])
         result = run.optimization.scalars.tabulate(name="Scalar 2")
-        assert_unordered_equality(expected, result, check_dtype=False)
-
-        # Test that only Scalars belonging to this Run are tabulated
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        scalar_3 = run_2.optimization.scalars.create(
-            "Scalar 1", value=1, unit=unit.name
-        )
-        scalar_4 = run_2.optimization.scalars.create(
-            "Scalar 2", value=2, unit=unit.name
-        )
-        expected = df_from_list(scalars=[scalar_3, scalar_4])
-        result = run_2.optimization.scalars.tabulate()
         assert_unordered_equality(expected, result, check_dtype=False)
 
     def test_scalar_docs(self, test_mp, request):

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -224,6 +224,13 @@ class TestCoreTable:
         table_2 = run.optimization.tables.create(
             "Table 2", constrained_to_indexsets=["Indexset 2"]
         )
+        # Create table in another run to test listing tables for specific run
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
+        run_2.optimization.tables.create(
+            "Table 1", constrained_to_indexsets=[indexset_3.name]
+        )
+
         expected_ids = [table.id, table_2.id]
         list_ids = [table.id for table in run.optimization.tables.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -232,20 +239,6 @@ class TestCoreTable:
         expected_id = [table.id]
         list_id = [table.id for table in run.optimization.tables.list(name="Table")]
         assert not (set(expected_id) ^ set(list_id))
-
-        # Test that only Tables belonging to this Run are listed
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
-        indexset_4 = run_2.optimization.indexsets.create("Indexset 4")
-        table_3 = run_2.optimization.tables.create(
-            "Table", constrained_to_indexsets=[indexset_3.name, indexset_4.name]
-        )
-        table_4 = run_2.optimization.tables.create(
-            "Table 2", constrained_to_indexsets=[indexset_3.name, indexset_4.name]
-        )
-        expected_ids = [table_3.id, table_4.id]
-        list_ids = [table.id for table in run_2.optimization.tables.list()]
-        assert not (set(expected_ids) ^ set(list_ids))
 
     def test_tabulate_table(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
@@ -260,6 +253,13 @@ class TestCoreTable:
             name="Table 2",
             constrained_to_indexsets=["Indexset", "Indexset 2"],
         )
+        # Create table in another run to test listing tables for specific run
+        run_2 = test_mp.runs.create("Model", "Scenario")
+        indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
+        run_2.optimization.tables.create(
+            "Table 1", constrained_to_indexsets=[indexset_3.name]
+        )
+
         pd.testing.assert_frame_equal(
             df_from_list([table_2]),
             run.optimization.tables.tabulate(name="Table 2"),
@@ -274,21 +274,6 @@ class TestCoreTable:
         pd.testing.assert_frame_equal(
             df_from_list([table, table_2]),
             run.optimization.tables.tabulate(),
-        )
-
-        # Test that only Tables belonging to this Run are listed
-        run_2 = test_mp.runs.create("Model", "Scenario")
-        indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
-        indexset_4 = run_2.optimization.indexsets.create("Indexset 4")
-        table_3 = run_2.optimization.tables.create(
-            "Table", constrained_to_indexsets=[indexset_3.name, indexset_4.name]
-        )
-        table_4 = run_2.optimization.tables.create(
-            "Table 2", constrained_to_indexsets=[indexset_3.name, indexset_4.name]
-        )
-        pd.testing.assert_frame_equal(
-            df_from_list([table_3, table_4]),
-            run_2.optimization.tables.tabulate(),
         )
 
     def test_table_docs(self, test_mp, request):

--- a/tests/core/test_table.py
+++ b/tests/core/test_table.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import pytest
 
-from ixmp4.core import Platform, Table
+from ixmp4.core import IndexSet, Platform, Table
 
-from ..utils import all_platforms
+from ..utils import all_platforms, create_indexsets_for_run
 
 
 def df_from_list(tables: list[Table]):
@@ -39,7 +39,10 @@ class TestCoreTable:
         run = test_mp.runs.create("Model", "Scenario")
 
         # Test normal creation
-        indexset = run.optimization.indexsets.create("Indexset")
+        indexset, indexset_2 = tuple(
+            IndexSet(_backend=test_mp.backend, _model=model)
+            for model in create_indexsets_for_run(platform=test_mp, run_id=run.id)
+        )
         table = run.optimization.tables.create(
             "Table 1",
             constrained_to_indexsets=[indexset.name],
@@ -48,20 +51,20 @@ class TestCoreTable:
         assert table.id == 1
         assert table.name == "Table 1"
         assert table.data == {}
-        assert table.columns[0].name == "Indexset"
+        assert table.columns[0].name == indexset.name
         assert table.constrained_to_indexsets == [indexset.name]
 
         # Test duplicate name raises
         with pytest.raises(Table.NotUnique):
             _ = run.optimization.tables.create(
-                "Table 1", constrained_to_indexsets=["Indexset"]
+                "Table 1", constrained_to_indexsets=[indexset.name]
             )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
         with pytest.raises(ValueError, match="not equal in length"):
             _ = run.optimization.tables.create(
                 name="Table 2",
-                constrained_to_indexsets=["Indexset"],
+                constrained_to_indexsets=[indexset.name],
                 column_names=["Dimension 1", "Dimension 2"],
             )
 
@@ -82,11 +85,10 @@ class TestCoreTable:
             )
 
         # Test column.dtype is registered correctly
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
         indexset_2.add(elements=2024)
         table_3 = run.optimization.tables.create(
             "Table 5",
-            constrained_to_indexsets=["Indexset", indexset_2.name],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         # If indexset doesn't have elements, a generic dtype is registered
         assert table_3.columns[0].dtype == "object"
@@ -95,9 +97,11 @@ class TestCoreTable:
     def test_get_table(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create(name="Indexset")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id, amount=1
+        )
         _ = run.optimization.tables.create(
-            name="Table", constrained_to_indexsets=["Indexset"]
+            name="Table", constrained_to_indexsets=[indexset.name]
         )
         table = run.optimization.tables.get("Table")
         assert table.run_id == run.id
@@ -113,16 +117,18 @@ class TestCoreTable:
     def test_table_add_data(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
+        indexset, indexset_2 = tuple(
+            IndexSet(_backend=test_mp.backend, _model=model)
+            for model in create_indexsets_for_run(platform=test_mp, run_id=run.id)
+        )
         indexset.add(elements=["foo", "bar", ""])
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
         indexset_2.add([1, 2, 3])
         # pandas can only convert dicts to dataframes if the values are lists
         # or if index is given. But maybe using read_json instead of from_dict
         # can remedy this. Or maybe we want to catch the resulting
         # "ValueError: If using all scalar values, you must pass an index" and
         # reraise a custom informative error?
-        test_data_1 = {"Indexset": ["foo"], "Indexset 2": [1]}
+        test_data_1 = {indexset.name: ["foo"], indexset_2.name: [1]}
         table = run.optimization.tables.create(
             "Table",
             constrained_to_indexsets=[indexset.name, indexset_2.name],
@@ -137,22 +143,22 @@ class TestCoreTable:
 
         with pytest.raises(ValueError, match="missing values"):
             table_2.add(
-                pd.DataFrame({"Indexset": [None], "Indexset 2": [2]}),
+                pd.DataFrame({indexset.name: [None], indexset_2.name: [2]}),
                 # empty string is allowed for now, but None or NaN raise
             )
 
         with pytest.raises(ValueError, match="contains duplicate rows"):
             table_2.add(
-                data={"Indexset": ["foo", "foo"], "Indexset 2": [2, 2]},
+                data={indexset.name: ["foo", "foo"], indexset_2.name: [2, 2]},
             )
 
         # Test raising on unrecognised data.values()
         with pytest.raises(ValueError, match="contains values that are not allowed"):
             table_2.add(
-                data={"Indexset": ["foo"], "Indexset 2": [0]},
+                data={indexset.name: ["foo"], indexset_2.name: [0]},
             )
 
-        test_data_2 = {"Indexset": [""], "Indexset 2": [3]}
+        test_data_2 = {indexset.name: [""], indexset_2.name: [3]}
         table_2.add(data=test_data_2)
         assert table_2.data == test_data_2
 
@@ -195,12 +201,15 @@ class TestCoreTable:
         # This doesn't seem to test a distinct case compared to the above
         with pytest.raises(ValueError, match="Trying to add data to unknown Columns!"):
             table_4.add(
-                data={"Column 1": ["bar"], "Column 2": [3], "Indexset": ["foo"]},
+                data={"Column 1": ["bar"], "Column 2": [3], indexset.name: ["foo"]},
             )
 
         # Test various data types
-        test_data_5 = {"Indexset": ["foo", "foo", "bar"], "Indexset 3": [1, "2", 3.14]}
         indexset_3 = run.optimization.indexsets.create(name="Indexset 3")
+        test_data_5 = {
+            indexset.name: ["foo", "foo", "bar"],
+            indexset_3.name: [1, "2", 3.14],
+        }
         indexset_3.add(elements=[1, "2", 3.14])
         table_5 = run.optimization.tables.create(
             name="Table 5",
@@ -216,10 +225,9 @@ class TestCoreTable:
     def test_list_tables(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        _ = run.optimization.indexsets.create("Indexset")
-        _ = run.optimization.indexsets.create("Indexset 2")
+        create_indexsets_for_run(platform=test_mp, run_id=run.id)
         table = run.optimization.tables.create(
-            "Table", constrained_to_indexsets=["Indexset"]
+            "Table", constrained_to_indexsets=["Indexset 1"]
         )
         table_2 = run.optimization.tables.create(
             "Table 2", constrained_to_indexsets=["Indexset 2"]
@@ -243,15 +251,17 @@ class TestCoreTable:
     def test_tabulate_table(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        indexset, indexset_2 = tuple(
+            IndexSet(_backend=test_mp.backend, _model=model)
+            for model in create_indexsets_for_run(platform=test_mp, run_id=run.id)
+        )
         table = run.optimization.tables.create(
             name="Table",
-            constrained_to_indexsets=["Indexset", "Indexset 2"],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         table_2 = run.optimization.tables.create(
             name="Table 2",
-            constrained_to_indexsets=["Indexset", "Indexset 2"],
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
         )
         # Create table in another run to test listing tables for specific run
         run_2 = test_mp.runs.create("Model", "Scenario")
@@ -267,9 +277,9 @@ class TestCoreTable:
 
         indexset.add(["foo", "bar"])
         indexset_2.add([1, 2, 3])
-        test_data_1 = {"Indexset": ["foo"], "Indexset 2": [1]}
+        test_data_1 = {indexset.name: ["foo"], indexset_2.name: [1]}
         table.add(test_data_1)
-        test_data_2 = {"Indexset 2": [2, 3], "Indexset": ["foo", "bar"]}
+        test_data_2 = {indexset_2.name: [2, 3], indexset.name: ["foo", "bar"]}
         table_2.add(test_data_2)
         pd.testing.assert_frame_equal(
             df_from_list([table, table_2]),
@@ -279,7 +289,9 @@ class TestCoreTable:
     def test_table_docs(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
+        (indexset,) = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id, amount=1
+        )
         table_1 = run.optimization.tables.create(
             "Table 1", constrained_to_indexsets=[indexset.name]
         )

--- a/tests/data/test_optimization_indexset.py
+++ b/tests/data/test_optimization_indexset.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from ixmp4 import IndexSet
+from ixmp4.core import IndexSet, Platform
 
 from ..utils import all_platforms
 
@@ -36,7 +36,7 @@ def df_from_list(indexsets: list):
 @all_platforms
 class TestDataOptimizationIndexSet:
     def test_create_indexset(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
         indexset_1 = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset"
@@ -51,7 +51,7 @@ class TestDataOptimizationIndexSet:
             )
 
     def test_get_indexset(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
         _ = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset"
@@ -69,7 +69,7 @@ class TestDataOptimizationIndexSet:
             )
 
     def test_list_indexsets(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
         indexset_1 = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset 1"
@@ -95,7 +95,7 @@ class TestDataOptimizationIndexSet:
         )
 
     def test_tabulate_indexsets(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
         indexset_1 = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset 1"
@@ -140,7 +140,7 @@ class TestDataOptimizationIndexSet:
         )
 
     def test_add_elements(self, test_mp, request):
-        test_mp = request.getfixturevalue(test_mp)
+        test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         test_elements = ["foo", "bar"]
         run = test_mp.backend.runs.create("Model", "Scenario")
         indexset_1 = test_mp.backend.optimization.indexsets.create(

--- a/tests/data/test_optimization_indexset.py
+++ b/tests/data/test_optimization_indexset.py
@@ -71,8 +71,6 @@ class TestDataOptimizationIndexSet:
     def test_list_indexsets(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
         run = test_mp.backend.runs.create("Model", "Scenario")
-        # Per default, list() lists scalars for `default` version runs:
-        test_mp.backend.runs.set_as_default_version(run.id)
         indexset_1 = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset 1"
         )
@@ -84,11 +82,21 @@ class TestDataOptimizationIndexSet:
         )
         assert [indexset_1, indexset_2] == test_mp.backend.optimization.indexsets.list()
 
+        # Test only indexsets belonging to this Run are listed when run_id is provided
+        run_2 = test_mp.backend.runs.create("Model", "Scenario")
+        indexset_3 = test_mp.backend.optimization.indexsets.create(
+            run_id=run_2.id, name="Indexset 1"
+        )
+        indexset_4 = test_mp.backend.optimization.indexsets.create(
+            run_id=run_2.id, name="Indexset 2"
+        )
+        assert [indexset_3, indexset_4] == test_mp.backend.optimization.indexsets.list(
+            run_id=run_2.id
+        )
+
     def test_tabulate_indexsets(self, test_mp, request):
         test_mp = request.getfixturevalue(test_mp)
         run = test_mp.backend.runs.create("Model", "Scenario")
-        # Per default, tabulate() lists scalars for `default` version runs:
-        test_mp.backend.runs.set_as_default_version(run.id)
         indexset_1 = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset 1"
         )
@@ -116,6 +124,19 @@ class TestDataOptimizationIndexSet:
         expected = df_from_list(indexsets=[indexset_1])
         pdt.assert_frame_equal(
             expected, test_mp.backend.optimization.indexsets.tabulate(name="Indexset 1")
+        )
+
+        # Test only indexsets belonging to this Run are tabulated if run_id is provided
+        run_2 = test_mp.backend.runs.create("Model", "Scenario")
+        indexset_3 = test_mp.backend.optimization.indexsets.create(
+            run_id=run_2.id, name="Indexset 1"
+        )
+        indexset_4 = test_mp.backend.optimization.indexsets.create(
+            run_id=run_2.id, name="Indexset 2"
+        )
+        expected = df_from_list(indexsets=[indexset_3, indexset_4])
+        pdt.assert_frame_equal(
+            expected, test_mp.backend.optimization.indexsets.tabulate(run_id=run_2.id)
         )
 
     def test_add_elements(self, test_mp, request):

--- a/tests/data/test_optimization_indexset.py
+++ b/tests/data/test_optimization_indexset.py
@@ -2,9 +2,10 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from ixmp4.core import IndexSet, Platform
+from ixmp4.core import Platform
+from ixmp4.data.abstract import IndexSet
 
-from ..utils import all_platforms
+from ..utils import all_platforms, create_indexsets_for_run
 
 
 def df_from_list(indexsets: list):
@@ -53,15 +54,13 @@ class TestDataOptimizationIndexSet:
     def test_get_indexset(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        _ = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset"
-        )
+        create_indexsets_for_run(platform=test_mp, run_id=run.id, amount=1)
         indexset = test_mp.backend.optimization.indexsets.get(
-            run_id=run.id, name="Indexset"
+            run_id=run.id, name="Indexset 1"
         )
         assert indexset.id == 1
         assert indexset.run__id == 1
-        assert indexset.name == "Indexset"
+        assert indexset.name == "Indexset 1"
 
         with pytest.raises(IndexSet.NotFound):
             _ = test_mp.backend.optimization.indexsets.get(
@@ -71,24 +70,18 @@ class TestDataOptimizationIndexSet:
     def test_list_indexsets(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_1 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 1"
-        )
-        indexset_2 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 2"
+        indexset_1, indexset_2 = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id
         )
         assert [indexset_1] == test_mp.backend.optimization.indexsets.list(
-            name="Indexset 1"
+            name=indexset_1.name
         )
         assert [indexset_1, indexset_2] == test_mp.backend.optimization.indexsets.list()
 
         # Test only indexsets belonging to this Run are listed when run_id is provided
         run_2 = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_3 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 1"
-        )
-        indexset_4 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 2"
+        indexset_3, indexset_4 = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, offset=2
         )
         assert [indexset_3, indexset_4] == test_mp.backend.optimization.indexsets.list(
             run_id=run_2.id
@@ -97,11 +90,8 @@ class TestDataOptimizationIndexSet:
     def test_tabulate_indexsets(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_1 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 1"
-        )
-        indexset_2 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 2"
+        indexset_1, indexset_2 = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id
         )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_1.id, elements="foo"
@@ -128,11 +118,8 @@ class TestDataOptimizationIndexSet:
 
         # Test only indexsets belonging to this Run are tabulated if run_id is provided
         run_2 = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_3 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 1"
-        )
-        indexset_4 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 2"
+        indexset_3, indexset_4 = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, offset=2
         )
         expected = df_from_list(indexsets=[indexset_3, indexset_4])
         pdt.assert_frame_equal(
@@ -143,19 +130,17 @@ class TestDataOptimizationIndexSet:
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         test_elements = ["foo", "bar"]
         run = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_1 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="IndexSet 1"
+        indexset_1, indexset_2 = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id
         )
+
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_1.id, elements=test_elements
         )
         indexset_1 = test_mp.backend.optimization.indexsets.get(
-            run_id=run.id, name="IndexSet 1"
+            run_id=run.id, name=indexset_1.name
         )
 
-        indexset_2 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="IndexSet 2"
-        )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_2.id, elements=test_elements
         )
@@ -163,7 +148,7 @@ class TestDataOptimizationIndexSet:
         assert (
             indexset_1.elements
             == test_mp.backend.optimization.indexsets.get(
-                run_id=run.id, name="IndexSet 2"
+                run_id=run.id, name=indexset_2.name
             ).elements
         )
 
@@ -181,25 +166,25 @@ class TestDataOptimizationIndexSet:
             indexset_id=indexset_1.id, elements=1
         )
         indexset_3 = test_mp.backend.optimization.indexsets.get(
-            run_id=run.id, name="IndexSet 1"
+            run_id=run.id, name=indexset_1.name
         )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_2.id, elements="1"
         )
         indexset_4 = test_mp.backend.optimization.indexsets.get(
-            run_id=run.id, name="IndexSet 2"
+            run_id=run.id, name=indexset_2.name
         )
         assert indexset_3.elements != indexset_4.elements
         assert len(indexset_3.elements) == len(indexset_4.elements)
 
         test_elements_2 = [1, "2", 3.14]
         indexset_5 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="IndexSet 5"
+            run_id=run.id, name="Indexset 5"
         )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_5.id, elements=test_elements_2
         )
         indexset_5 = test_mp.backend.optimization.indexsets.get(
-            run_id=run.id, name="IndexSet 5"
+            run_id=run.id, name="Indexset 5"
         )
         assert indexset_5.elements == test_elements_2

--- a/tests/data/test_optimization_scalar.py
+++ b/tests/data/test_optimization_scalar.py
@@ -2,7 +2,8 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from ixmp4.core import Platform, Scalar
+from ixmp4.core import Platform
+from ixmp4.data.abstract import Scalar
 
 from ..utils import all_platforms
 

--- a/tests/data/test_optimization_table.py
+++ b/tests/data/test_optimization_table.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import pytest
 
-from ixmp4.core import Platform, Table
+from ixmp4.core import Platform
+from ixmp4.data.abstract import Table
 
-from ..utils import all_platforms
+from ..utils import all_platforms, create_indexsets_for_run
 
 
 def df_from_list(tables: list):
@@ -37,23 +38,23 @@ class TestDataOptimizationTable:
         run = test_mp.backend.runs.create("Model", "Scenario")
 
         # Test normal creation
-        indexset_1 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset"
+        indexset_1, indexset_2 = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id
         )
         table = test_mp.backend.optimization.tables.create(
-            run_id=run.id, name="Table", constrained_to_indexsets=["Indexset"]
+            run_id=run.id, name="Table", constrained_to_indexsets=[indexset_1.name]
         )
 
         assert table.run__id == run.id
         assert table.name == "Table"
         assert table.data == {}  # JsonDict type currently requires a dict, not None
-        assert table.columns[0].name == "Indexset"
+        assert table.columns[0].name == indexset_1.name
         assert table.columns[0].constrained_to_indexset == indexset_1.id
 
         # Test duplicate name raises
         with pytest.raises(Table.NotUnique):
             _ = test_mp.backend.optimization.tables.create(
-                run_id=run.id, name="Table", constrained_to_indexsets=["Indexset"]
+                run_id=run.id, name="Table", constrained_to_indexsets=[indexset_1.name]
             )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
@@ -61,7 +62,7 @@ class TestDataOptimizationTable:
             _ = test_mp.backend.optimization.tables.create(
                 run_id=run.id,
                 name="Table 2",
-                constrained_to_indexsets=["Indexset"],
+                constrained_to_indexsets=[indexset_1.name],
                 column_names=["Dimension 1", "Dimension 2"],
             )
 
@@ -84,9 +85,6 @@ class TestDataOptimizationTable:
             )
 
         # Test column.dtype is registered correctly
-        indexset_2 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 2"
-        )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_2.id, elements=2024
         )
@@ -94,7 +92,7 @@ class TestDataOptimizationTable:
         table_3 = test_mp.backend.optimization.tables.create(
             run_id=run.id,
             name="Table 5",
-            constrained_to_indexsets=["Indexset", indexset_2.name],
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
         )
         # If indexset doesn't have elements, a generic dtype is registered
         assert table_3.columns[0].dtype == "object"
@@ -119,14 +117,11 @@ class TestDataOptimizationTable:
     def test_table_add_data(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_1 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset"
+        indexset_1, indexset_2 = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id
         )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_1.id, elements=["foo", "bar", ""]
-        )
-        indexset_2 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 2"
         )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_2.id, elements=[1, 2, 3]
@@ -136,7 +131,7 @@ class TestDataOptimizationTable:
         # can remedy this. Or maybe we want to catch the resulting
         # "ValueError: If using all scalar values, you must pass an index" and
         # reraise a custom informative error?
-        test_data_1 = {"Indexset": ["foo"], "Indexset 2": [1]}
+        test_data_1 = {indexset_1.name: ["foo"], indexset_2.name: [1]}
         table = test_mp.backend.optimization.tables.create(
             run_id=run.id,
             name="Table",
@@ -158,24 +153,24 @@ class TestDataOptimizationTable:
         with pytest.raises(ValueError, match="missing values"):
             test_mp.backend.optimization.tables.add_data(
                 table_id=table_2.id,
-                data=pd.DataFrame({"Indexset": [None], "Indexset 2": [2]}),
+                data=pd.DataFrame({indexset_1.name: [None], indexset_2.name: [2]}),
                 # empty string is allowed for now (see below), but None or NaN raise
             )
 
         with pytest.raises(ValueError, match="contains duplicate rows"):
             test_mp.backend.optimization.tables.add_data(
                 table_id=table_2.id,
-                data={"Indexset": ["foo", "foo"], "Indexset 2": [2, 2]},
+                data={indexset_1.name: ["foo", "foo"], indexset_2.name: [2, 2]},
             )
 
         # Test raising on unrecognised data.values()
         with pytest.raises(ValueError, match="contains values that are not allowed"):
             test_mp.backend.optimization.tables.add_data(
                 table_id=table_2.id,
-                data={"Indexset": ["foo"], "Indexset 2": [0]},
+                data={indexset_1.name: ["foo"], indexset_2.name: [0]},
             )
 
-        test_data_2 = {"Indexset": [""], "Indexset 2": [3]}
+        test_data_2 = {indexset_1.name: [""], indexset_2.name: [3]}
         test_mp.backend.optimization.tables.add_data(
             table_id=table_2.id, data=test_data_2
         )
@@ -243,10 +238,13 @@ class TestDataOptimizationTable:
             )
 
         # Test various data types
-        test_data_5 = {"Indexset": ["foo", "foo", "bar"], "Indexset 3": [1, "2", 3.14]}
         indexset_3 = test_mp.backend.optimization.indexsets.create(
             run_id=run.id, name="Indexset 3"
         )
+        test_data_5 = {
+            indexset_1.name: ["foo", "foo", "bar"],
+            indexset_3.name: [1, "2", 3.14],
+        }
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_3.id, elements=[1, "2", 3.14]
         )
@@ -269,14 +267,9 @@ class TestDataOptimizationTable:
     def test_list_table(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        _ = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset"
-        )
-        _ = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 2"
-        )
+        create_indexsets_for_run(platform=test_mp, run_id=run.id)
         table = test_mp.backend.optimization.tables.create(
-            run_id=run.id, name="Table", constrained_to_indexsets=["Indexset"]
+            run_id=run.id, name="Table", constrained_to_indexsets=["Indexset 1"]
         )
         table_2 = test_mp.backend.optimization.tables.create(
             run_id=run.id, name="Table 2", constrained_to_indexsets=["Indexset 2"]
@@ -287,11 +280,8 @@ class TestDataOptimizationTable:
 
         # Test listing of Tables when specifying a Run
         run_2 = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_3 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 3"
-        )
-        indexset_4 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 4"
+        indexset_3, indexset_4 = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, offset=2
         )
         table_3 = test_mp.backend.optimization.tables.create(
             run_id=run_2.id, name="Table", constrained_to_indexsets=[indexset_3.name]
@@ -306,21 +296,18 @@ class TestDataOptimizationTable:
     def test_tabulate_table(self, test_mp, request):
         test_mp: Platform = request.getfixturevalue(test_mp)  # type: ignore
         run = test_mp.backend.runs.create("Model", "Scenario")
-        indexset = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset"
-        )
-        indexset_2 = test_mp.backend.optimization.indexsets.create(
-            run_id=run.id, name="Indexset 2"
+        indexset_1, indexset_2 = create_indexsets_for_run(
+            platform=test_mp, run_id=run.id, offset=2
         )
         table = test_mp.backend.optimization.tables.create(
             run_id=run.id,
             name="Table",
-            constrained_to_indexsets=["Indexset", "Indexset 2"],
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
         )
         table_2 = test_mp.backend.optimization.tables.create(
             run_id=run.id,
             name="Table 2",
-            constrained_to_indexsets=["Indexset", "Indexset 2"],
+            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
         )
         pd.testing.assert_frame_equal(
             df_from_list([table_2]),
@@ -328,18 +315,18 @@ class TestDataOptimizationTable:
         )
 
         test_mp.backend.optimization.indexsets.add_elements(
-            indexset_id=indexset.id, elements=["foo", "bar"]
+            indexset_id=indexset_1.id, elements=["foo", "bar"]
         )
         test_mp.backend.optimization.indexsets.add_elements(
             indexset_id=indexset_2.id, elements=[1, 2, 3]
         )
-        test_data_1 = {"Indexset": ["foo"], "Indexset 2": [1]}
+        test_data_1 = {indexset_1.name: ["foo"], indexset_2.name: [1]}
         test_mp.backend.optimization.tables.add_data(
             table_id=table.id, data=test_data_1
         )
         table = test_mp.backend.optimization.tables.get(run_id=run.id, name="Table")
 
-        test_data_2 = {"Indexset 2": [2, 3], "Indexset": ["foo", "bar"]}
+        test_data_2 = {indexset_2.name: [2, 3], indexset_1.name: ["foo", "bar"]}
         test_mp.backend.optimization.tables.add_data(
             table_id=table_2.id, data=test_data_2
         )
@@ -351,11 +338,8 @@ class TestDataOptimizationTable:
 
         # Test tabulation of Tables when specifying a Run
         run_2 = test_mp.backend.runs.create("Model", "Scenario")
-        indexset_3 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 3"
-        )
-        indexset_4 = test_mp.backend.optimization.indexsets.create(
-            run_id=run_2.id, name="Indexset 4"
+        indexset_3, indexset_4 = create_indexsets_for_run(
+            platform=test_mp, run_id=run_2.id, offset=2
         )
         table_3 = test_mp.backend.optimization.tables.create(
             run_id=run_2.id, name="Table", constrained_to_indexsets=[indexset_3.name]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -203,13 +203,12 @@ def create_iamc_query_test_data(test_mp):
 
 
 def create_indexsets_for_run(
-    platform: Platform, run_id: int, amount: int = 2, offset: int = 0
+    platform: Platform, run_id: int, amount: int = 2, offset: int = 1
 ) -> tuple[IndexSet, ...]:
-    """Create `amount` indexsets called `Indexset n` for `run` (n in (offset,
-    offset+amount])."""
+    """Create `amount` indexsets called `Indexset n` for `run`."""
     return tuple(
         platform.backend.optimization.indexsets.create(
-            run_id=run_id, name=f"Indexset {i+1}"
+            run_id=run_id, name=f"Indexset {i}"
         )
         for i in range(offset, offset + amount)
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,8 @@ import pandas.testing as pdt
 import pytest
 
 from ixmp4 import DataPoint
+from ixmp4.core import Platform
+from ixmp4.data.abstract import IndexSet
 
 from .conftest import SKIP_PGSQL_TESTS
 
@@ -198,3 +200,16 @@ def create_iamc_query_test_data(test_mp):
     run2.meta = {"run": 2, "test": "string", "bool": False}
 
     return [r1, r2, r3], units
+
+
+def create_indexsets_for_run(
+    platform: Platform, run_id: int, amount: int = 2, offset: int = 0
+) -> tuple[IndexSet, ...]:
+    """Create `amount` indexsets called `Indexset n` for `run` (n in (offset,
+    offset+amount])."""
+    return tuple(
+        platform.backend.optimization.indexsets.create(
+            run_id=run_id, name=f"Indexset {i+1}"
+        )
+        for i in range(offset, offset + amount)
+    )


### PR DESCRIPTION
Also while working on the GAMS transport tutorial, I discovered that all optimization items had inconsistent behavior in the facade layer: `run.optimization.scalar.tabulate()` would list all scalars of all runs, while `...list()` would list only those of the run the scalars belong to. The latter is clearly desired, so this PR fixes the inconsistency and adds tests to confirm. 

Since `Parameter`, `Equation`, and `Variable` have not yet landed on main, I'll include corresponding changes in their pending PRs.

 