### PR TITLE
Setup Codecov uploading and reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 1
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  require_changes: true
+  # Don't display the large graph
+  layout: "diff, files"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -129,7 +129,7 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest --backend ${{ matrix.backend }} --postgres-dsn "postgresql://postgres:postgres@localhost:5432/test" --cov-report xml:.coverage.xml --cov-report term --cov=ixmp4 -rsxX --benchmark-skip --color=yes
+          pytest --backend ${{ matrix.backend }} --postgres-dsn "postgresql://postgres:postgres@localhost:5432/test" --cov-report xml:.coverage.xml --cov=ixmp4 -rsxX --benchmark-skip --color=yes
 
       #------------------------------
       #  Upload coverage to codecov

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -131,6 +131,15 @@ jobs:
           source .venv/bin/activate
           pytest --backend ${{ matrix.backend }} --postgres-dsn "postgresql://postgres:postgres@localhost:5432/test" --cov-report xml:.coverage.xml --cov-report term --cov=ixmp4 -rsxX --benchmark-skip --color=yes
 
+      #------------------------------
+      #  Upload coverage to codecov
+      #------------------------------
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: .coverage.xml
+
   pre-commit:
     name: Code quality
     runs-on: ubuntu-latest


### PR DESCRIPTION
When studying failed CI builds, I often find having to scroll past the codecov report tedious. In the rest of the MESSAGE stack, codecov is configured differently: a bot is picking up changes in coverage and reporting them as comments on the PR. For the rest of the stack, these are not just comments, but hard checks: should the PR reduce the test coverage (by too much), it will be rejected.
We don't have a policy like this with ixmp4 at the moment, so I'm not going to change that immediately. However, this PR tries to converge the different reporting styles: I have [enabled the codecov bot for this repo](https://github.com/organizations/iiasa/settings/installations/2244352), added a [`CODECOV_TOKEN` secret](https://github.com/iiasa/ixmp4/settings/secrets/actions), and configured codecov so that it should leave comments on PRs about coverage both within the changes proposed as well as the whole project in an informational way, i.e. not rejecting the PR because of lowered coverage.  

Please let me know what you think :)