### PR TITLE
Fix Erroneous Audit Info Update

### DIFF
--- a/ixmp4/data/db/run/repository.py
+++ b/ixmp4/data/db/run/repository.py
@@ -149,12 +149,16 @@ class RunRepository(
             .where(
                 Run.model__id == run.model__id,
                 Run.scenario__id == run.scenario__id,
+                Run.is_default,
             )
             .values(is_default=False)
         )
 
-        self.session.execute(exc)
-        self.session.commit()
+        with self.backend.event_handler.pause():
+            # we dont want to trigger the
+            # updated_at fields for this operation.
+            self.session.execute(exc)
+            self.session.commit()
 
         run.is_default = True
         self.session.commit()

--- a/tests/data/test_run.py
+++ b/tests/data/test_run.py
@@ -110,14 +110,3 @@ class TestDataRun:
             inplace=True,
             columns=["created_by", "created_at", "updated_by", "updated_at"],
         )
-
-    def test_audit_info(self, platform: ixmp4.Platform):
-        run = platform.backend.runs.create("Model", "Scenario")
-        platform.backend.runs.set_as_default_version(run.id)
-        platform.backend.runs.create("Model", "Scenario")
-
-        runs = platform.backend.runs.tabulate(default_only=False)
-        assert (runs["created_by"] == "@unknown").all()
-        # was updated by set_as_default_version
-        assert runs["updated_by"][0] == "@unknown"
-        assert runs["updated_by"][1] is None


### PR DESCRIPTION
As described by @danielhuppmann, when setting a run as the default, ixmp4 accidentally also updates that info for all other runs with the same model/scenario combination. 

This happens because the `set_as_default` function sets all the other runs to `is_default = False` before setting `True` on the singular subject run. The query is adjusted to only update rows which are actually not already `is_default = False` and I implemented a way to pause the event listeners to avoid setting that field on the previous default run as well. 

A repository can now pause the event listeners for a few lines like this: 

```py
with self.backend.event_handler.pause():
    # we dont want to trigger the
    # updated_at fields for this operation.
    self.session.execute(exc)
    self.session.commit()
```

Test is also adjusted to break if any of this ever happens again. 

fixes #126