### PR TITLE
Introduce `Indexset.remove_data()`

### DIFF
--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -43,6 +43,17 @@ class IndexSet(BaseModelFacade):
             run_id=self._model.run__id, name=self._model.name
         )
 
+    def remove(
+        self, data: float | int | str | list[float] | list[int] | list[str]
+    ) -> None:
+        """Removes data from an existing IndexSet."""
+        self.backend.optimization.indexsets.remove_data(
+            indexset_id=self._model.id, data=data
+        )
+        self._model = self.backend.optimization.indexsets.get(
+            run_id=self._model.run__id, name=self._model.name
+        )
+
     @property
     def run_id(self) -> int:
         return self._model.run__id

--- a/ixmp4/data/abstract/optimization/indexset.py
+++ b/ixmp4/data/abstract/optimization/indexset.py
@@ -149,3 +149,24 @@ class IndexSetRepository(
             Due to compatibility with ixmp.
         """
         ...
+
+    def remove_data(
+        self,
+        indexset_id: int,
+        data: float | int | str | List[float] | List[int] | List[str],
+    ) -> None:
+        """Removes data from an existing IndexSet.
+
+        Parameters
+        ----------
+        indexset_id : int
+            The id of the target IndexSet.
+        data : float | int | str | List[float] | List[int] | List[str]
+            The data to be removed from the IndexSet.
+
+        Returns
+        -------
+        None:
+            Due to compatibility with ixmp.
+        """
+        ...

--- a/ixmp4/data/api/optimization/indexset.py
+++ b/ixmp4/data/api/optimization/indexset.py
@@ -82,4 +82,17 @@ class IndexSetRepository(
         | List[StrictStr],
     ) -> None:
         kwargs = {"indexset_id": indexset_id, "data": data}
-        self._request("PATCH", self.prefix + str(indexset_id) + "/", json=kwargs)
+        self._request("PATCH", self.prefix + str(indexset_id) + "/data/", json=kwargs)
+
+    def remove_data(
+        self,
+        indexset_id: int,
+        data: StrictFloat
+        | StrictInt
+        | StrictStr
+        | List[StrictFloat]
+        | List[StrictInt]
+        | List[StrictStr],
+    ) -> None:
+        kwargs = {"indexset_id": indexset_id, "data": data}
+        self._request("DELETE", self.prefix + str(indexset_id) + "/data/", json=kwargs)

--- a/ixmp4/server/rest/optimization/indexset.py
+++ b/ixmp4/server/rest/optimization/indexset.py
@@ -54,12 +54,24 @@ def create(
 
 
 @autodoc
-@router.patch("/{indexset_id}/")
+@router.patch("/{indexset_id}/data/")
 def add_data(
     indexset_id: int,
     data: DataInput,
     backend: Backend = Depends(deps.get_backend),
 ) -> None:
     backend.optimization.indexsets.add_data(
+        indexset_id=indexset_id, **data.model_dump()
+    )
+
+
+@autodoc
+@router.delete("/{indexset_id}/data/")
+def remove_data(
+    indexset_id: int,
+    data: DataInput,
+    backend: Backend = Depends(deps.get_backend),
+) -> None:
+    backend.optimization.indexsets.remove_data(
         indexset_id=indexset_id, **data.model_dump()
     )

--- a/tests/core/test_optimization_indexset.py
+++ b/tests/core/test_optimization_indexset.py
@@ -96,6 +96,30 @@ class TestCoreIndexset:
         assert indexset_4.data == test_data_3
         assert type(indexset_4.data[0]).__name__ == "int"
 
+    def test_remove_elements(self, platform: ixmp4.Platform) -> None:
+        run = platform.runs.create("Model", "Scenario")
+        test_data = ["do", "re", "mi", "fa", "so", "la", "ti"]
+        indexset_1 = run.optimization.indexsets.create("Indexset 1")
+        indexset_1.add(test_data)
+
+        # Test removing multiple arbitrary known data
+        remove_data = ["do", "mi", "la", "ti"]
+        expected = [data for data in test_data if data not in remove_data]
+        indexset_1.remove(data=remove_data)
+
+        assert indexset_1.data == expected
+
+        # Test removing single item
+        expected.remove("fa")
+        indexset_1.remove(data="fa")
+
+        assert indexset_1.data == expected
+
+        # Test removing all remaining data
+        indexset_1.remove(data=["so", "re"])
+
+        assert indexset_1.data == []
+
     def test_list_indexsets(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset_1, indexset_2 = create_indexsets_for_run(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,11 @@
+from collections.abc import Generator
+from contextlib import contextmanager, nullcontext
+from itertools import chain
+from typing import Any
+
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 
 # Import this from typing when dropping 3.11
 from typing_extensions import TypedDict, Unpack
@@ -34,3 +40,72 @@ def create_indexsets_for_run(
         )
         for i in range(offset, offset + amount)
     )
+
+
+# Thanks to khaeru for writing this for ixmp
+@contextmanager
+def assert_logs(
+    caplog: pytest.LogCaptureFixture,
+    message_or_messages: str | list[str],
+    at_level: int | str | None = None,
+) -> Generator[None, Any, None]:
+    """Assert that *message_or_messages* appear in logs.
+
+    Use assert_logs as a context manager for a statement that is expected to trigger
+    certain log messages. assert_logs checks that these messages are generated.
+
+    Example
+    -------
+
+    def test_foo(caplog):
+        with assert_logs(caplog, 'a message'):
+            logging.getLogger(__name__).info('this is a message!')
+
+    Parameters
+    ----------
+    caplog : pytest.LogCaptureFixture
+        The pytest caplog fixture.
+    message_or_messages : str or list of str
+        String(s) that must appear in log messages.
+    at_level : int or str, optional
+        Messages must appear on 'ixmp4' or a sub-logger with at least this level.
+    """
+    __tracebackhide__ = True
+
+    # Wrap a string in a list
+    expected = (
+        [message_or_messages]
+        if isinstance(message_or_messages, str)
+        else message_or_messages
+    )
+
+    # Record the number of records prior to the managed block
+    first = len(caplog.records)
+
+    # Use the pytest caplog fixture's built-in context manager to temporarily set
+    # the level of the 'ixmp4' logger if a specific level is requested
+    # Otherwise, ctx does nothing
+    ctx = (
+        caplog.at_level(at_level, logger="ixmp4")
+        if at_level is not None
+        else nullcontext()
+    )
+
+    try:
+        with ctx:
+            yield  # Nothing provided to the managed block
+    finally:
+        # List of bool indicating whether each of `expected` was found
+        found = [any(e in msg for msg in caplog.messages[first:]) for e in expected]
+
+        if not all(found):
+            # Format a description of the missing messages
+            lines = chain(
+                ["Did not log:"],
+                [f"    {repr(msg)}" for i, msg in enumerate(expected) if not found[i]],
+                ["among:"],
+                ["    []"]
+                if len(caplog.records) == first
+                else [f"    {repr(msg)}" for msg in caplog.messages[first:]],
+            )
+            pytest.fail("\n".join(lines))


### PR DESCRIPTION
For iiasa/ixmp#557, I will next need functions that allow removal of individual keys from Indexsets, Tables, and Parameters. This PR adds such a function for Indexsets.

While working on that function, I found myself thinking: wouldn't it be nice to get some sort of warning if you're trying to remove data from an Indexset, but that Indexset doesn't have that data? This can be checked easily in sqlalchemy, so I added `log.info()` messages for two cases. 
In order to test that these messages are actually logged, I copied over the `assert_logs()` utility function we have in ixmp and enhanced it with some type hints. Thanks to @khaeru for writing that in the first place!

> [!NOTE]
> This PR looks larger than it is because I swapped the order of the tests in the `data/` subfolder to be consistent with the other optimization tests. There's no need to verify `test_list_indexset` and `test_tabulate_indexset` again.