### PR TITLE
Fix actual return type of `column_names` property

### DIFF
--- a/ixmp4/data/db/optimization/equation/model.py
+++ b/ixmp4/data/db/optimization/equation/model.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar
 
 # TODO Why do we need this only for Equations?
 if TYPE_CHECKING:
@@ -65,7 +65,8 @@ class Equation(base.BaseModel):
 
     @property
     def column_names(self) -> list[str] | None:
-        return cast(list[str], self._column_names) if any(self._column_names) else None
+        names = [name for name in self._column_names if name]
+        return names if bool(names) else None
 
     __table_args__ = (db.UniqueConstraint("name", "run__id"),)
 

--- a/ixmp4/data/db/optimization/parameter/model.py
+++ b/ixmp4/data/db/optimization/parameter/model.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from ixmp4 import db
 from ixmp4.core.exceptions import OptimizationDataValidationError
@@ -61,6 +61,7 @@ class Parameter(base.BaseModel):
 
     @property
     def column_names(self) -> list[str] | None:
-        return cast(list[str], self._column_names) if any(self._column_names) else None
+        names = [name for name in self._column_names if name]
+        return names if bool(names) else None
 
     __table_args__ = (db.UniqueConstraint("name", "run__id"),)

--- a/ixmp4/data/db/optimization/table/model.py
+++ b/ixmp4/data/db/optimization/table/model.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from ixmp4 import db
 from ixmp4.core.exceptions import OptimizationDataValidationError
@@ -61,6 +61,7 @@ class Table(base.BaseModel):
 
     @property
     def column_names(self) -> list[str] | None:
-        return cast(list[str], self._column_names) if any(self._column_names) else None
+        names = [name for name in self._column_names if name]
+        return names if bool(names) else None
 
     __table_args__ = (db.UniqueConstraint("name", "run__id"),)

--- a/ixmp4/data/db/optimization/variable/model.py
+++ b/ixmp4/data/db/optimization/variable/model.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from ixmp4 import db
 from ixmp4.core.exceptions import (
@@ -69,7 +69,8 @@ class OptimizationVariable(base.BaseModel):
 
     @property
     def column_names(self) -> list[str] | None:
-        return cast(list[str], self._column_names) if any(self._column_names) else None
+        names = [name for name in self._column_names if name]
+        return names if bool(names) else None
 
     __table_args__ = (db.UniqueConstraint("name", "run__id"),)
 

--- a/tests/core/test_optimization_equation.py
+++ b/tests/core/test_optimization_equation.py
@@ -63,6 +63,11 @@ class TestCoreEquation:
             _ = run.optimization.equations.create(
                 "Equation", constrained_to_indexsets=[indexset.name]
             )
+            _ = run.optimization.equations.create(
+                "Equation",
+                constrained_to_indexsets=[indexset_1.name],
+                column_names=["Column 1"],
+            )
 
         # Test mismatch in constrained_to_indexsets and column_names raises
         with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
@@ -247,6 +252,22 @@ class TestCoreEquation:
         assert_unordered_equality(
             expected, pd.DataFrame(equation_4.data), check_dtype=False
         )
+
+        # Test adding with column_names
+        equation_5 = run.optimization.equations.create(
+            name="Equation 5",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        test_data_8 = {
+            "Column 1": ["", "", "foo", "foo", "bar", "bar"],
+            "Column 2": [3, 1, 2, 1, 2, 3],
+            "levels": [6, 5, 4, 3, 2, 1],
+            "marginals": [0.5] * 6,
+        }
+        equation_5.add(data=test_data_8)
+
+        assert equation_5.data == test_data_8
 
     def test_equation_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")

--- a/tests/core/test_optimization_parameter.py
+++ b/tests/core/test_optimization_parameter.py
@@ -239,6 +239,22 @@ class TestCoreParameter:
         )
         assert_unordered_equality(expected, pd.DataFrame(parameter_4.data))
 
+        # Test adding with column_names
+        parameter_5 = run.optimization.parameters.create(
+            name="Parameter 5",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        test_data_8 = {
+            "Column 1": ["", "", "foo", "foo", "bar", "bar"],
+            "Column 2": [3, 1, 2, 1, 2, 3],
+            "values": [6, 5, 4, 3, 2, 1],
+            "units": [unit.name] * 6,
+        }
+        parameter_5.add(data=test_data_8)
+
+        assert parameter_5.data == test_data_8
+
     def test_list_parameter(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         create_indexsets_for_run(platform=platform, run_id=run.id)

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -277,6 +277,22 @@ class TestCoreVariable:
             variable_5 = run.optimization.variables.create("Variable 5")
             variable_5.add(data={"foo": ["bar"], "levels": [1], "marginals": [0]})
 
+        # Test adding with column_names
+        variable_6 = run.optimization.variables.create(
+            name="Variable 6",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        test_data_8 = {
+            "Column 1": ["", "", "foo", "foo", "bar", "bar"],
+            "Column 2": [3, 1, 2, 1, 2, 3],
+            "levels": [6, 5, 4, 3, 2, 1],
+            "marginals": [0.5] * 6,
+        }
+        variable_6.add(data=test_data_8)
+
+        assert variable_6.data == test_data_8
+
     def test_variable_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset = run.optimization.indexsets.create("Indexset")

--- a/tests/data/test_optimization_equation.py
+++ b/tests/data/test_optimization_equation.py
@@ -269,6 +269,28 @@ class TestDataOptimizationEquation:
             expected, pd.DataFrame(equation_4.data), check_dtype=False
         )
 
+        # Test adding with column_names
+        equation_5 = platform.backend.optimization.equations.create(
+            run_id=run.id,
+            name="Equation 5",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        test_data_8 = {
+            "Column 1": ["", "", "foo", "foo", "bar", "bar"],
+            "Column 2": [3, 1, 2, 1, 2, 3],
+            "levels": [6, 5, 4, 3, 2, 1],
+            "marginals": [0.5] * 6,
+        }
+        platform.backend.optimization.equations.add_data(
+            equation_id=equation_5.id, data=test_data_8
+        )
+        equation_5 = platform.backend.optimization.equations.get(
+            run_id=run.id, name="Equation 5"
+        )
+
+        assert equation_5.data == test_data_8
+
     def test_equation_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(

--- a/tests/data/test_optimization_parameter.py
+++ b/tests/data/test_optimization_parameter.py
@@ -269,6 +269,28 @@ class TestDataOptimizationParameter:
         )
         assert_unordered_equality(expected, pd.DataFrame(parameter_4.data))
 
+        # Test adding with column_names
+        parameter_3 = platform.backend.optimization.parameters.create(
+            run_id=run.id,
+            name="Parameter 3",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        test_data_8 = {
+            "Column 1": ["", "", "foo", "foo", "bar", "bar"],
+            "Column 2": [3, 1, 2, 1, 2, 3],
+            "values": [6, 5, 4, 3, 2, 1],
+            "units": [unit.name] * 6,
+        }
+        platform.backend.optimization.parameters.add_data(
+            parameter_id=parameter_3.id, data=test_data_8
+        )
+        parameter_3 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name="Parameter 3"
+        )
+
+        assert parameter_3.data == test_data_8
+
     def test_list_parameter(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         indexset, indexset_2 = create_indexsets_for_run(

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -292,6 +292,28 @@ class TestDataOptimizationVariable:
             expected, pd.DataFrame(variable_4.data), check_dtype=False
         )
 
+        # Test adding with column_names
+        variable_5 = platform.backend.optimization.variables.create(
+            run_id=run.id,
+            name="Variable 5",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        test_data_8 = {
+            "Column 1": ["", "", "foo", "foo", "bar", "bar"],
+            "Column 2": [3, 1, 2, 1, 2, 3],
+            "levels": [6, 5, 4, 3, 2, 1],
+            "marginals": [0.5] * 6,
+        }
+        platform.backend.optimization.variables.add_data(
+            variable_id=variable_5.id, data=test_data_8
+        )
+        variable_5 = platform.backend.optimization.variables.get(
+            run_id=run.id, name="Variable 5"
+        )
+
+        assert variable_5.data == test_data_8
+
     def test_variable_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         indexset = platform.backend.optimization.indexsets.create(run.id, "Indexset")


### PR DESCRIPTION
Uncovered another bug introduced by #156 and #157: previously, I returned the `column_names` property as a `cast(list[str], ...)` of the underlying sqlalchemy collection. Mypy understood this just fine, but the actual type of the return object was not changed, it was just made to look that way. This created an error in `pd.DataFrame().set_index()` as this function does not know how to handle sqlalchemy's `_AssociationList` objects. 
This PR fixes this bug by explicitly creating the return object as a `list[str]`. The `for` loop should be fine as no item should have more than 12 `column_names` in practice. It also adds tests to ensure this behaviour doesn't break again in the future.