### PR TITLE
Avoid superfluous DB calls from facade

### DIFF
--- a/ixmp4/core/optimization/equation.py
+++ b/ixmp4/core/optimization/equation.py
@@ -44,16 +44,16 @@ class Equation(BaseModelFacade):
         self.backend.optimization.equations.add_data(
             equation_id=self._model.id, data=data
         )
-        self._model.data = self.backend.optimization.equations.get(
+        self._model = self.backend.optimization.equations.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     def remove_data(self) -> None:
         """Removes data from an existing Equation."""
         self.backend.optimization.equations.remove_data(equation_id=self._model.id)
-        self._model.data = self.backend.optimization.equations.get(
+        self._model = self.backend.optimization.equations.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     @property
     def levels(self) -> list[float]:

--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -39,9 +39,9 @@ class IndexSet(BaseModelFacade):
         self.backend.optimization.indexsets.add_data(
             indexset_id=self._model.id, data=data
         )
-        self._model.data = self.backend.optimization.indexsets.get(
+        self._model = self.backend.optimization.indexsets.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     @property
     def run_id(self) -> int:

--- a/ixmp4/core/optimization/parameter.py
+++ b/ixmp4/core/optimization/parameter.py
@@ -44,9 +44,9 @@ class Parameter(BaseModelFacade):
         self.backend.optimization.parameters.add_data(
             parameter_id=self._model.id, data=data
         )
-        self._model.data = self.backend.optimization.parameters.get(
+        self._model = self.backend.optimization.parameters.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     @property
     def values(self) -> list[float]:

--- a/ixmp4/core/optimization/table.py
+++ b/ixmp4/core/optimization/table.py
@@ -42,9 +42,9 @@ class Table(BaseModelFacade):
     def add(self, data: dict[str, Any] | pd.DataFrame) -> None:
         """Adds data to an existing Table."""
         self.backend.optimization.tables.add_data(table_id=self._model.id, data=data)
-        self._model.data = self.backend.optimization.tables.get(
+        self._model = self.backend.optimization.tables.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     @property
     def constrained_to_indexsets(self) -> list[str]:

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -44,16 +44,16 @@ class Variable(BaseModelFacade):
         self.backend.optimization.variables.add_data(
             variable_id=self._model.id, data=data
         )
-        self._model.data = self.backend.optimization.variables.get(
+        self._model = self.backend.optimization.variables.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     def remove_data(self) -> None:
         """Removes data from an existing Variable."""
         self.backend.optimization.variables.remove_data(variable_id=self._model.id)
-        self._model.data = self.backend.optimization.variables.get(
+        self._model = self.backend.optimization.variables.get(
             run_id=self._model.run__id, name=self._model.name
-        ).data
+        )
 
     @property
     def levels(self) -> list[float]:


### PR DESCRIPTION
While working on #148, @meksor and I noted that there were always two calls to `validate_data` when adding data to a `Parameter`. This is superfluous, of course, and the culprit is in the core layer: in `parameter.add()`, we `add_data()`, but then also set `parameter._model.data`, which triggers another `validate_data()` run because that always fires when the attribute is set. 

This PR fixes that by setting `parameter._model` instead of just `.data`, also for all other relevant optimization items. This significantly boosts their performance.