### PR TITLE
Expose `list_docs()` in the facade & enable `list_docs(id__in=...)`

### DIFF
--- a/ixmp4/core/iamc/variable.py
+++ b/ixmp4/core/iamc/variable.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from datetime import datetime
 from typing import ClassVar
 
@@ -111,3 +112,13 @@ class VariableRepository(BaseFacade):
             return None
         except DocsModel.NotFound:
             return None
+
+    def list_docs(
+        self, id: int | None = None, id__in: Iterable[int] | None = None
+    ) -> Iterable[str]:
+        return [
+            item.description
+            for item in self.backend.iamc.variables.docs.list(
+                dimension_id=id, dimension_id__in=id__in
+            )
+        ]

--- a/ixmp4/core/model.py
+++ b/ixmp4/core/model.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from datetime import datetime
 from typing import ClassVar
 
@@ -112,3 +113,13 @@ class ModelRepository(BaseFacade):
             return None
         except DocsModel.NotFound:
             return None
+
+    def list_docs(
+        self, id: int | None = None, id__in: Iterable[int] | None = None
+    ) -> Iterable[str]:
+        return [
+            item.description
+            for item in self.backend.models.docs.list(
+                dimension_id=id, dimension_id__in=id__in
+            )
+        ]

--- a/ixmp4/core/region.py
+++ b/ixmp4/core/region.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from datetime import datetime
 
 import pandas as pd
@@ -151,3 +152,13 @@ class RegionRepository(BaseFacade):
             return None
         except DocsModel.NotFound:
             return None
+
+    def list_docs(
+        self, id: int | None = None, id__in: Iterable[int] | None = None
+    ) -> Iterable[str]:
+        return [
+            item.description
+            for item in self.backend.regions.docs.list(
+                dimension_id=id, dimension_id__in=id__in
+            )
+        ]

--- a/ixmp4/core/scenario.py
+++ b/ixmp4/core/scenario.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from datetime import datetime
 from typing import ClassVar
 
@@ -112,3 +113,13 @@ class ScenarioRepository(BaseFacade):
             return None
         except DocsModel.NotFound:
             return None
+
+    def list_docs(
+        self, id: int | None = None, id__in: Iterable[int] | None = None
+    ) -> Iterable[str]:
+        return [
+            item.description
+            for item in self.backend.scenarios.docs.list(
+                dimension_id=id, dimension_id__in=id__in
+            )
+        ]

--- a/ixmp4/core/unit.py
+++ b/ixmp4/core/unit.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from datetime import datetime
 
 import pandas as pd
@@ -131,3 +132,13 @@ class UnitRepository(BaseFacade):
             return None
         except DocsModel.NotFound:
             return None
+
+    def list_docs(
+        self, id: int | None = None, id__in: Iterable[int] | None = None
+    ) -> Iterable[str]:
+        return [
+            item.description
+            for item in self.backend.units.docs.list(
+                dimension_id=id, dimension_id__in=id__in
+            )
+        ]

--- a/ixmp4/data/abstract/docs.py
+++ b/ixmp4/data/abstract/docs.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Protocol
 
 from ixmp4.data import types
@@ -79,14 +80,22 @@ class DocsRepository(base.Retriever, base.Deleter, base.Enumerator, Protocol):
         """
         ...
 
-    def list(self, *, dimension_id: int | None = None) -> list[Docs]:
+    def list(
+        self,
+        *,
+        dimension_id: int | None = None,
+        dimension_id__in: Iterable[int] | None = None,
+    ) -> list[Docs]:
         """Lists documentations.
 
         Parameters
         ----------
-        dimension_id : int
+        dimension_id : int or None
             The id of an object in any dimension. If supplied only one result will be
             returned.
+        dimension_id__in : list[int] or None
+            A list of ids of objects in any one dimension. If supplied, only these
+            objects will be returned.
 
         Returns
         -------

--- a/ixmp4/data/api/base.py
+++ b/ixmp4/data/api/base.py
@@ -42,7 +42,7 @@ JsonType: TypeAlias = Mapping[
     | None,
 ]
 ParamType: TypeAlias = dict[
-    str, bool | int | str | list[int] | Mapping[str, Any] | None
+    str, bool | int | str | list[int] | Iterable[int] | Mapping[str, Any] | None
 ]
 _RequestParamType: TypeAlias = Mapping[
     str,
@@ -427,7 +427,10 @@ class GetKwargs(TypedDict, total=False):
 class Retriever(BaseRepository[ModelType]):
     def get(self, **kwargs: Unpack[GetKwargs]) -> ModelType:
         _kwargs = cast(
-            dict[str, bool | int | str | list[int] | Mapping[str, Any] | None],
+            dict[
+                str,
+                bool | int | str | list[int] | Iterable[int] | Mapping[str, Any] | None,
+            ],
             kwargs,
         )
         list_ = (

--- a/ixmp4/data/api/docs.py
+++ b/ixmp4/data/api/docs.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import ClassVar
 
 import pandas as pd
@@ -45,8 +46,15 @@ class DocsRepository(
     def enumerate(self, dimension_id: int | None = None) -> list[Docs] | pd.DataFrame:
         return super().enumerate(dimension_id=dimension_id)
 
-    def list(self, *, dimension_id: int | None = None) -> list[Docs]:
-        return super()._list(params={"dimension_id": dimension_id})
+    def list(
+        self,
+        *,
+        dimension_id: int | None = None,
+        dimension_id__in: Iterable[int] | None = None,
+    ) -> list[Docs]:
+        return super()._list(
+            params={"dimension_id": dimension_id, "dimension_id__in": dimension_id__in}
+        )
 
     def delete(self, dimension_id: int) -> None:
         super().delete(dimension_id)

--- a/ixmp4/data/db/base.py
+++ b/ixmp4/data/db/base.py
@@ -208,6 +208,7 @@ class CheckAccessKwargs(TypedDict, total=False):
 class SelectCountKwargs(abstract.HasNameFilter, total=False):
     default_only: bool | None
     dimension_id: int | None
+    dimension_id__in: Iterable[int] | None
     id__in: set[int]
     is_default: bool | None
     join_parameters: bool | None
@@ -367,6 +368,7 @@ class EnumerateKwargs(TypedDict):
 
 class CountKwargs(abstract.HasNameFilter, total=False):
     dimension_id: int | None
+    dimension_id__in: Iterable[int] | None
     _filter: filters.BaseFilter
     join_parameters: bool | None
     join_runs: bool | None

--- a/ixmp4/data/db/docs.py
+++ b/ixmp4/data/db/docs.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from typing import ClassVar, TypeVar
 
@@ -11,6 +12,8 @@ from ixmp4.data import abstract, types
 
 from ..auth.decorators import guard
 from . import base
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractDocs(base.BaseModel):
@@ -70,7 +73,13 @@ class BaseDocsRepository(
         # TODO Should we enforce that only one of these filters can be active?
         if dimension_id is not None:
             _exc = _exc.where(self.model_class.dimension__id == dimension_id)
-        elif dimension_id__in is not None:
+        if dimension_id__in is not None:
+            if dimension_id and dimension_id not in dimension_id__in:
+                logger.warning(
+                    "Applying incompatible filters to select for docs: "
+                    f"dimension_id '{dimension_id}' is not in dimension_id__in "
+                    f"{dimension_id__in}!"
+                )
             _exc = _exc.where(self.model_class.dimension__id.in_(dimension_id__in))
 
         return _exc
@@ -83,7 +92,13 @@ class BaseDocsRepository(
     ) -> db.sql.Select[tuple[int]]:
         if dimension_id is not None:
             _exc = _exc.where(self.model_class.dimension__id == dimension_id)
-        elif dimension_id__in is not None:
+        if dimension_id__in is not None:
+            if dimension_id and dimension_id not in dimension_id__in:
+                logger.warning(
+                    "Applying incompatible filters to select for docs: "
+                    f"dimension_id '{dimension_id}' is not in dimension_id__in "
+                    f"{dimension_id__in}!"
+                )
             _exc = _exc.where(self.model_class.dimension__id.in_(dimension_id__in))
 
         return _exc

--- a/ixmp4/data/db/model/docs.py
+++ b/ixmp4/data/db/model/docs.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any
 
 from .. import base
@@ -11,5 +12,12 @@ class ModelDocsRepository(BaseDocsRepository[Any], base.BaseRepository[Model]):
     model_class = ModelDocs
     dimension_model_class = Model
 
-    def list(self, *, dimension_id: int | None = None) -> list[AbstractDocs]:
-        return super().list(dimension_id=dimension_id)
+    def list(
+        self,
+        *,
+        dimension_id: int | None = None,
+        dimension_id__in: Iterable[int] | None = None,
+    ) -> list[AbstractDocs]:
+        return super().list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        )

--- a/ixmp4/data/db/region/docs.py
+++ b/ixmp4/data/db/region/docs.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any
 
 from ixmp4.data.auth.decorators import guard
@@ -14,5 +15,12 @@ class RegionDocsRepository(BaseDocsRepository[Any], base.BaseRepository[Region])
     dimension_model_class = Region
 
     @guard("view")
-    def list(self, *, dimension_id: int | None = None) -> list[AbstractDocs]:
-        return super().list(dimension_id=dimension_id)
+    def list(
+        self,
+        *,
+        dimension_id: int | None = None,
+        dimension_id__in: Iterable[int] | None = None,
+    ) -> list[AbstractDocs]:
+        return super().list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        )

--- a/ixmp4/data/db/unit/docs.py
+++ b/ixmp4/data/db/unit/docs.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any
 
 from ixmp4.data.auth.decorators import guard
@@ -17,5 +18,12 @@ class UnitDocsRepository(
     dimension_model_class = Unit
 
     @guard("view")
-    def list(self, *, dimension_id: int | None = None) -> list[AbstractDocs]:
-        return super().list(dimension_id=dimension_id)
+    def list(
+        self,
+        *,
+        dimension_id: int | None = None,
+        dimension_id__in: Iterable[int] | None = None,
+    ) -> list[AbstractDocs]:
+        return super().list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        )

--- a/ixmp4/server/rest/docs.py
+++ b/ixmp4/server/rest/docs.py
@@ -23,12 +23,17 @@ class DocsInput(BaseModel):
 @router.get("/models/", response_model=EnumerationOutput[api.Docs])
 def list_models(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.models.docs.list(dimension_id=dimension_id),
-        total=backend.models.docs.count(dimension_id=dimension_id),
+        results=backend.models.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.models.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -52,12 +57,17 @@ def delete_models(
 @router.get("/regions/", response_model=EnumerationOutput[api.Docs])
 def list_regions(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.regions.docs.list(dimension_id=dimension_id),
-        total=backend.regions.docs.count(dimension_id=dimension_id),
+        results=backend.regions.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.regions.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -81,12 +91,17 @@ def delete_regions(
 @router.get("/scenarios/", response_model=EnumerationOutput[api.Docs])
 def list_scenarios(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.scenarios.docs.list(dimension_id=dimension_id),
-        total=backend.scenarios.docs.count(dimension_id=dimension_id),
+        results=backend.scenarios.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.scenarios.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -110,12 +125,17 @@ def delete_scenarios(
 @router.get("/units/", response_model=EnumerationOutput[api.Docs])
 def list_units(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.units.docs.list(dimension_id=dimension_id),
-        total=backend.units.docs.count(dimension_id=dimension_id),
+        results=backend.units.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.units.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -139,12 +159,17 @@ def delete_units(
 @router.get("/iamc/variables/", response_model=EnumerationOutput[api.Docs])
 def list_variables(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.iamc.variables.docs.list(dimension_id=dimension_id),
-        total=backend.iamc.variables.docs.count(dimension_id=dimension_id),
+        results=backend.iamc.variables.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.iamc.variables.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -168,12 +193,17 @@ def delete_variables(
 @router.get("/optimization/indexsets/", response_model=EnumerationOutput[api.Docs])
 def list_indexsets(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.optimization.indexsets.docs.list(dimension_id=dimension_id),
-        total=backend.optimization.indexsets.docs.count(dimension_id=dimension_id),
+        results=backend.optimization.indexsets.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.optimization.indexsets.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -197,12 +227,17 @@ def delete_indexsets(
 @router.get("/optimization/scalars/", response_model=EnumerationOutput[api.Docs])
 def list_scalars(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.optimization.scalars.docs.list(dimension_id=dimension_id),
-        total=backend.optimization.scalars.docs.count(dimension_id=dimension_id),
+        results=backend.optimization.scalars.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.optimization.scalars.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -226,12 +261,17 @@ def delete_scalars(
 @router.get("/optimization/tables/", response_model=EnumerationOutput[api.Docs])
 def list_tables(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.optimization.tables.docs.list(dimension_id=dimension_id),
-        total=backend.optimization.tables.docs.count(dimension_id=dimension_id),
+        results=backend.optimization.tables.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.optimization.tables.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -255,12 +295,17 @@ def delete_tables(
 @router.get("/optimization/parameters/", response_model=EnumerationOutput[api.Docs])
 def list_parameters(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.optimization.parameters.docs.list(dimension_id=dimension_id),
-        total=backend.optimization.parameters.docs.count(dimension_id=dimension_id),
+        results=backend.optimization.parameters.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.optimization.parameters.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -284,12 +329,17 @@ def delete_parameters(
 @router.get("/optimization/variables/", response_model=EnumerationOutput[api.Docs])
 def list_optimization_variables(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.optimization.variables.docs.list(dimension_id=dimension_id),
-        total=backend.optimization.variables.docs.count(dimension_id=dimension_id),
+        results=backend.optimization.variables.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.optimization.variables.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 
@@ -313,12 +363,17 @@ def delete_optimization_variables(
 @router.get("/optimization/equations/", response_model=EnumerationOutput[api.Docs])
 def list_equations(
     dimension_id: int | None = Query(None),
+    dimension_id__in: list[int] | None = Query(None),
     pagination: Pagination = Depends(),
     backend: Backend = Depends(deps.get_backend),
 ) -> EnumerationOutput[AbstractDocs]:
     return EnumerationOutput(
-        results=backend.optimization.equations.docs.list(dimension_id=dimension_id),
-        total=backend.optimization.equations.docs.count(dimension_id=dimension_id),
+        results=backend.optimization.equations.docs.list(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
+        total=backend.optimization.equations.docs.count(
+            dimension_id=dimension_id, dimension_id__in=dimension_id__in
+        ),
         pagination=pagination,
     )
 

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -90,3 +90,20 @@ class TestCoreModel:
         platform.models.delete_docs("Model")
 
         assert model.docs is None
+
+    def test_list_docs(self, platform: ixmp4.Platform) -> None:
+        model_1 = platform.models.create("Model 1")
+        model_1.docs = "Description of Model 1"
+        model_2 = platform.models.create("Model 2")
+        model_2.docs = "Description of Model 2"
+        model_3 = platform.models.create("Model 3")
+        model_3.docs = "Description of Model 3"
+
+        assert platform.models.list_docs() == [model_1.docs, model_2.docs, model_3.docs]
+
+        assert platform.models.list_docs(id=model_2.id) == [model_2.docs]
+
+        assert platform.models.list_docs(id__in=[model_1.id, model_3.id]) == [
+            model_1.docs,
+            model_3.docs,
+        ]

--- a/tests/core/test_region.py
+++ b/tests/core/test_region.py
@@ -147,3 +147,24 @@ class TestCoreRegion:
         platform.regions.delete_docs("Test Region")
 
         assert region.docs is None
+
+    def test_list_docs(self, platform: ixmp4.Platform) -> None:
+        region_1 = platform.regions.create("Region 1", "Hierarchy")
+        region_1.docs = "Description of Region 1"
+        region_2 = platform.regions.create("Region 2", "Hierarchy")
+        region_2.docs = "Description of Region 2"
+        region_3 = platform.regions.create("Region 3", "Hierarchy")
+        region_3.docs = "Description of Region 3"
+
+        assert platform.regions.list_docs() == [
+            region_1.docs,
+            region_2.docs,
+            region_3.docs,
+        ]
+
+        assert platform.regions.list_docs(id=region_2.id) == [region_2.docs]
+
+        assert platform.regions.list_docs(id__in=[region_1.id, region_3.id]) == [
+            region_1.docs,
+            region_3.docs,
+        ]

--- a/tests/core/test_scenario.py
+++ b/tests/core/test_scenario.py
@@ -93,3 +93,24 @@ class TestCoreScenario:
         platform.scenarios.delete_docs("Scenario")
 
         assert scenario.docs is None
+
+    def test_list_docs(self, platform: ixmp4.Platform) -> None:
+        scenario_1 = platform.scenarios.create("Scenario 1")
+        scenario_1.docs = "Description of Scenario 1"
+        scenario_2 = platform.scenarios.create("Scenario 2")
+        scenario_2.docs = "Description of Scenario 2"
+        scenario_3 = platform.scenarios.create("Scenario 3")
+        scenario_3.docs = "Description of Scenario 3"
+
+        assert platform.scenarios.list_docs() == [
+            scenario_1.docs,
+            scenario_2.docs,
+            scenario_3.docs,
+        ]
+
+        assert platform.scenarios.list_docs(id=scenario_2.id) == [scenario_2.docs]
+
+        assert platform.scenarios.list_docs(id__in=[scenario_1.id, scenario_3.id]) == [
+            scenario_1.docs,
+            scenario_3.docs,
+        ]

--- a/tests/core/test_unit.py
+++ b/tests/core/test_unit.py
@@ -148,3 +148,20 @@ class TestCoreUnit:
         platform.units.delete_docs("Unit")
 
         assert unit.docs is None
+
+    def test_list_docs(self, platform: ixmp4.Platform) -> None:
+        unit_1 = platform.units.create("Unit 1")
+        unit_1.docs = "Description of Unit 1"
+        unit_2 = platform.units.create("Unit 2")
+        unit_2.docs = "Description of Unit 2"
+        unit_3 = platform.units.create("Unit 3")
+        unit_3.docs = "Description of Unit 3"
+
+        assert platform.units.list_docs() == [unit_1.docs, unit_2.docs, unit_3.docs]
+
+        assert platform.units.list_docs(id=unit_2.id) == [unit_2.docs]
+
+        assert platform.units.list_docs(id__in=[unit_1.id, unit_3.id]) == [
+            unit_1.docs,
+            unit_3.docs,
+        ]

--- a/tests/core/test_variable.py
+++ b/tests/core/test_variable.py
@@ -127,3 +127,26 @@ class TestCoreVariable:
         platform.iamc.variables.delete_docs("IAMC Variable")
 
         assert iamc_variable.docs is None
+
+    def test_list_docs(self, platform: ixmp4.Platform) -> None:
+        variable_1 = platform.iamc.variables.create("Variable 1")
+        variable_1.docs = "Description of Variable 1"
+        variable_2 = platform.iamc.variables.create("Variable 2")
+        variable_2.docs = "Description of Variable 2"
+        variable_3 = platform.iamc.variables.create("Variable 3")
+        variable_3.docs = "Description of Variable 3"
+
+        assert platform.iamc.variables.list_docs() == [
+            variable_1.docs,
+            variable_2.docs,
+            variable_3.docs,
+        ]
+
+        assert platform.iamc.variables.list_docs(id=variable_2.id) == [variable_2.docs]
+
+        assert platform.iamc.variables.list_docs(
+            id__in=[variable_1.id, variable_3.id]
+        ) == [
+            variable_1.docs,
+            variable_3.docs,
+        ]

--- a/tests/data/test_docs.py
+++ b/tests/data/test_docs.py
@@ -43,6 +43,34 @@ class TestDataDocs:
         with pytest.raises(Docs.NotFound):
             platform.backend.models.docs.get(model.id)
 
+    def test_list_modeldocs(self, platform: ixmp4.Platform) -> None:
+        model_1 = platform.backend.models.create("Model 1")
+        model_2 = platform.backend.models.create("Model 2")
+        model_3 = platform.backend.models.create("Model 3")
+        docs_model_1 = platform.backend.models.docs.set(
+            model_1.id, "Description of Model 1"
+        )
+        docs_model_2 = platform.backend.models.docs.set(
+            model_2.id, "Description of Model 2"
+        )
+        docs_model_3 = platform.backend.models.docs.set(
+            model_3.id, "Description of Model 3"
+        )
+
+        assert platform.backend.models.docs.list() == [
+            docs_model_1,
+            docs_model_2,
+            docs_model_3,
+        ]
+
+        assert platform.backend.models.docs.list(dimension_id=model_2.id) == [
+            docs_model_2
+        ]
+
+        assert platform.backend.models.docs.list(
+            dimension_id__in=[model_1.id, model_3.id]
+        ) == [docs_model_1, docs_model_3]
+
     def test_get_and_set_regiondocs(self, platform: ixmp4.Platform) -> None:
         region = platform.backend.regions.create("Region", "Hierarchy")
         docs_region = platform.backend.regions.docs.set(
@@ -83,6 +111,34 @@ class TestDataDocs:
         with pytest.raises(Docs.NotFound):
             platform.backend.regions.docs.get(region.id)
 
+    def test_list_regiondocs(self, platform: ixmp4.Platform) -> None:
+        region_1 = platform.backend.regions.create("Region 1", "Hierarchy")
+        region_2 = platform.backend.regions.create("Region 2", "Hierarchy")
+        region_3 = platform.backend.regions.create("Region 3", "Hierarchy")
+        docs_region_1 = platform.backend.regions.docs.set(
+            region_1.id, "Description of Region 1"
+        )
+        docs_region_2 = platform.backend.regions.docs.set(
+            region_2.id, "Description of Region 2"
+        )
+        docs_region_3 = platform.backend.regions.docs.set(
+            region_3.id, "Description of Region 3"
+        )
+
+        assert platform.backend.regions.docs.list() == [
+            docs_region_1,
+            docs_region_2,
+            docs_region_3,
+        ]
+
+        assert platform.backend.regions.docs.list(dimension_id=region_2.id) == [
+            docs_region_2
+        ]
+
+        assert platform.backend.regions.docs.list(
+            dimension_id__in=[region_1.id, region_3.id]
+        ) == [docs_region_1, docs_region_3]
+
     def test_get_and_set_scenariodocs(self, platform: ixmp4.Platform) -> None:
         scenario = platform.backend.scenarios.create("Scenario")
         docs_scenario = platform.backend.scenarios.docs.set(
@@ -122,6 +178,34 @@ class TestDataDocs:
         with pytest.raises(Docs.NotFound):
             platform.backend.scenarios.docs.get(scenario.id)
 
+    def test_list_scenariodocs(self, platform: ixmp4.Platform) -> None:
+        scenario_1 = platform.backend.scenarios.create("Scenario 1")
+        scenario_2 = platform.backend.scenarios.create("Scenario 2")
+        scenario_3 = platform.backend.scenarios.create("Scenario 3")
+        docs_scenario_1 = platform.backend.scenarios.docs.set(
+            scenario_1.id, "Description of Scenario 1"
+        )
+        docs_scenario_2 = platform.backend.scenarios.docs.set(
+            scenario_2.id, "Description of Scenario 2"
+        )
+        docs_scenario_3 = platform.backend.scenarios.docs.set(
+            scenario_3.id, "Description of Scenario 3"
+        )
+
+        assert platform.backend.scenarios.docs.list() == [
+            docs_scenario_1,
+            docs_scenario_2,
+            docs_scenario_3,
+        ]
+
+        assert platform.backend.scenarios.docs.list(dimension_id=scenario_2.id) == [
+            docs_scenario_2
+        ]
+
+        assert platform.backend.scenarios.docs.list(
+            dimension_id__in=[scenario_1.id, scenario_3.id]
+        ) == [docs_scenario_1, docs_scenario_3]
+
     def test_get_and_set_unitdocs(self, platform: ixmp4.Platform) -> None:
         unit = platform.backend.units.create("Unit")
         docs_unit = platform.backend.units.docs.set(unit.id, "Description of test Unit")
@@ -157,6 +241,32 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.units.docs.get(unit.id)
+
+    def test_list_unitdocs(self, platform: ixmp4.Platform) -> None:
+        unit_1 = platform.backend.units.create("Unit 1")
+        unit_2 = platform.backend.units.create("Unit 2")
+        unit_3 = platform.backend.units.create("Unit 3")
+        docs_unit_1 = platform.backend.units.docs.set(
+            unit_1.id, "Description of Unit 1"
+        )
+        docs_unit_2 = platform.backend.units.docs.set(
+            unit_2.id, "Description of Unit 2"
+        )
+        docs_unit_3 = platform.backend.units.docs.set(
+            unit_3.id, "Description of Unit 3"
+        )
+
+        assert platform.backend.units.docs.list() == [
+            docs_unit_1,
+            docs_unit_2,
+            docs_unit_3,
+        ]
+
+        assert platform.backend.units.docs.list(dimension_id=unit_2.id) == [docs_unit_2]
+
+        assert platform.backend.units.docs.list(
+            dimension_id__in=[unit_1.id, unit_3.id]
+        ) == [docs_unit_1, docs_unit_3]
 
     def test_get_and_set_variabledocs(self, platform: ixmp4.Platform) -> None:
         variable = platform.backend.iamc.variables.create("Variable")
@@ -197,6 +307,34 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.iamc.variables.docs.get(variable.id)
+
+    def test_list_variabledocs(self, platform: ixmp4.Platform) -> None:
+        variable_1 = platform.backend.iamc.variables.create("Variable 1")
+        variable_2 = platform.backend.iamc.variables.create("Variable 2")
+        variable_3 = platform.backend.iamc.variables.create("Variable 3")
+        docs_variable_1 = platform.backend.iamc.variables.docs.set(
+            variable_1.id, "Description of Variable 1"
+        )
+        docs_variable_2 = platform.backend.iamc.variables.docs.set(
+            variable_2.id, "Description of Variable 2"
+        )
+        docs_variable_3 = platform.backend.iamc.variables.docs.set(
+            variable_3.id, "Description of Variable 3"
+        )
+
+        assert platform.backend.iamc.variables.docs.list() == [
+            docs_variable_1,
+            docs_variable_2,
+            docs_variable_3,
+        ]
+
+        assert platform.backend.iamc.variables.docs.list(
+            dimension_id=variable_2.id
+        ) == [docs_variable_2]
+
+        assert platform.backend.iamc.variables.docs.list(
+            dimension_id__in=[variable_1.id, variable_3.id]
+        ) == [docs_variable_1, docs_variable_3]
 
     def test_get_and_set_indexsetdocs(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
@@ -256,6 +394,41 @@ class TestDataDocs:
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.indexsets.docs.get(indexset.id)
 
+    def test_list_indexsetdocs(self, platform: ixmp4.Platform) -> None:
+        run = platform.backend.runs.create("Model", "Scenario")
+        indexset_1 = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="IndexSet 1"
+        )
+        indexset_2 = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="IndexSet 2"
+        )
+        indexset_3 = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="IndexSet 3"
+        )
+        docs_indexset_1 = platform.backend.optimization.indexsets.docs.set(
+            indexset_1.id, "Description of IndexSet 1"
+        )
+        docs_indexset_2 = platform.backend.optimization.indexsets.docs.set(
+            indexset_2.id, "Description of IndexSet 2"
+        )
+        docs_indexset_3 = platform.backend.optimization.indexsets.docs.set(
+            indexset_3.id, "Description of IndexSet 3"
+        )
+
+        assert platform.backend.optimization.indexsets.docs.list() == [
+            docs_indexset_1,
+            docs_indexset_2,
+            docs_indexset_3,
+        ]
+
+        assert platform.backend.optimization.indexsets.docs.list(
+            dimension_id=indexset_2.id
+        ) == [docs_indexset_2]
+
+        assert platform.backend.optimization.indexsets.docs.list(
+            dimension_id__in=[indexset_1.id, indexset_3.id]
+        ) == [docs_indexset_1, docs_indexset_3]
+
     def test_get_and_set_scalardocs(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         unit = platform.backend.units.create("Unit")
@@ -307,6 +480,42 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.scalars.docs.get(scalar.id)
+
+    def test_list_scalardocs(self, platform: ixmp4.Platform) -> None:
+        run = platform.backend.runs.create("Model", "Scenario")
+        unit = platform.backend.units.create("Unit")
+        scalar_1 = platform.backend.optimization.scalars.create(
+            run_id=run.id, name="Scalar 1", value=1, unit_name=unit.name
+        )
+        scalar_2 = platform.backend.optimization.scalars.create(
+            run_id=run.id, name="Scalar 2", value=2, unit_name=unit.name
+        )
+        scalar_3 = platform.backend.optimization.scalars.create(
+            run_id=run.id, name="Scalar 3", value=3, unit_name=unit.name
+        )
+        docs_scalar_1 = platform.backend.optimization.scalars.docs.set(
+            scalar_1.id, "Description of Scalar 1"
+        )
+        docs_scalar_2 = platform.backend.optimization.scalars.docs.set(
+            scalar_2.id, "Description of Scalar 2"
+        )
+        docs_scalar_3 = platform.backend.optimization.scalars.docs.set(
+            scalar_3.id, "Description of Scalar 3"
+        )
+
+        assert platform.backend.optimization.scalars.docs.list() == [
+            docs_scalar_1,
+            docs_scalar_2,
+            docs_scalar_3,
+        ]
+
+        assert platform.backend.optimization.scalars.docs.list(
+            dimension_id=scalar_2.id
+        ) == [docs_scalar_2]
+
+        assert platform.backend.optimization.scalars.docs.list(
+            dimension_id__in=[scalar_1.id, scalar_3.id]
+        ) == [docs_scalar_1, docs_scalar_3]
 
     def test_get_and_set_tabledocs(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
@@ -365,6 +574,44 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.tables.docs.get(table.id)
+
+    def test_list_tabledocs(self, platform: ixmp4.Platform) -> None:
+        run = platform.backend.runs.create("Model", "Scenario")
+        indexset = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        table_1 = platform.backend.optimization.tables.create(
+            run_id=run.id, name="Table 1", constrained_to_indexsets=[indexset.name]
+        )
+        table_2 = platform.backend.optimization.tables.create(
+            run_id=run.id, name="Table 2", constrained_to_indexsets=[indexset.name]
+        )
+        table_3 = platform.backend.optimization.tables.create(
+            run_id=run.id, name="Table 3", constrained_to_indexsets=[indexset.name]
+        )
+        docs_table_1 = platform.backend.optimization.tables.docs.set(
+            table_1.id, "Description of Table 1"
+        )
+        docs_table_2 = platform.backend.optimization.tables.docs.set(
+            table_2.id, "Description of Table 2"
+        )
+        docs_table_3 = platform.backend.optimization.tables.docs.set(
+            table_3.id, "Description of Table 3"
+        )
+
+        assert platform.backend.optimization.tables.docs.list() == [
+            docs_table_1,
+            docs_table_2,
+            docs_table_3,
+        ]
+
+        assert platform.backend.optimization.tables.docs.list(
+            dimension_id=table_2.id
+        ) == [docs_table_2]
+
+        assert platform.backend.optimization.tables.docs.list(
+            dimension_id__in=[table_1.id, table_3.id]
+        ) == [docs_table_1, docs_table_3]
 
     def test_get_and_set_parameterdocs(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
@@ -434,6 +681,44 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.parameters.docs.get(parameter.id)
+
+    def test_list_parameterdocs(self, platform: ixmp4.Platform) -> None:
+        run = platform.backend.runs.create("Model", "Scenario")
+        indexset = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        parameter_1 = platform.backend.optimization.parameters.create(
+            run_id=run.id, name="Parameter 1", constrained_to_indexsets=[indexset.name]
+        )
+        parameter_2 = platform.backend.optimization.parameters.create(
+            run_id=run.id, name="Parameter 2", constrained_to_indexsets=[indexset.name]
+        )
+        parameter_3 = platform.backend.optimization.parameters.create(
+            run_id=run.id, name="Parameter 3", constrained_to_indexsets=[indexset.name]
+        )
+        docs_parameter_1 = platform.backend.optimization.parameters.docs.set(
+            parameter_1.id, "Description of Parameter 1"
+        )
+        docs_parameter_2 = platform.backend.optimization.parameters.docs.set(
+            parameter_2.id, "Description of Parameter 2"
+        )
+        docs_parameter_3 = platform.backend.optimization.parameters.docs.set(
+            parameter_3.id, "Description of Parameter 3"
+        )
+
+        assert platform.backend.optimization.parameters.docs.list() == [
+            docs_parameter_1,
+            docs_parameter_2,
+            docs_parameter_3,
+        ]
+
+        assert platform.backend.optimization.parameters.docs.list(
+            dimension_id=parameter_2.id
+        ) == [docs_parameter_2]
+
+        assert platform.backend.optimization.parameters.docs.list(
+            dimension_id__in=[parameter_1.id, parameter_3.id]
+        ) == [docs_parameter_1, docs_parameter_3]
 
     def test_get_and_set_optimizationvariabledocs(
         self, platform: ixmp4.Platform
@@ -506,6 +791,41 @@ class TestDataDocs:
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.variables.docs.get(variable.id)
 
+    def test_list_optimizationvariabledocs(self, platform: ixmp4.Platform) -> None:
+        run = platform.backend.runs.create("Model", "Scenario")
+        variable_1 = platform.backend.optimization.variables.create(
+            run_id=run.id, name="Variable 1"
+        )
+        variable_2 = platform.backend.optimization.variables.create(
+            run_id=run.id, name="Variable 2"
+        )
+        variable_3 = platform.backend.optimization.variables.create(
+            run_id=run.id, name="Variable 3"
+        )
+        docs_variable_1 = platform.backend.optimization.variables.docs.set(
+            variable_1.id, "Description of Variable 1"
+        )
+        docs_variable_2 = platform.backend.optimization.variables.docs.set(
+            variable_2.id, "Description of Variable 2"
+        )
+        docs_variable_3 = platform.backend.optimization.variables.docs.set(
+            variable_3.id, "Description of Variable 3"
+        )
+
+        assert platform.backend.optimization.variables.docs.list() == [
+            docs_variable_1,
+            docs_variable_2,
+            docs_variable_3,
+        ]
+
+        assert platform.backend.optimization.variables.docs.list(
+            dimension_id=variable_2.id
+        ) == [docs_variable_2]
+
+        assert platform.backend.optimization.variables.docs.list(
+            dimension_id__in=[variable_1.id, variable_3.id]
+        ) == [docs_variable_1, docs_variable_3]
+
     def test_get_and_set_equationdocs(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         _ = platform.backend.optimization.indexsets.create(
@@ -572,3 +892,41 @@ class TestDataDocs:
 
         with pytest.raises(Docs.NotFound):
             platform.backend.optimization.equations.docs.get(equation.id)
+
+    def test_list_optimizationequationdocs(self, platform: ixmp4.Platform) -> None:
+        run = platform.backend.runs.create("Model", "Scenario")
+        indexset = platform.backend.optimization.indexsets.create(
+            run_id=run.id, name="Indexset"
+        )
+        equation_1 = platform.backend.optimization.equations.create(
+            run_id=run.id, name="Equation 1", constrained_to_indexsets=[indexset.name]
+        )
+        equation_2 = platform.backend.optimization.equations.create(
+            run_id=run.id, name="Equation 2", constrained_to_indexsets=[indexset.name]
+        )
+        equation_3 = platform.backend.optimization.equations.create(
+            run_id=run.id, name="Equation 3", constrained_to_indexsets=[indexset.name]
+        )
+        docs_equation_1 = platform.backend.optimization.equations.docs.set(
+            equation_1.id, "Description of Equation 1"
+        )
+        docs_equation_2 = platform.backend.optimization.equations.docs.set(
+            equation_2.id, "Description of Equation 2"
+        )
+        docs_equation_3 = platform.backend.optimization.equations.docs.set(
+            equation_3.id, "Description of Equation 3"
+        )
+
+        assert platform.backend.optimization.equations.docs.list() == [
+            docs_equation_1,
+            docs_equation_2,
+            docs_equation_3,
+        ]
+
+        assert platform.backend.optimization.equations.docs.list(
+            dimension_id=equation_2.id
+        ) == [docs_equation_2]
+
+        assert platform.backend.optimization.equations.docs.list(
+            dimension_id__in=[equation_1.id, equation_3.id]
+        ) == [docs_equation_1, docs_equation_3]


### PR DESCRIPTION
Here's the PR you asked for, @danielhuppmann: it exposes the `list()` functionality we already have for docs for most facade objects and enables a filter so that only IDs from a provided list are considered.

There are several things to consider, though:

1. I don't know if this is how you envisioned the facade API (i.e. providing IDs; the other docs functions often translate one name to one ID first, which would need to be adapted for a list of names).
2. The PR comes with tests, but these are not exhaustive. For instance, I don't enforce anywhere that only one of `dimension_id` or `dimension_id__in` can be used. In fact, if both are used, we silently discard the latter at the moment. This behavior is not tested.
3. The code includes quite a bit of repetition, which is not great style/potentially even technical debt. However, I didn't see how else to do this unless I'm rewriting more significant parts of the docs feature, which might be worthwhile itself, but not the target here.
4. Currently, the optimization items in the facade layer all have a `.docs` property through which one can manage each item's docs, but their repository classes lack any docs functionality. So rather than adding all of that here, I assumed we don't urgently need this and thus did not expose the `list_docs()` function for them.