### PR TITLE
fix down revision in update info migration

### DIFF
--- a/ixmp4/db/migrations/versions/e7b7a37cf111_add_update_audit_info.py
+++ b/ixmp4/db/migrations/versions/e7b7a37cf111_add_update_audit_info.py
@@ -12,7 +12,7 @@ from alembic import op
 
 # Revision identifiers, used by Alembic.
 revision = "e7b7a37cf111"
-down_revision = "081bbda6bb7b"
+down_revision = "c29289ced488"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Currently when migrating a database with the current main branch, the following error occurs: 
```
CommandError: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 
'heads' for all heads
```
This is because due to a faulty merge, the down_revision was set incorrectly in a migration. 
