### PR TITLE
Make `Equation.indexsets` optional

### DIFF
--- a/ixmp4/core/optimization/equation.py
+++ b/ixmp4/core/optimization/equation.py
@@ -61,7 +61,7 @@ class Equation(BaseModelFacade):
         return cast(list[float], self._model.data.get("marginals", []))
 
     @property
-    def indexset_names(self) -> list[str]:
+    def indexset_names(self) -> list[str] | None:
         return self._model.indexset_names
 
     @property
@@ -117,7 +117,7 @@ class EquationRepository(
     def create(
         self,
         name: str,
-        constrained_to_indexsets: list[str],
+        constrained_to_indexsets: list[str] | None = None,
         column_names: list[str] | None = None,
     ) -> Equation:
         return super().create(

--- a/ixmp4/data/abstract/optimization/equation.py
+++ b/ixmp4/data/abstract/optimization/equation.py
@@ -23,7 +23,7 @@ class Equation(base.BaseModel, Protocol):
     """Unique name of the Equation."""
     data: types.JsonDict
     """Data stored in the Equation."""
-    indexset_names: types.Mapped[list[str]]
+    indexset_names: types.Mapped[list[str] | None]
     """List of the names of the IndexSets the Equation is bound to."""
     column_names: types.Mapped[list[str] | None]
     """List of the Equation's column names, if distinct from the IndexSet names."""
@@ -54,7 +54,7 @@ class EquationRepository(
         self,
         run_id: int,
         name: str,
-        constrained_to_indexsets: list[str],
+        constrained_to_indexsets: list[str] | None = None,
         column_names: list[str] | None = None,
     ) -> Equation:
         """Creates an Equation.
@@ -71,9 +71,10 @@ class EquationRepository(
             defined.
         name : str
             The unique name of the Equation.
-        constrained_to_indexsets : list[str]
+        constrained_to_indexsets : list[str] | None = None
             List of :class:`ixmp4.data.abstract.optimization.IndexSet` names that define
-            the allowed contents of the Equation's columns.
+            the allowed contents of the Equation's columns. If None, no data
+            can be added beyond `levels` and `marginals`!
         column_names: list[str] | None = None
             Optional list of names to use as column names. If given, overwrites the
             names inferred from `constrained_to_indexsets`.

--- a/ixmp4/data/api/optimization/equation.py
+++ b/ixmp4/data/api/optimization/equation.py
@@ -24,7 +24,7 @@ class Equation(base.BaseModel):
     id: int
     name: str
     data: dict[str, list[float] | list[int] | list[str]]
-    indexset_names: list[str]
+    indexset_names: list[str] | None
     column_names: list[str] | None
     run__id: int
 
@@ -55,7 +55,7 @@ class EquationRepository(
         self,
         run_id: int,
         name: str,
-        constrained_to_indexsets: list[str],
+        constrained_to_indexsets: list[str] | None = None,
         column_names: list[str] | None = None,
     ) -> Equation:
         return super().create(

--- a/ixmp4/data/db/optimization/equation/model.py
+++ b/ixmp4/data/db/optimization/equation/model.py
@@ -65,8 +65,9 @@ class Equation(base.BaseModel):
     )
 
     @property
-    def indexset_names(self) -> list[str]:
-        return [indexset.name for indexset in self._indexsets]
+    def indexset_names(self) -> list[str] | None:
+        names = [indexset.name for indexset in self._indexsets]
+        return names if bool(names) else None
 
     @property
     def column_names(self) -> list[str] | None:

--- a/ixmp4/data/db/optimization/parameter/repository.py
+++ b/ixmp4/data/db/optimization/parameter/repository.py
@@ -158,11 +158,7 @@ class ParameterRepository(
                     message=f"'{unit_name}' is not defined for this Platform!"
                 ) from e
 
-        index_list = (
-            parameter.column_names
-            if parameter.column_names
-            else parameter.indexset_names
-        )
+        index_list = parameter.column_names or parameter.indexset_names
         existing_data = pd.DataFrame(parameter.data)
         if not existing_data.empty:
             existing_data.set_index(index_list, inplace=True)
@@ -185,11 +181,7 @@ class ParameterRepository(
             return
 
         parameter = self.get_by_id(id=id)
-        index_list = (
-            parameter.column_names
-            if parameter.column_names
-            else parameter.indexset_names
-        )
+        index_list = parameter.column_names or parameter.indexset_names
         existing_data = pd.DataFrame(parameter.data)
         if not existing_data.empty:
             existing_data.set_index(index_list, inplace=True)

--- a/ixmp4/data/db/optimization/table/repository.py
+++ b/ixmp4/data/db/optimization/table/repository.py
@@ -151,7 +151,7 @@ class TableRepository(
             return
 
         table = self.get_by_id(id=id)
-        index_list = table.column_names if table.column_names else table.indexset_names
+        index_list = table.column_names or table.indexset_names
         existing_data = pd.DataFrame(table.data)
         if not existing_data.empty:
             existing_data.set_index(index_list, inplace=True)

--- a/ixmp4/data/db/optimization/variable/model.py
+++ b/ixmp4/data/db/optimization/variable/model.py
@@ -66,11 +66,8 @@ class OptimizationVariable(base.BaseModel):
 
     @property
     def indexset_names(self) -> list[str] | None:
-        return (
-            [indexset.name for indexset in self._indexsets]
-            if len(self._indexsets) > 0
-            else None
-        )
+        names = [indexset.name for indexset in self._indexsets]
+        return names if bool(names) else None
 
     @property
     def column_names(self) -> list[str] | None:

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -154,9 +154,7 @@ class VariableRepository(
                 f"{', '.join(missing_columns)}!"
             )
 
-        index_list = (
-            variable.column_names if variable.column_names else variable.indexset_names
-        )
+        index_list = variable.column_names or variable.indexset_names
         existing_data = pd.DataFrame(variable.data)
         if index_list:
             data = data.set_index(index_list)

--- a/ixmp4/data/db/region/repository.py
+++ b/ixmp4/data/db/region/repository.py
@@ -66,8 +66,7 @@ class RegionRepository(
     def get(self, name: str) -> Region:
         exc = self.select().where(Region.name == name)
         try:
-            region: Region = self.session.execute(exc).scalar_one()
-            return region
+            return self.session.execute(exc).scalar_one()
         except NoResultFound:
             raise Region.NotFound
 

--- a/ixmp4/server/rest/optimization/equation.py
+++ b/ixmp4/server/rest/optimization/equation.py
@@ -20,7 +20,7 @@ router: APIRouter = APIRouter(
 class EquationCreateInput(BaseModel):
     name: str
     run_id: int
-    constrained_to_indexsets: list[str]
+    constrained_to_indexsets: list[str] | None
     column_names: list[str] | None
 
 

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -73,6 +73,12 @@ class TestCoreVariable:
             _ = run.optimization.variables.create(
                 "Variable", constrained_to_indexsets=[indexset_1.name]
             )
+        with pytest.raises(OptimizationVariable.NotUnique):
+            _ = run.optimization.variables.create(
+                "Variable",
+                constrained_to_indexsets=[indexset_1.name],
+                column_names=["Column 1"],
+            )
 
         # Test that giving column_names, but not constrained_to_indexsets raises
         with pytest.raises(

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -73,6 +73,13 @@ class TestDataOptimizationVariable:
                 name="Variable",
                 constrained_to_indexsets=[indexset_1.name],
             )
+        with pytest.raises(OptimizationVariable.NotUnique):
+            _ = platform.backend.optimization.variables.create(
+                run_id=run.id,
+                name="Variable",
+                constrained_to_indexsets=[indexset_1.name],
+                column_names=["Column 1"],
+            )
 
         # Test that giving column_names, but not constrained_to_indexsets raises
         with pytest.raises(


### PR DESCRIPTION
Working on the ixmp4 shim, I discovered that our assumption that `Equation`s must always be constrained to `IndexSet`s is wrong: in message_ix, there are [numerous examples of `Equation`s not linked to `IndexSet`s](https://github.com/iiasa/message_ix/blob/main/message_ix/models.py#L680-L712).

This PR includes some minor improvements to the code, but mainly makes the `Equation.indexsets` attribute optional.

### TODO

- ~[ ] I'm not sure the changes here need their own DB migration. It looks like only an ORM attribute/property is affected, but make sure that's true; otherwise, include the migrations.~
  `alembic check` tells me there are no new upgrade operations for this PR :) 