### PR TITLE
Show audit info in `runs.tabulate()` 

### DIFF
--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -89,11 +89,16 @@ class RunRepository(BaseFacade):
             for r in self.backend.runs.list(default_only=default_only, **kwargs)
         ]
 
-    def tabulate(self, default_only: bool = True, **kwargs) -> pd.DataFrame:
+    def tabulate(
+        self, default_only: bool = True, audit_info: bool = False, **kwargs
+    ) -> pd.DataFrame:
         runs = self.backend.runs.tabulate(default_only=default_only, **kwargs)
         runs["model"] = runs["model__id"].map(self.backend.models.map())
         runs["scenario"] = runs["scenario__id"].map(self.backend.scenarios.map())
-        return runs[["id", "model", "scenario", "version", "is_default"]]
+        columns = ["model", "scenario", "version", "is_default"]
+        if audit_info:
+            columns += ["updated_at", "updated_by", "created_at", "created_by", "id"]
+        return runs[columns]
 
 
 class RunMetaFacade(BaseFacade, UserDict):

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -13,11 +13,9 @@ def _expected_runs_table(*row_default):
     rows = []
     for i, default in enumerate(row_default, start=1):
         if default is not None:
-            rows.append([i, "Model", "Scenario", i] + [default])
+            rows.append(["Model", "Scenario", i] + [default])
 
-    return pd.DataFrame(
-        rows, columns=["id", "model", "scenario", "version", "is_default"]
-    )
+    return pd.DataFrame(rows, columns=["model", "scenario", "version", "is_default"])
 
 
 class TestCoreRun:

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -66,6 +66,12 @@ class TestCoreRun:
             pd.DataFrame(_expected_runs_table(True, False)),
         )
 
+        # using audit_info=True shows additional columns
+        audit_info = platform.runs.tabulate(default_only=False, audit_info=True)
+        for column in ["updated_at", "updated_by", "created_at", "created_by", "id"]:
+            assert column in audit_info.columns
+        pdt.assert_series_equal(audit_info.id, pd.Series([run1.id, run2.id], name="id"))
+
         # default version can be retrieved directly
         run = platform.runs.get("Model", "Scenario")
         assert run1.id == run.id


### PR DESCRIPTION
This PR adds an audit-info option to `runs.tabulate()` to show some extra columns.