### PR TITLE
Handle adding empty optimization data

### DIFF
--- a/ixmp4/data/db/optimization/equation/repository.py
+++ b/ixmp4/data/db/optimization/equation/repository.py
@@ -144,6 +144,10 @@ class EquationRepository(
                 data = pd.DataFrame.from_dict(data=data)
             except ValueError as e:
                 raise Equation.DataInvalid(str(e)) from e
+
+        if data.empty:
+            return  # nothing to do
+
         equation = self.get_by_id(id=id)
 
         missing_columns = set(["levels", "marginals"]) - set(data.columns)

--- a/ixmp4/data/db/optimization/indexset/repository.py
+++ b/ixmp4/data/db/optimization/indexset/repository.py
@@ -82,8 +82,12 @@ class IndexSetRepository(
     def add_data(
         self, id: int, data: float | int | str | List[float] | List[int] | List[str]
     ) -> None:
-        indexset = self.get_by_id(id=id)
         _data = data if isinstance(data, list) else [data]
+
+        if len(_data) == 0:
+            return  # nothing to be done
+
+        indexset = self.get_by_id(id=id)
 
         bulk_insert_enabled_data = [{"value": str(d)} for d in _data]
         try:

--- a/ixmp4/data/db/optimization/parameter/repository.py
+++ b/ixmp4/data/db/optimization/parameter/repository.py
@@ -139,6 +139,9 @@ class ParameterRepository(
             except ValueError as e:
                 raise Parameter.DataInvalid(str(e)) from e
 
+        if data.empty:
+            return  # nothing to do
+
         parameter = self.get_by_id(id=id)
 
         missing_columns = set(["values", "units"]) - set(data.columns)

--- a/ixmp4/data/db/optimization/table/repository.py
+++ b/ixmp4/data/db/optimization/table/repository.py
@@ -131,6 +131,10 @@ class TableRepository(
     def add_data(self, id: int, data: dict[str, Any] | pd.DataFrame) -> None:
         if isinstance(data, dict):
             data = pd.DataFrame.from_dict(data=data)
+
+        if data.empty:
+            return  # nothing to do
+
         table = self.get_by_id(id=id)
 
         table.data = cast(

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -145,6 +145,10 @@ class VariableRepository(
                 data = pd.DataFrame.from_dict(data=data)
             except ValueError as e:
                 raise Variable.DataInvalid(str(e)) from e
+
+        if data.empty:
+            return  # nothing to do
+
         variable = self.get_by_id(id=id)
 
         missing_columns = set(["levels", "marginals"]) - set(data.columns)

--- a/tests/core/test_optimization_equation.py
+++ b/tests/core/test_optimization_equation.py
@@ -345,6 +345,11 @@ class TestCoreEquation:
 
         assert equation_6.data == test_data_8
 
+        # Test adding empty data works
+        equation_6.add(pd.DataFrame())
+
+        assert equation_6.data == test_data_8
+
     def test_equation_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset = run.optimization.indexsets.create("Indexset")

--- a/tests/core/test_optimization_indexset.py
+++ b/tests/core/test_optimization_indexset.py
@@ -121,6 +121,11 @@ class TestCoreIndexset:
         assert indexset_4.data == test_data_3
         assert type(indexset_4.data[0]).__name__ == "int"
 
+        # Test adding empty data works
+        indexset_4.add(data=[])
+
+        assert indexset_4.data == test_data_3
+
     def test_remove_elements(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         test_data = ["do", "re", "mi", "fa", "so", "la", "ti"]

--- a/tests/core/test_optimization_parameter.py
+++ b/tests/core/test_optimization_parameter.py
@@ -293,6 +293,11 @@ class TestCoreParameter:
 
         assert parameter_5.data == test_data_8
 
+        # Test adding empty data works
+        parameter_5.add(pd.DataFrame())
+
+        assert parameter_5.data == test_data_8
+
     def test_parameter_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Unit")

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -345,6 +345,11 @@ class TestCoreVariable:
 
         assert variable_6.data == test_data_8
 
+        # Test adding empty data works
+        variable_6.add(pd.DataFrame())
+
+        assert variable_6.data == test_data_8
+
     def test_variable_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset = run.optimization.indexsets.create("Indexset")

--- a/tests/data/test_optimization_equation.py
+++ b/tests/data/test_optimization_equation.py
@@ -379,6 +379,14 @@ class TestDataOptimizationEquation:
 
         assert equation_6.data == test_data_8
 
+        # Test adding empty data works
+        platform.backend.optimization.equations.add_data(id=equation_6.id, data={})
+        equation_6 = platform.backend.optimization.equations.get(
+            run_id=run.id, name="Equation 6"
+        )
+
+        assert equation_6.data == test_data_8
+
     def test_equation_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(

--- a/tests/data/test_optimization_indexset.py
+++ b/tests/data/test_optimization_indexset.py
@@ -161,6 +161,15 @@ class TestDataOptimizationIndexSet:
         assert indexset_4.data == test_data_3
         assert type(indexset_4.data[0]).__name__ == "int"
 
+        # Test adding empty data works
+        platform.backend.optimization.indexsets.add_data(id=indexset_4.id, data=[])
+
+        indexset_4 = platform.backend.optimization.indexsets.get(
+            run_id=run.id, name=indexset_4.name
+        )
+
+        assert indexset_4.data == test_data_3
+
     def test_remove_data(
         self, platform: ixmp4.Platform, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/data/test_optimization_parameter.py
+++ b/tests/data/test_optimization_parameter.py
@@ -328,6 +328,13 @@ class TestDataOptimizationParameter:
 
         assert parameter_3.data == test_data_8
 
+        # Test adding empty data works
+        platform.backend.optimization.parameters.add_data(id=parameter_3.id, data={})
+        parameter_3 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name="Parameter 3"
+        )
+        assert parameter_3.data == test_data_8
+
     def test_parameter_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
 

--- a/tests/data/test_optimization_variable.py
+++ b/tests/data/test_optimization_variable.py
@@ -369,6 +369,14 @@ class TestDataOptimizationVariable:
 
         assert variable_5.data == test_data_8
 
+        # Test adding empty data works
+        platform.backend.optimization.variables.add_data(id=variable_5.id, data={})
+        variable_5 = platform.backend.optimization.variables.get(
+            run_id=run.id, name="Variable 5"
+        )
+
+        assert variable_5.data == test_data_8
+
     def test_variable_remove_data(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
         indexset = platform.backend.optimization.indexsets.create(run.id, "Indexset")


### PR DESCRIPTION
In message_ix, we may iterate over all variables etc of one `Scenario` (backed by a `Run`) to add them to another `Scenario` (backed by another `Run`), which may include adding empty data (`{}` or `pd.DataFrame()`) to them. This should be working already as only the combination of existing and new data are validated. 
However, this led to an error for indexsets because adding an empty list violates one of the `UniqueConstraint`s for their underlying tables. So I was adjusting that already and figured the remaining items would also benefit from tests covering this case.
On top of which, I figure we don't need to bother the DB or validate data when adding empty data. This PR avoids that, which should make the code more performant. 

NOTE: I'm also using this branch right now for some temporary debug commits.