### PR TITLE
set server log level to INFO

### DIFF
--- a/ixmp4/conf/logging/server.json
+++ b/ixmp4/conf/logging/server.json
@@ -30,12 +30,12 @@
   "handlers": {
     "console": {
       "class": "logging.StreamHandler",
-      "level": "DEBUG",
+      "level": "INFO",
       "formatter": "generic"
     }
   },
   "root": { 
-    "level": "DEBUG",
+    "level": "INFO",
     "handlers": ["console"]
   }
 }


### PR DESCRIPTION
We should probably make this configurable via an env var, but Im setting this down to INFO because we dont necessarily need debug info everywhere anymore.