### PR TITLE
Introduce `run.get_by_id()`

### DIFF
--- a/ixmp4/data/abstract/run.py
+++ b/ixmp4/data/abstract/run.py
@@ -137,6 +137,26 @@ class RunRepository(
         """
         ...
 
+    def get_by_id(self, id: int) -> Run:
+        """Retrieves a Run by its id.
+
+        Parameters
+        ----------
+        id : int
+            Unique integer id.
+
+        Raises
+        ------
+        :class:`ixmp4.data.abstract.Run.NotFound`.
+            If the Run with `id` does not exist.
+
+        Returns
+        -------
+        :class:`ixmp4.data.abstract.Run`:
+            The retrieved Run.
+        """
+        ...
+
     def list(self, **kwargs: Unpack[EnumerateKwargs]) -> list[Run]:
         r"""Lists runs by specified criteria.
 

--- a/ixmp4/data/api/run.py
+++ b/ixmp4/data/api/run.py
@@ -67,6 +67,10 @@ class RunRepository(
             is_default=None,
         )
 
+    def get_by_id(self, id: int) -> Run:
+        res = self._get_by_id(id)
+        return Run(**res)
+
     def enumerate(
         self, **kwargs: Unpack[abstract.run.EnumerateKwargs]
     ) -> list[Run] | pd.DataFrame:

--- a/ixmp4/server/rest/run.py
+++ b/ixmp4/server/rest/run.py
@@ -61,3 +61,11 @@ def unset_as_default_version(
     backend: Backend = Depends(deps.get_backend),
 ) -> None:
     backend.runs.unset_as_default_version(id)
+
+
+@router.get("/{id}/", response_model=api.Run)
+def get_by_id(
+    id: int,
+    backend: Backend = Depends(deps.get_backend),
+) -> Run:
+    return backend.runs.get_by_id(id)

--- a/tests/data/test_run.py
+++ b/tests/data/test_run.py
@@ -2,6 +2,8 @@ import pandas as pd
 import pytest
 
 import ixmp4
+import ixmp4.data
+import ixmp4.data.abstract
 from ixmp4.core.exceptions import NoDefaultRunVersion
 
 from ..utils import assert_unordered_equality
@@ -54,6 +56,14 @@ class TestDataRun:
 
         run3 = platform.backend.runs.get_or_create("Model", "Scenario")
         assert run1.id == run3.id
+
+    def test_get_run_by_id(self, platform: ixmp4.Platform) -> None:
+        expected = platform.backend.runs.create("Model", "Scenario")
+        result = platform.backend.runs.get_by_id(id=expected.id)
+        assert expected.id == result.id
+
+        with pytest.raises(ixmp4.data.abstract.Run.NotFound):
+            _ = platform.backend.runs.get_by_id(id=expected.id + 1)
 
     def test_list_run(self, platform: ixmp4.Platform) -> None:
         run1 = platform.backend.runs.create("Model", "Scenario")


### PR DESCRIPTION
The second part of cleaning up #101. This exposes the `run.get_by_id()` function to all remaining data layers as it is only used by `run.clone()` (see next clean up PR) in the data/server layers (and present already in the DB layer).