### PR TITLE
Fix not enough column names used for same `IndexSet`

### DIFF
--- a/ixmp4/data/db/optimization/equation/repository.py
+++ b/ixmp4/data/db/optimization/equation/repository.py
@@ -48,14 +48,16 @@ class EquationRepository(
     ) -> Equation:
         equation = Equation(name=name, run__id=run_id)
 
-        indexsets = self.backend.optimization.indexsets.list(
-            name__in=constrained_to_indexsets, run_id=run_id
-        )
-
-        for i in range(len(indexsets)):
+        indexsets = {
+            indexset: self.backend.optimization.indexsets.get(
+                run_id=run_id, name=indexset
+            )
+            for indexset in set(constrained_to_indexsets)
+        }
+        for i in range(len(constrained_to_indexsets)):
             _ = EquationIndexsetAssociation(
                 equation=equation,
-                indexset=indexsets[i],
+                indexset=indexsets[constrained_to_indexsets[i]],
                 column_name=column_names[i] if column_names else None,
             )
 

--- a/ixmp4/data/db/optimization/parameter/repository.py
+++ b/ixmp4/data/db/optimization/parameter/repository.py
@@ -53,13 +53,16 @@ class ParameterRepository(
     ) -> Parameter:
         parameter = Parameter(name=name, run__id=run_id)
 
-        indexsets = self.backend.optimization.indexsets.list(
-            name__in=constrained_to_indexsets, run_id=run_id
-        )
-        for i in range(len(indexsets)):
+        indexsets = {
+            indexset: self.backend.optimization.indexsets.get(
+                run_id=run_id, name=indexset
+            )
+            for indexset in set(constrained_to_indexsets)
+        }
+        for i in range(len(constrained_to_indexsets)):
             _ = ParameterIndexsetAssociation(
                 parameter=parameter,
-                indexset=indexsets[i],
+                indexset=indexsets[constrained_to_indexsets[i]],
                 column_name=column_names[i] if column_names else None,
             )
 

--- a/ixmp4/data/db/optimization/table/repository.py
+++ b/ixmp4/data/db/optimization/table/repository.py
@@ -50,13 +50,17 @@ class TableRepository(
     ) -> Table:
         table = Table(name=name, run__id=run_id)
 
-        indexsets = self.backend.optimization.indexsets.list(
-            name__in=constrained_to_indexsets, run_id=run_id
-        )
-        for i in range(len(indexsets)):
+        # TODO fix this for other items and add tests for all, too
+        indexsets = {
+            indexset: self.backend.optimization.indexsets.get(
+                run_id=run_id, name=indexset
+            )
+            for indexset in set(constrained_to_indexsets)
+        }
+        for i in range(len(constrained_to_indexsets)):
             _ = TableIndexsetAssociation(
                 table=table,
-                indexset=indexsets[i],
+                indexset=indexsets[constrained_to_indexsets[i]],
                 column_name=column_names[i] if column_names else None,
             )
 

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -49,14 +49,16 @@ class VariableRepository(
         variable = Variable(name=name, run__id=run_id)
 
         if constrained_to_indexsets:
-            indexsets = self.backend.optimization.indexsets.list(
-                name__in=constrained_to_indexsets, run_id=run_id
-            )
-
-            for i in range(len(indexsets)):
+            indexsets = {
+                indexset: self.backend.optimization.indexsets.get(
+                    run_id=run_id, name=indexset
+                )
+                for indexset in set(constrained_to_indexsets)
+            }
+            for i in range(len(constrained_to_indexsets)):
                 _ = VariableIndexsetAssociation(
                     variable=variable,
-                    indexset=indexsets[i],
+                    indexset=indexsets[constrained_to_indexsets[i]],
                     column_name=column_names[i] if column_names else None,
                 )
 

--- a/tests/core/test_optimization_table.py
+++ b/tests/core/test_optimization_table.py
@@ -42,39 +42,39 @@ class TestCoreTable:
         run = platform.runs.create("Model", "Scenario")
 
         # Test normal creation
-        indexset, indexset_2 = tuple(
+        indexset_1, indexset_2 = tuple(
             IndexSet(_backend=platform.backend, _model=model)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
         table = run.optimization.tables.create(
             "Table 1",
-            constrained_to_indexsets=[indexset.name],
+            constrained_to_indexsets=[indexset_1.name],
         )
         assert table.run_id == run.id
         assert table.id == 1
         assert table.name == "Table 1"
         assert table.data == {}
-        assert table.indexset_names == [indexset.name]
+        assert table.indexset_names == [indexset_1.name]
         assert table.column_names is None
 
         # Test duplicate name raises
         with pytest.raises(Table.NotUnique):
             _ = run.optimization.tables.create(
-                "Table 1", constrained_to_indexsets=[indexset.name]
+                "Table 1", constrained_to_indexsets=[indexset_1.name]
             )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
         with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
             _ = run.optimization.tables.create(
                 name="Table 2",
-                constrained_to_indexsets=[indexset.name],
+                constrained_to_indexsets=[indexset_1.name],
                 column_names=["Dimension 1", "Dimension 2"],
             )
 
         # Test columns_names are used for names if given
         table_2 = run.optimization.tables.create(
             name="Table 2",
-            constrained_to_indexsets=[indexset.name],
+            constrained_to_indexsets=[indexset_1.name],
             column_names=["Column 1"],
         )
         table_2.column_names == ["Column 1"]
@@ -85,9 +85,19 @@ class TestCoreTable:
         ):
             _ = run.optimization.tables.create(
                 name="Table 3",
-                constrained_to_indexsets=[indexset.name, indexset.name],
+                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
                 column_names=["Column 1", "Column 1"],
             )
+
+        # Test using different column names for same indexset
+        table_3 = run.optimization.tables.create(
+            name="Table 3",
+            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+            column_names=["Column 1", "Column 2"],
+        )
+
+        assert table_3.column_names == ["Column 1", "Column 2"]
+        assert table_3.indexset_names == [indexset_1.name, indexset_1.name]
 
     def test_get_table(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")

--- a/tests/data/test_optimization_parameter.py
+++ b/tests/data/test_optimization_parameter.py
@@ -40,27 +40,27 @@ class TestDataOptimizationParameter:
         run = platform.backend.runs.create("Model", "Scenario")
 
         # Test normal creation
-        indexset, indexset_2 = create_indexsets_for_run(
+        indexset_1, indexset_2 = create_indexsets_for_run(
             platform=platform, run_id=run.id
         )
         parameter = platform.backend.optimization.parameters.create(
             run_id=run.id,
             name="Parameter",
-            constrained_to_indexsets=[indexset.name],
+            constrained_to_indexsets=[indexset_1.name],
         )
 
         assert parameter.run__id == run.id
         assert parameter.name == "Parameter"
         assert parameter.data == {}  # JsonDict type currently requires a dict, not None
         assert parameter.column_names is None
-        assert parameter.indexset_names == [indexset.name]
+        assert parameter.indexset_names == [indexset_1.name]
 
         # Test duplicate name raises
         with pytest.raises(Parameter.NotUnique):
             _ = platform.backend.optimization.parameters.create(
                 run_id=run.id,
                 name="Parameter",
-                constrained_to_indexsets=[indexset.name],
+                constrained_to_indexsets=[indexset_1.name],
             )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
@@ -68,7 +68,7 @@ class TestDataOptimizationParameter:
             _ = platform.backend.optimization.parameters.create(
                 run_id=run.id,
                 name="Parameter 2",
-                constrained_to_indexsets=[indexset.name],
+                constrained_to_indexsets=[indexset_1.name],
                 column_names=["Dimension 1", "Dimension 2"],
             )
 
@@ -76,7 +76,7 @@ class TestDataOptimizationParameter:
         parameter_2 = platform.backend.optimization.parameters.create(
             run_id=run.id,
             name="Parameter 2",
-            constrained_to_indexsets=[indexset.name],
+            constrained_to_indexsets=[indexset_1.name],
             column_names=["Column 1"],
         )
         assert parameter_2.column_names == ["Column 1"]
@@ -88,9 +88,20 @@ class TestDataOptimizationParameter:
             _ = platform.backend.optimization.parameters.create(
                 run_id=run.id,
                 name="Parameter 3",
-                constrained_to_indexsets=[indexset.name, indexset.name],
+                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
                 column_names=["Column 1", "Column 1"],
             )
+
+        # Test using different column names for same indexset
+        parameter_3 = platform.backend.optimization.parameters.create(
+            run_id=run.id,
+            name="Parameter 3",
+            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+            column_names=["Column 1", "Column 2"],
+        )
+
+        assert parameter_3.column_names == ["Column 1", "Column 2"]
+        assert parameter_3.indexset_names == [indexset_1.name, indexset_1.name]
 
     def test_get_parameter(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")

--- a/tests/data/test_optimization_table.py
+++ b/tests/data/test_optimization_table.py
@@ -88,6 +88,17 @@ class TestDataOptimizationTable:
                 column_names=["Column 1", "Column 1"],
             )
 
+        # Test using different column names for same indexset
+        table_3 = platform.backend.optimization.tables.create(
+            run_id=run.id,
+            name="Table 3",
+            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+            column_names=["Column 1", "Column 2"],
+        )
+
+        assert table_3.column_names == ["Column 1", "Column 2"]
+        assert table_3.indexset_names == [indexset_1.name, indexset_1.name]
+
     def test_get_table(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         _, _ = create_indexsets_for_run(platform=platform, run_id=run.id)


### PR DESCRIPTION
#156 and #157 introduce a bug: when e.g. a `Table` is created with some columns linked to the same `IndexSet`, but distinct `column_names`, we no longer used these column names properly (i.e. we used too few of them). This PR fixes the bug and adds a test to all relevant classes to prevent this in the future.

> [!NOTE]
> We currently check that if `column_names` are given, they must be unique. However, I've been wondering if we should also check that if `constrained_to_indexsets` are not unique, `column_names` must be given. Otherwise, columns could end up with the same name and a subsequent data-adding operation (or so) won't know how to deal with this.