### PR TITLE
Implement safeguard against problematic meta keys

### DIFF
--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -211,7 +211,7 @@ class RunMetaEntryRepository(
     @check_types
     @guard("edit")
     def bulk_upsert(self, df: DataFrame[AddRunMetaEntryFrameSchema]) -> None:
-        if illegal_keys:= ( set(np.unique(df.key.values)) & ILLEGAL_META_KEYS ):
+        if illegal_keys := (set(np.unique(df.key.values)) & ILLEGAL_META_KEYS):
             raise InvalidRunMeta("Illegal meta key(s): " + ", ".join(illegal_keys))
 
         self.check_df_access(df)

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -1,5 +1,6 @@
 from typing import Union
 
+import numpy as np
 import pandas as pd
 import pandera as pa
 from pandera.typing import DataFrame, Series
@@ -210,6 +211,9 @@ class RunMetaEntryRepository(
     @check_types
     @guard("edit")
     def bulk_upsert(self, df: DataFrame[AddRunMetaEntryFrameSchema]) -> None:
+        if illegal_keys:= ( set(np.unique(df.key.values)) & ILLEGAL_META_KEYS ):
+            raise InvalidRunMeta("Illegal meta key(s): " + ", ".join(illegal_keys))
+
         self.check_df_access(df)
         df["type"] = df["value"].map(type).map(RunMetaEntry.Type.from_pytype)
 

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import NoResultFound
 
 from ixmp4 import db
 from ixmp4.core.decorators import check_types
+from ixmp4.core.exceptions import InvalidRunMeta
 from ixmp4.data import abstract
 from ixmp4.data.auth.decorators import guard
 from ixmp4.data.db.model import Model
@@ -15,6 +16,8 @@ from ixmp4.data.db.scenario import Scenario
 
 from .. import base
 from .model import RunMetaEntry
+
+ILLEGAL_META_KEYS = {"model", "scenario", "id", "version", "is_default"}
 
 
 class RemoveRunMetaEntryFrameSchema(pa.DataFrameModel):
@@ -60,6 +63,8 @@ class RunMetaEntryRepository(
                 default_only=False,
             )
 
+        if key in ILLEGAL_META_KEYS:
+            raise InvalidRunMeta("Illegal meta key: " + key)
         entry = RunMetaEntry(run__id=run__id, key=key, value=value)
         self.session.add(entry)
         return entry

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -1,6 +1,5 @@
 from typing import Union
 
-import numpy as np
 import pandas as pd
 import pandera as pa
 from pandera.typing import DataFrame, Series
@@ -211,7 +210,8 @@ class RunMetaEntryRepository(
     @check_types
     @guard("edit")
     def bulk_upsert(self, df: DataFrame[AddRunMetaEntryFrameSchema]) -> None:
-        if illegal_keys := (set(np.unique(df.key.values)) & ILLEGAL_META_KEYS):
+
+        if illegal_keys := (set(df.key.values) & ILLEGAL_META_KEYS):
             raise InvalidRunMeta("Illegal meta key(s): " + ", ".join(illegal_keys))
 
         self.check_df_access(df)

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -210,7 +210,6 @@ class RunMetaEntryRepository(
     @check_types
     @guard("edit")
     def bulk_upsert(self, df: DataFrame[AddRunMetaEntryFrameSchema]) -> None:
-
         if illegal_keys := (set(df.key.values) & ILLEGAL_META_KEYS):
             raise InvalidRunMeta("Illegal meta key(s): " + ", ".join(illegal_keys))
 

--- a/tests/data/test_meta.py
+++ b/tests/data/test_meta.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 import ixmp4
-from ixmp4.core.exceptions import SchemaError
+from ixmp4.core.exceptions import InvalidRunMeta, SchemaError
 from ixmp4.data.abstract.meta import RunMetaEntry
 
 from ..utils import assert_unordered_equality
@@ -36,6 +36,11 @@ class TestDataMeta:
             assert entry.key == key
             assert entry.value == value
             assert entry.type == type
+
+    def test_illegal_key(self, platform: ixmp4.Platform):
+        run = platform.runs.create("Model", "Scenario")
+        with pytest.raises(InvalidRunMeta):
+            platform.backend.meta.create(run.id, "version", "foo")
 
     def test_entry_unique(self, platform: ixmp4.Platform):
         run = platform.runs.create("Model", "Scenario")


### PR DESCRIPTION
Just ran into an issue (with @pmussak) in the new ECEMF app and ixmp4 database instance - I had added meta-indicators named "version" to the database, which was "overwriting" the version-attribute in the run-selection component of the app.

To avoid such issues, this PR makes several terms illegal as meta-indicator-keys (at creation). I briefly thought about adding this to the meta-model (see link below), but I was worried that if a meta indicator with such a name was already created in a database with a current ixmp4 version, there might be issues with then loading them after upgrading ixmp4.

https://github.com/iiasa/ixmp4/blob/70366d4f1081d2a030ca8eb52feff2976a2b6724/ixmp4/data/db/meta/model.py#L64