### PR TITLE
Remove data from linked items when removing data from indexset items

### DIFF
--- a/ixmp4/core/optimization/equation.py
+++ b/ixmp4/core/optimization/equation.py
@@ -45,9 +45,14 @@ class Equation(BaseModelFacade):
             run_id=self._model.run__id, name=self._model.name
         )
 
-    def remove_data(self) -> None:
-        """Removes all data from the Equation."""
-        self.backend.optimization.equations.remove_data(id=self._model.id)
+    # TODO Make name of these functions consistent across items
+    def remove_data(self, data: dict[str, Any] | pd.DataFrame | None = None) -> None:
+        """Removes data from the Equation.
+
+        If `data` is `None` (the default), remove all data. Otherwise, data must specify
+        all indexed columns. All other keys/columns are ignored.
+        """
+        self.backend.optimization.equations.remove_data(id=self._model.id, data=data)
         self._model = self.backend.optimization.equations.get(
             run_id=self._model.run__id, name=self._model.name
         )

--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -42,10 +42,14 @@ class IndexSet(BaseModelFacade):
         )
 
     def remove(
-        self, data: float | int | str | list[float] | list[int] | list[str]
+        self,
+        data: float | int | str | list[float] | list[int] | list[str],
+        remove_dependent_data: bool = True,
     ) -> None:
         """Removes data from an existing IndexSet."""
-        self.backend.optimization.indexsets.remove_data(id=self._model.id, data=data)
+        self.backend.optimization.indexsets.remove_data(
+            id=self._model.id, data=data, remove_dependent_data=remove_dependent_data
+        )
         self._model = self.backend.optimization.indexsets.get(
             run_id=self._model.run__id, name=self._model.name
         )

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -45,9 +45,13 @@ class Variable(BaseModelFacade):
             run_id=self._model.run__id, name=self._model.name
         )
 
-    def remove_data(self) -> None:
-        """Removes all data from the Variable."""
-        self.backend.optimization.variables.remove_data(id=self._model.id)
+    def remove_data(self, data: dict[str, Any] | pd.DataFrame | None = None) -> None:
+        """Removes all data from the Variable.
+
+        If `data` is `None` (the default), remove all data. Otherwise, data must specify
+        all indexed columns. All other keys/columns are ignored.
+        """
+        self.backend.optimization.variables.remove_data(id=self._model.id, data=data)
         self._model = self.backend.optimization.variables.get(
             run_id=self._model.run__id, name=self._model.name
         )

--- a/ixmp4/data/abstract/optimization/equation.py
+++ b/ixmp4/data/abstract/optimization/equation.py
@@ -225,13 +225,19 @@ class EquationRepository(
         """
         ...
 
-    def remove_data(self, id: int) -> None:
+    def remove_data(
+        self, id: int, data: dict[str, Any] | pd.DataFrame | None = None
+    ) -> None:
         """Removes data from an Equation.
 
         Parameters
         ----------
         id : int
             The id of the :class:`ixmp4.data.abstract.optimization.Equation`.
+        data : dict[str, Any] | pandas.DataFrame, optional
+            The data to be removed. If specified, remove only specific data. This must
+            specify all indexed columns. All other keys/columns are ignored. Otherwise,
+            remove all data (the default).
 
         Returns
         -------

--- a/ixmp4/data/abstract/optimization/indexset.py
+++ b/ixmp4/data/abstract/optimization/indexset.py
@@ -167,7 +167,10 @@ class IndexSetRepository(
         ...
 
     def remove_data(
-        self, id: int, data: float | int | str | List[float] | List[int] | List[str]
+        self,
+        id: int,
+        data: float | int | str | List[float] | List[int] | List[str],
+        remove_dependent_data: bool = True,
     ) -> None:
         """Removes data from an existing IndexSet.
 
@@ -177,6 +180,9 @@ class IndexSetRepository(
             The id of the target IndexSet.
         data : float | int | str | List[float] | List[int] | List[str]
             The data to be removed from the IndexSet.
+        remove_dependent_data : bool, optional
+            Whether to delete data from all linked items referencing `data`.
+            Default: `True`.
 
         Returns
         -------

--- a/ixmp4/data/abstract/optimization/variable.py
+++ b/ixmp4/data/abstract/optimization/variable.py
@@ -225,13 +225,19 @@ class VariableRepository(
         """
         ...
 
-    def remove_data(self, id: int) -> None:
+    def remove_data(
+        self, id: int, data: dict[str, Any] | pd.DataFrame | None = None
+    ) -> None:
         """Removes data from a Variable.
 
         Parameters
         ----------
         id : int
             The id of the :class:`ixmp4.data.abstract.optimization.Variable`.
+        data : dict[str, Any] | pandas.DataFrame, optional
+            The data to be removed. If specified, remove only specific data. This must
+            specify all indexed columns. All other keys/columns are ignored. Otherwise,
+            remove all data (the default).
 
         Returns
         -------

--- a/ixmp4/data/api/optimization/equation.py
+++ b/ixmp4/data/api/optimization/equation.py
@@ -78,8 +78,17 @@ class EquationRepository(
             method="PATCH", path=self.prefix + str(id) + "/data/", json=kwargs
         )
 
-    def remove_data(self, id: int) -> None:
-        self._request(method="DELETE", path=self.prefix + str(id) + "/data/")
+    def remove_data(
+        self, id: int, data: dict[str, Any] | pd.DataFrame | None = None
+    ) -> None:
+        if isinstance(data, pd.DataFrame):
+            data = cast(dict[str, Any], data.to_dict(orient="list"))
+        # data will always contain str, not only Hashable
+        kwargs = {"data": data}
+
+        self._request(
+            method="DELETE", path=self.prefix + str(id) + "/data/", json=kwargs
+        )
 
     def get(self, run_id: int, name: str) -> Equation:
         return super().get(run_id=run_id, name=name)

--- a/ixmp4/data/api/optimization/indexset.py
+++ b/ixmp4/data/api/optimization/indexset.py
@@ -97,6 +97,12 @@ class IndexSetRepository(
         | List[StrictFloat]
         | List[StrictInt]
         | List[StrictStr],
+        remove_dependent_data: bool = True,
     ) -> None:
         kwargs = {"id": id, "data": data}
-        self._request("DELETE", self.prefix + str(id) + "/data/", json=kwargs)
+        self._request(
+            "DELETE",
+            self.prefix + str(id) + "/data/",
+            params={"remove_dependent_data": remove_dependent_data},
+            json=kwargs,
+        )

--- a/ixmp4/data/api/optimization/variable.py
+++ b/ixmp4/data/api/optimization/variable.py
@@ -78,8 +78,17 @@ class VariableRepository(
             method="PATCH", path=self.prefix + str(id) + "/data/", json=kwargs
         )
 
-    def remove_data(self, id: int) -> None:
-        self._request(method="DELETE", path=self.prefix + str(id) + "/data/")
+    def remove_data(
+        self, id: int, data: dict[str, Any] | pd.DataFrame | None = None
+    ) -> None:
+        if isinstance(data, pd.DataFrame):
+            # data will always contain str, not only Hashable
+            data = cast(dict[str, Any], data.to_dict(orient="list"))
+        kwargs = {"data": data}
+
+        self._request(
+            method="DELETE", path=self.prefix + str(id) + "/data/", json=kwargs
+        )
 
     def get(self, run_id: int, name: str) -> Variable:
         return super().get(run_id=run_id, name=name)

--- a/ixmp4/data/db/optimization/base.py
+++ b/ixmp4/data/db/optimization/base.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 from ixmp4.core.exceptions import IxmpError
 from ixmp4.data import types
-from ixmp4.data.abstract.annotations import HasNameFilter, HasRunIdFilter
+from ixmp4.data.abstract.annotations import HasIdFilter, HasNameFilter, HasRunIdFilter
 from ixmp4.db.filters import BaseFilter
 
 from .. import mixins
@@ -30,5 +30,5 @@ class BaseModel(RootBaseModel, mixins.HasCreationInfo):
     name: types.Name
 
 
-class EnumerateKwargs(HasNameFilter, HasRunIdFilter, total=False):
+class EnumerateKwargs(HasIdFilter, HasNameFilter, HasRunIdFilter, total=False):
     _filter: BaseFilter

--- a/ixmp4/data/db/optimization/equation/model.py
+++ b/ixmp4/data/db/optimization/equation/model.py
@@ -1,15 +1,14 @@
 from typing import TYPE_CHECKING, Any, ClassVar
 
-# TODO Why do we need this only for Equations?
-if TYPE_CHECKING:
-    from .. import IndexSet
-
 from ixmp4 import db
 from ixmp4.core.exceptions import OptimizationDataValidationError
 from ixmp4.data import types
 from ixmp4.data.abstract import optimization as abstract
 
 from .. import base, utils
+
+if TYPE_CHECKING:
+    from .. import IndexSet
 
 
 class EquationIndexsetAssociation(base.RootBaseModel):

--- a/ixmp4/data/db/optimization/equation/repository.py
+++ b/ixmp4/data/db/optimization/equation/repository.py
@@ -185,9 +185,6 @@ class EquationRepository(
             # TODO Is there a better way to reset .data?
             equation.data = {}
         else:
-            # # TODO Why is this necessary? Could bool(None) ever be True?
-            # assert data
-
             if isinstance(data, dict):
                 data = pd.DataFrame.from_dict(data=data)
 

--- a/ixmp4/data/db/optimization/equation/repository.py
+++ b/ixmp4/data/db/optimization/equation/repository.py
@@ -193,6 +193,10 @@ class EquationRepository(
 
             index_list = equation.column_names or equation.indexset_names
             if not index_list:
+                logger.warning(
+                    f"Trying to remove {data.to_dict(orient='list')} from Equation '"
+                    f"{equation.name}', but that is not indexed; not removing anything!"
+                )
                 return  # can't remove specific data from unindexed variable
 
             existing_data = pd.DataFrame(equation.data)

--- a/ixmp4/data/db/optimization/equation/repository.py
+++ b/ixmp4/data/db/optimization/equation/repository.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -19,6 +20,8 @@ from ixmp4.data.auth.decorators import guard
 from .. import base
 from .docs import EquationDocsRepository
 from .model import Equation, EquationIndexsetAssociation
+
+logger = logging.getLogger(__name__)
 
 
 class EquationRepository(
@@ -172,8 +175,50 @@ class EquationRepository(
         self.session.commit()
 
     @guard("edit")
-    def remove_data(self, id: int) -> None:
+    def remove_data(
+        self, id: int, data: dict[str, Any] | pd.DataFrame | None = None
+    ) -> None:
         equation = self.get_by_id(id=id)
-        # TODO Is there a better way to reset .data?
-        equation.data = {}
+
+        if data is None:
+            # Remove all data per default
+            # TODO Is there a better way to reset .data?
+            equation.data = {}
+        else:
+            # # TODO Why is this necessary? Could bool(None) ever be True?
+            # assert data
+
+            if isinstance(data, dict):
+                data = pd.DataFrame.from_dict(data=data)
+
+            if data.empty:
+                return
+
+            index_list = equation.column_names or equation.indexset_names
+            if not index_list:
+                return  # can't remove specific data from unindexed variable
+
+            existing_data = pd.DataFrame(equation.data)
+            if not existing_data.empty:
+                existing_data.set_index(index_list, inplace=True)
+
+            # This is the only kind of validation we do for removal data
+            try:
+                data.set_index(index_list, inplace=True)
+            except KeyError as e:
+                logger.error(
+                    f"Data to be removed must include {index_list} as keys/columns, "
+                    f"but {[name for name in data.columns]} were provided."
+                )
+                raise OptimizationItemUsageError(
+                    "The data to be removed must specify one or more complete indices "
+                    "to remove associated levels and marginals!"
+                ) from e
+
+            remaining_data = existing_data[~existing_data.index.isin(data.index)]
+            if not remaining_data.index.empty:
+                remaining_data.reset_index(inplace=True)
+
+            equation.data = cast(types.JsonDict, remaining_data.to_dict(orient="list"))
+
         self.session.commit()

--- a/ixmp4/data/db/optimization/indexset/repository.py
+++ b/ixmp4/data/db/optimization/indexset/repository.py
@@ -5,19 +5,16 @@ from typing import TYPE_CHECKING, Any, List, Literal, Sequence, cast
 from typing_extensions import Unpack
 
 from ixmp4.data.db.optimization.equation.model import (
-    Equation,
     EquationIndexsetAssociation,
 )
 from ixmp4.data.db.optimization.equation.repository import EquationRepository
 from ixmp4.data.db.optimization.parameter.model import (
-    Parameter,
     ParameterIndexsetAssociation,
 )
 from ixmp4.data.db.optimization.parameter.repository import ParameterRepository
-from ixmp4.data.db.optimization.table.model import Table, TableIndexsetAssociation
+from ixmp4.data.db.optimization.table.model import TableIndexsetAssociation
 from ixmp4.data.db.optimization.table.repository import TableRepository
 from ixmp4.data.db.optimization.variable.model import (
-    OptimizationVariable,
     VariableIndexsetAssociation,
 )
 from ixmp4.data.db.optimization.variable.repository import VariableRepository
@@ -33,7 +30,7 @@ from ixmp4 import db
 from ixmp4.data.abstract import optimization as abstract
 from ixmp4.data.auth.decorators import guard
 
-from .. import base
+from .. import base, utils
 from .docs import IndexSetDocsRepository
 from .model import IndexSet, IndexSetData
 
@@ -56,6 +53,25 @@ class IndexSetRepository(
         from .filter import OptimizationIndexSetFilter
 
         self.filter_class = OptimizationIndexSetFilter
+
+        self._linked_columns_lookup = {
+            "table": (
+                TableIndexsetAssociation.table__id,
+                TableIndexsetAssociation.indexset__id,
+            ),
+            "parameter": (
+                ParameterIndexsetAssociation.parameter__id,
+                ParameterIndexsetAssociation.indexset__id,
+            ),
+            "equation": (
+                EquationIndexsetAssociation.equation__id,
+                EquationIndexsetAssociation.indexset__id,
+            ),
+            "variable": (
+                VariableIndexsetAssociation.variable__id,
+                VariableIndexsetAssociation.indexset__id,
+            ),
+        }
 
     def add(self, run_id: int, name: str) -> IndexSet:
         indexset = IndexSet(run__id=run_id, name=name)
@@ -138,7 +154,7 @@ class IndexSetRepository(
         _data = [str(d) for d in data] if isinstance(data, list) else [str(data)]
 
         if remove_dependent_data:
-            REPOS: dict[
+            repos: dict[
                 Literal["table", "parameter", "equation", "variable"],
                 TableRepository
                 | ParameterRepository
@@ -150,11 +166,9 @@ class IndexSetRepository(
                 "equation": self.backend.optimization.equations,
                 "variable": self.backend.optimization.variables,
             }
-            for kind, ids in find_all_linked_item_ids(
-                session=self.session, indexset_id=id
-            ):
-                remove_invalid_data(
-                    repo=REPOS[kind],
+            for kind, ids in self.find_all_linked_item_ids(id=id):
+                self.remove_invalid_linked_data(
+                    repo=repos[kind],
                     ids=ids,
                     indexset_name=self.get_by_id(id=id).name,
                     data=_data,
@@ -176,155 +190,105 @@ class IndexSetRepository(
         # Expire session to refresh IndexSets stored in it
         self.session.commit()
 
+    def _find_linked_item_ids(
+        self, id: int, item_kind: Literal["table", "parameter", "equation", "variable"]
+    ) -> Sequence[int]:
+        """Finds all items of `item_kind` linked to an IndexSet in `session.
 
-COLUMNS = {
-    "table": (
-        TableIndexsetAssociation.table__id,
-        TableIndexsetAssociation.indexset__id,
-    ),
-    "parameter": (
-        ParameterIndexsetAssociation.parameter__id,
-        ParameterIndexsetAssociation.indexset__id,
-    ),
-    "equation": (
-        EquationIndexsetAssociation.equation__id,
-        EquationIndexsetAssociation.indexset__id,
-    ),
-    "variable": (
-        VariableIndexsetAssociation.variable__id,
-        VariableIndexsetAssociation.indexset__id,
-    ),
-}
+        Parameters
+        ----------
+        id : int
+            The id of the IndexSet we are looking for.
+        item_kind : Literal["table", "parameter", "equation", "variable"]
+            The type of item we are looking for.
 
+        Returns
+        -------
+        list of int
+            A list of ids of items of `item_kind` linked to the IndexSet.
+        """
 
-def _find_linked_item_ids(
-    session: db.Session,
-    indexset_id: int,
-    item_kind: Literal["table", "parameter", "equation", "variable"],
-) -> Sequence[int]:
-    """Finds all items of `item_kind` linked to an IndexSet in `session.
+        column_clause, compare_column = self._linked_columns_lookup[item_kind]
 
-    Parameters
-    ----------
-    session : sqlalchemy.orm.Session
-        The session used to search for items.
-    indexset_id : int
-        The id of the IndexSet we are looking for.
-    item_kind : Literal["table", "parameter", "equation", "variable"]
-        The type of item we are looking for.
+        statement = db.select(column_clause).where(compare_column == id)
 
-    Returns
-    -------
-    list of int
-        A list of ids of items of `item_kind` linked to the IndexSet.
-    """
+        return self.session.scalars(statement).all()
 
-    column_clause, compare_column = COLUMNS[item_kind]
+    @guard("view")
+    def find_all_linked_item_ids(
+        self, id: int
+    ) -> Generator[
+        tuple[Literal["table", "parameter", "equation", "variable"], Sequence[int]],
+        Any,
+        None,
+    ]:
+        """Finds all optimization items linked to an IndexSet.
 
-    statement = db.select(column_clause).where(compare_column == indexset_id)
+        This is done by iterating over all possible kinds and yielding the ids of linked
+        items.
 
-    return session.scalars(statement).all()
+        Parameters
+        ----------
+        id : int
+            The id of the IndexSet we are looking for.
 
+        Yields
+        ------
+        (item kind, list of ids)
+            A tuple with the item kind being one of
+            {'table', 'parameter', 'equation', 'variable'} and a list of integer ids
+            representing linked items.
+        """
+        item_kinds: set[Literal["table", "parameter", "equation", "variable"]] = {
+            "table",
+            "parameter",
+            "equation",
+            "variable",
+        }
+        for kind in item_kinds:
+            yield (kind, self._find_linked_item_ids(id=id, item_kind=kind))
 
-def find_all_linked_item_ids(
-    session: db.Session, indexset_id: int
-) -> Generator[
-    tuple[Literal["table", "parameter", "equation", "variable"], Sequence[int]],
-    Any,
-    None,
-]:
-    """Finds all optimization items in `session` linked to an IndexSet.
+    @guard("edit")
+    def remove_invalid_linked_data(
+        self,
+        repo: TableRepository
+        | ParameterRepository
+        | EquationRepository
+        | VariableRepository,
+        ids: Sequence[int],
+        indexset_name: str,
+        data: List[str],
+    ) -> None:
+        """Remove invalid data from linked optimization items.
 
-    This is done by operating over all possible kinds and yielding the ids of linked
-    items.
+        Parameters
+        ----------
+        repo : TableRepository | ParameterRepository | EquationRepository | VariableRepository
+            The repository including the linked items.
+        ids : Sequence[int]
+            The IDs of items linked to the IndexSet with `indexset_name`.
+        indexset_name : str
+            The name of the IndexSet from which data is to be removed.
+        data : list[str]
+            The data to be removed from `indexset_name` in str format.
+        """  # noqa: E501
+        for item in repo.list(id__in=ids):
+            # Convert existing data for manipulation
+            df = pd.DataFrame(item.data)
 
-    Parameters
-    ----------
-    session : sqlalchemy.orm.Session
-        The session used to search for items.
-    indexset_id : int
-        The id of the IndexSet we are looking for.
+            if df.empty:
+                continue  # nothing to do
 
-    Yields
-    ------
-    (item kind, list of ids)
-        A tuple with the item kind being one of
-        {'table', 'parameter', 'equation', 'variable'} and a list of integer ids
-        representing linked items.
-    """
-    item_kinds: set[Literal["table", "parameter", "equation", "variable"]] = {
-        "table",
-        "parameter",
-        "equation",
-        "variable",
-    }
-    for kind in item_kinds:
-        yield (
-            kind,
-            _find_linked_item_ids(
-                session=session, indexset_id=indexset_id, item_kind=kind
-            ),
-        )
+            # Identify column/dimension names to target; item and name must be linked
+            columns = utils._find_columns_linked_to_indexset(
+                item=item, name=indexset_name
+            )
 
+            # Prepare data template to exclude
+            invalid_data = {columns[i]: data for i in range(len(columns))}
 
-def _find_columns_to_filter(
-    item: Table | Parameter | Equation | OptimizationVariable, name: str
-) -> list[str] | None:
-    """Determine columns in `item`.data that correspond to `name`."""
-    if not item.column_names:
-        # This assumes that every indexset name is unique
-        # Variables and Equations could have no .indexsets
-        return [name] if item.indexset_names else None
-    else:
-        # If we have column_names, we must also have indexsets
-        assert item.indexset_names
+            # Prepare stored data to remove
+            # NOTE if any linked column is not of type str, this may be incorrect
+            remove_data = df[df[columns].isin(invalid_data).any(axis=1)]
 
-        # Handle possible duplicate values
-        return [
-            item.column_names[i]
-            for i in range(len(item.column_names))
-            if item.indexset_names[i] == name
-        ]
-
-
-def remove_invalid_data(
-    repo: TableRepository
-    | ParameterRepository
-    | EquationRepository
-    | VariableRepository,
-    ids: Sequence[int],
-    indexset_name: str,
-    data: list[str],
-) -> None:
-    """Remove invalid data from linked optimization items.
-
-    repo : TableRepository | ParameterRepository | EquationRepository | VariableRepository
-        The repository including the linked items.
-    ids : Sequence[int]
-        The IDs of items linked to the IndexSet with `indexset_name`.
-    indexset_name : str
-        The name of the IndexSet from which data is to be removed.
-    data : list[str]
-        The data to be removed from `indexset_name` in str format.
-    """  # noqa: E501
-    for item in repo.list(id__in=ids):
-        # Convert existing data for manipulation
-        df = pd.DataFrame(item.data)
-
-        if df.empty:
-            continue  # nothing to do
-
-        # Identify column/dimension names to target
-        columns = _find_columns_to_filter(item=item, name=indexset_name)
-
-        if not columns:
-            continue  # nothing to do
-
-        # Prepare data template to exclude
-        invalid_data = {columns[i]: data for i in range(len(columns))}
-
-        # Prepare stored data to remove
-        # NOTE if any linked column is not of type str, this may be incorrect
-        remove_data = df[df[columns].isin(invalid_data).any(axis=1)]
-
-        repo.remove_data(item.id, remove_data)
+            repo.remove_data(item.id, remove_data)

--- a/ixmp4/data/db/optimization/indexset/repository.py
+++ b/ixmp4/data/db/optimization/indexset/repository.py
@@ -1,7 +1,26 @@
-from typing import TYPE_CHECKING, List, Literal, cast
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any, List, Literal, Sequence, cast
 
 # TODO Import this from typing when dropping Python 3.11
 from typing_extensions import Unpack
+
+from ixmp4.data.db.optimization.equation.model import (
+    Equation,
+    EquationIndexsetAssociation,
+)
+from ixmp4.data.db.optimization.equation.repository import EquationRepository
+from ixmp4.data.db.optimization.parameter.model import (
+    Parameter,
+    ParameterIndexsetAssociation,
+)
+from ixmp4.data.db.optimization.parameter.repository import ParameterRepository
+from ixmp4.data.db.optimization.table.model import Table, TableIndexsetAssociation
+from ixmp4.data.db.optimization.table.repository import TableRepository
+from ixmp4.data.db.optimization.variable.model import (
+    OptimizationVariable,
+    VariableIndexsetAssociation,
+)
+from ixmp4.data.db.optimization.variable.repository import VariableRepository
 
 if TYPE_CHECKING:
     from ixmp4.data.backend.db import SqlAlchemyBackend
@@ -108,12 +127,38 @@ class IndexSetRepository(
 
     @guard("edit")
     def remove_data(
-        self, id: int, data: float | int | str | List[float] | List[int] | List[str]
+        self,
+        id: int,
+        data: float | int | str | List[float] | List[int] | List[str],
+        remove_dependent_data: bool = True,
     ) -> None:
         if not bool(data):
             return
 
         _data = [str(d) for d in data] if isinstance(data, list) else [str(data)]
+
+        if remove_dependent_data:
+            REPOS: dict[
+                Literal["table", "parameter", "equation", "variable"],
+                TableRepository
+                | ParameterRepository
+                | EquationRepository
+                | VariableRepository,
+            ] = {
+                "table": self.backend.optimization.tables,
+                "parameter": self.backend.optimization.parameters,
+                "equation": self.backend.optimization.equations,
+                "variable": self.backend.optimization.variables,
+            }
+            for kind, ids in find_all_linked_item_ids(
+                session=self.session, indexset_id=id
+            ):
+                remove_invalid_data(
+                    repo=REPOS[kind],
+                    ids=ids,
+                    indexset_name=self.get_by_id(id=id).name,
+                    data=_data,
+                )
 
         result = self.session.execute(
             db.delete(IndexSetData).where(
@@ -130,3 +175,156 @@ class IndexSetRepository(
 
         # Expire session to refresh IndexSets stored in it
         self.session.commit()
+
+
+COLUMNS = {
+    "table": (
+        TableIndexsetAssociation.table__id,
+        TableIndexsetAssociation.indexset__id,
+    ),
+    "parameter": (
+        ParameterIndexsetAssociation.parameter__id,
+        ParameterIndexsetAssociation.indexset__id,
+    ),
+    "equation": (
+        EquationIndexsetAssociation.equation__id,
+        EquationIndexsetAssociation.indexset__id,
+    ),
+    "variable": (
+        VariableIndexsetAssociation.variable__id,
+        VariableIndexsetAssociation.indexset__id,
+    ),
+}
+
+
+def _find_linked_item_ids(
+    session: db.Session,
+    indexset_id: int,
+    item_kind: Literal["table", "parameter", "equation", "variable"],
+) -> Sequence[int]:
+    """Finds all items of `item_kind` linked to an IndexSet in `session.
+
+    Parameters
+    ----------
+    session : sqlalchemy.orm.Session
+        The session used to search for items.
+    indexset_id : int
+        The id of the IndexSet we are looking for.
+    item_kind : Literal["table", "parameter", "equation", "variable"]
+        The type of item we are looking for.
+
+    Returns
+    -------
+    list of int
+        A list of ids of items of `item_kind` linked to the IndexSet.
+    """
+
+    column_clause, compare_column = COLUMNS[item_kind]
+
+    statement = db.select(column_clause).where(compare_column == indexset_id)
+
+    return session.scalars(statement).all()
+
+
+def find_all_linked_item_ids(
+    session: db.Session, indexset_id: int
+) -> Generator[
+    tuple[Literal["table", "parameter", "equation", "variable"], Sequence[int]],
+    Any,
+    None,
+]:
+    """Finds all optimization items in `session` linked to an IndexSet.
+
+    This is done by operating over all possible kinds and yielding the ids of linked
+    items.
+
+    Parameters
+    ----------
+    session : sqlalchemy.orm.Session
+        The session used to search for items.
+    indexset_id : int
+        The id of the IndexSet we are looking for.
+
+    Yields
+    ------
+    (item kind, list of ids)
+        A tuple with the item kind being one of
+        {'table', 'parameter', 'equation', 'variable'} and a list of integer ids
+        representing linked items.
+    """
+    item_kinds: set[Literal["table", "parameter", "equation", "variable"]] = {
+        "table",
+        "parameter",
+        "equation",
+        "variable",
+    }
+    for kind in item_kinds:
+        yield (
+            kind,
+            _find_linked_item_ids(
+                session=session, indexset_id=indexset_id, item_kind=kind
+            ),
+        )
+
+
+def _find_columns_to_filter(
+    item: Table | Parameter | Equation | OptimizationVariable, name: str
+) -> list[str] | None:
+    """Determine columns in `item`.data that correspond to `name`."""
+    if not item.column_names:
+        # This assumes that every indexset name is unique
+        # Variables and Equations could have no .indexsets
+        return [name] if item.indexset_names else None
+    else:
+        # If we have column_names, we must also have indexsets
+        assert item.indexset_names
+
+        # Handle possible duplicate values
+        return [
+            item.column_names[i]
+            for i in range(len(item.column_names))
+            if item.indexset_names[i] == name
+        ]
+
+
+def remove_invalid_data(
+    repo: TableRepository
+    | ParameterRepository
+    | EquationRepository
+    | VariableRepository,
+    ids: Sequence[int],
+    indexset_name: str,
+    data: list[str],
+) -> None:
+    """Remove invalid data from linked optimization items.
+
+    repo : TableRepository | ParameterRepository | EquationRepository | VariableRepository
+        The repository including the linked items.
+    ids : Sequence[int]
+        The IDs of items linked to the IndexSet with `indexset_name`.
+    indexset_name : str
+        The name of the IndexSet from which data is to be removed.
+    data : list[str]
+        The data to be removed from `indexset_name` in str format.
+    """  # noqa: E501
+    for item in repo.list(id__in=ids):
+        # Convert existing data for manipulation
+        df = pd.DataFrame(item.data)
+
+        if df.empty:
+            continue  # nothing to do
+
+        # Identify column/dimension names to target
+        columns = _find_columns_to_filter(item=item, name=indexset_name)
+
+        if not columns:
+            continue  # nothing to do
+
+        # Prepare data template to exclude
+        invalid_data = {columns[i]: data for i in range(len(columns))}
+
+        # Prepare stored data to remove
+        # NOTE if any linked column is not of type str, this may be incorrect
+        remove_data = df[df[columns].isin(invalid_data).any(axis=1)]
+
+        repo.remove_data(item.id, remove_data)

--- a/ixmp4/data/db/optimization/parameter/model.py
+++ b/ixmp4/data/db/optimization/parameter/model.py
@@ -1,11 +1,14 @@
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from ixmp4 import db
 from ixmp4.core.exceptions import OptimizationDataValidationError
 from ixmp4.data import types
 from ixmp4.data.abstract import optimization as abstract
 
-from .. import IndexSet, base, utils
+from .. import base, utils
+
+if TYPE_CHECKING:
+    from .. import IndexSet
 
 
 class ParameterIndexsetAssociation(base.RootBaseModel):
@@ -16,7 +19,7 @@ class ParameterIndexsetAssociation(base.RootBaseModel):
         back_populates="_parameter_indexset_associations"
     )
     indexset__id: types.IndexSetId
-    indexset: types.Mapped[IndexSet] = db.relationship()
+    indexset: types.Mapped["IndexSet"] = db.relationship()
 
     column_name: types.String = db.Column(db.String(255), nullable=True)
 
@@ -55,7 +58,7 @@ class Parameter(base.BaseModel):
         passive_deletes=True,
     )
 
-    _indexsets: db.AssociationProxy[list[IndexSet]] = db.association_proxy(
+    _indexsets: db.AssociationProxy[list["IndexSet"]] = db.association_proxy(
         "_parameter_indexset_associations", "indexset"
     )
     _column_names: db.AssociationProxy[list[str | None]] = db.association_proxy(

--- a/ixmp4/data/db/optimization/table/model.py
+++ b/ixmp4/data/db/optimization/table/model.py
@@ -1,11 +1,14 @@
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from ixmp4 import db
 from ixmp4.core.exceptions import OptimizationDataValidationError
 from ixmp4.data import types
 from ixmp4.data.abstract import optimization as abstract
 
-from .. import IndexSet, base, utils
+from .. import base, utils
+
+if TYPE_CHECKING:
+    from .. import IndexSet
 
 
 class TableIndexsetAssociation(base.RootBaseModel):
@@ -16,7 +19,7 @@ class TableIndexsetAssociation(base.RootBaseModel):
         back_populates="_table_indexset_associations"
     )
     indexset__id: types.IndexSetId
-    indexset: types.Mapped[IndexSet] = db.relationship()
+    indexset: types.Mapped["IndexSet"] = db.relationship()
 
     column_name: types.String = db.Column(db.String(255), nullable=True)
 
@@ -53,7 +56,7 @@ class Table(base.BaseModel):
         )
     )
 
-    _indexsets: db.AssociationProxy[list[IndexSet]] = db.association_proxy(
+    _indexsets: db.AssociationProxy[list["IndexSet"]] = db.association_proxy(
         "_table_indexset_associations", "indexset"
     )
     _column_names: db.AssociationProxy[list[str | None]] = db.association_proxy(

--- a/ixmp4/data/db/optimization/utils.py
+++ b/ixmp4/data/db/optimization/utils.py
@@ -1,11 +1,15 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 import pandas as pd
 
 from . import base
 
 if TYPE_CHECKING:
+    from .equation import Equation
     from .indexset import IndexSet
+    from .parameter import Parameter
+    from .table import Table
+    from .variable import Variable
 
 
 def validate_data(
@@ -71,3 +75,26 @@ def validate_data(
             "The data contains values that are not allowed as per the IndexSets "
             "it is constrained to!"
         )
+
+
+# NOTE | does not seem to work yet for stringified type hints
+def _find_columns_linked_to_indexset(
+    item: Union["Table", "Parameter", "Equation", "Variable"], name: str
+) -> list[str]:
+    """Determine columns in `item`.data that are linked to IndexSet `name`.
+
+    Only works for `items` linked to IndexSet `name`.
+    """
+    if not item.column_names:
+        # The item's indexset_names must be a unique list of names
+        return [name]
+    else:
+        # If we have column_names, we must also have indexsets
+        assert item.indexset_names
+
+        # Handle possible duplicate values
+        return [
+            item.column_names[i]
+            for i in range(len(item.column_names))
+            if item.indexset_names[i] == name
+        ]

--- a/ixmp4/data/db/optimization/variable/model.py
+++ b/ixmp4/data/db/optimization/variable/model.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from ixmp4 import db
 from ixmp4.core.exceptions import (
@@ -7,7 +7,10 @@ from ixmp4.core.exceptions import (
 from ixmp4.data import types
 from ixmp4.data.abstract import optimization as abstract
 
-from .. import IndexSet, base, utils
+from .. import base, utils
+
+if TYPE_CHECKING:
+    from .. import IndexSet
 
 
 class VariableIndexsetAssociation(base.RootBaseModel):
@@ -18,7 +21,7 @@ class VariableIndexsetAssociation(base.RootBaseModel):
         back_populates="_variable_indexset_associations"
     )
     indexset__id: types.IndexSetId
-    indexset: types.Mapped[IndexSet] = db.relationship()
+    indexset: types.Mapped["IndexSet"] = db.relationship()
 
     column_name: types.String = db.Column(db.String(255), nullable=True)
 
@@ -57,7 +60,7 @@ class OptimizationVariable(base.BaseModel):
         )
     )
 
-    _indexsets: db.AssociationProxy[list[IndexSet]] = db.association_proxy(
+    _indexsets: db.AssociationProxy[list["IndexSet"]] = db.association_proxy(
         "_variable_indexset_associations", "indexset"
     )
     _column_names: db.AssociationProxy[list[str | None]] = db.association_proxy(

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -194,6 +194,10 @@ class VariableRepository(
 
             index_list = variable.column_names or variable.indexset_names
             if not index_list:
+                logger.warning(
+                    f"Trying to remove {data.to_dict(orient='list')} from Variable '"
+                    f"{variable.name}', but that is not indexed; not removing anything!"
+                )
                 return  # can't remove specific data from unindexed variable
 
             existing_data = pd.DataFrame(variable.data)

--- a/ixmp4/data/db/optimization/variable/repository.py
+++ b/ixmp4/data/db/optimization/variable/repository.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -19,6 +20,8 @@ from .. import base
 from .docs import OptimizationVariableDocsRepository
 from .model import OptimizationVariable as Variable
 from .model import VariableIndexsetAssociation
+
+logger = logging.getLogger(__name__)
 
 
 class VariableRepository(
@@ -173,8 +176,47 @@ class VariableRepository(
         self.session.commit()
 
     @guard("edit")
-    def remove_data(self, id: int) -> None:
+    def remove_data(
+        self, id: int, data: dict[str, Any] | pd.DataFrame | None = None
+    ) -> None:
         variable = self.get_by_id(id=id)
-        # TODO Is there a better way to reset .data?
-        variable.data = {}
+
+        if data is None:
+            # Remove all data per default
+            # TODO Is there a better way to reset .data?
+            variable.data = {}
+        else:
+            if isinstance(data, dict):
+                data = pd.DataFrame.from_dict(data=data)
+
+            if data.empty:
+                return
+
+            index_list = variable.column_names or variable.indexset_names
+            if not index_list:
+                return  # can't remove specific data from unindexed variable
+
+            existing_data = pd.DataFrame(variable.data)
+            if not existing_data.empty:
+                existing_data.set_index(index_list, inplace=True)
+
+            # This is the only kind of validation we do for removal data
+            try:
+                data.set_index(index_list, inplace=True)
+            except KeyError as e:
+                logger.error(
+                    f"Data to be removed must include {index_list} as keys/columns, "
+                    f"but {[name for name in data.columns]} were provided."
+                )
+                raise OptimizationItemUsageError(
+                    "The data to be removed must specify one or more complete indices "
+                    "to remove associated levels and marginals!"
+                ) from e
+
+            remaining_data = existing_data[~existing_data.index.isin(data.index)]
+            if not remaining_data.index.empty:
+                remaining_data.reset_index(inplace=True)
+
+            variable.data = cast(types.JsonDict, remaining_data.to_dict(orient="list"))
+
         self.session.commit()

--- a/ixmp4/data/db/run/repository.py
+++ b/ixmp4/data/db/run/repository.py
@@ -343,6 +343,10 @@ class RunRepository(
         self.session.commit()
         return run
 
+    # TODO improve performance
+    # Suggestion by meksor: write a (single) query to load all objects with run_id to a
+    # (single) dataframe, change the run_id, then write all back (does that work at
+    # once/with one query?)
     @guard("edit")
     def clone(
         self,

--- a/ixmp4/server/rest/optimization/equation.py
+++ b/ixmp4/server/rest/optimization/equation.py
@@ -25,7 +25,7 @@ class EquationCreateInput(BaseModel):
 
 
 class DataInput(BaseModel):
-    data: dict[str, Any]
+    data: dict[str, Any] | None
 
 
 @autodoc
@@ -71,9 +71,10 @@ def add_data(
 @router.delete("/{id}/data/")
 def remove_data(
     id: int,
+    data: DataInput,
     backend: Backend = Depends(deps.get_backend),
 ) -> None:
-    backend.optimization.equations.remove_data(id=id)
+    backend.optimization.equations.remove_data(id=id, **data.model_dump())
 
 
 @autodoc

--- a/ixmp4/server/rest/optimization/indexset.py
+++ b/ixmp4/server/rest/optimization/indexset.py
@@ -77,6 +77,9 @@ def add_data(
 def remove_data(
     id: int,
     data: DataInput,
+    remove_dependent_data: bool = Query(True),
     backend: Backend = Depends(deps.get_backend),
 ) -> None:
-    backend.optimization.indexsets.remove_data(id=id, **data.model_dump())
+    backend.optimization.indexsets.remove_data(
+        id=id, remove_dependent_data=remove_dependent_data, **data.model_dump()
+    )

--- a/ixmp4/server/rest/optimization/variable.py
+++ b/ixmp4/server/rest/optimization/variable.py
@@ -23,7 +23,7 @@ class VariableCreateInput(BaseModel):
 
 
 class DataInput(BaseModel):
-    data: dict[str, list[float] | list[int] | list[str]]
+    data: dict[str, list[float] | list[int] | list[str]] | None
 
 
 @autodoc
@@ -71,9 +71,10 @@ def add_data(
 @router.delete("/{id}/data/")
 def remove_data(
     id: int,
+    data: DataInput,
     backend: Backend = Depends(deps.get_backend),
 ) -> None:
-    backend.optimization.variables.remove_data(id=id)
+    backend.optimization.variables.remove_data(id=id, **data.model_dump())
 
 
 @autodoc

--- a/tests/core/test_optimization_indexset.py
+++ b/tests/core/test_optimization_indexset.py
@@ -5,6 +5,7 @@ import pytest
 import ixmp4
 from ixmp4.core import IndexSet
 from ixmp4.core.exceptions import DeletionPrevented, OptimizationDataValidationError
+from ixmp4.data.backend.api import RestBackend
 
 from ..utils import create_indexsets_for_run
 
@@ -136,17 +137,104 @@ class TestCoreIndexset:
         indexset_1.remove(data=[])
 
         assert indexset_1.data == test_data
+        # Define additional items affected by `remove_data`
+        # Define a basic affected Table
+        table = run.optimization.tables.create(
+            "Table", constrained_to_indexsets=[indexset_1.name]
+        )
+        table.add({indexset_1.name: ["do", "re", "mi"]})
+
+        # Define an affected Table without data
+        table_2 = run.optimization.tables.create(
+            "Table 2", constrained_to_indexsets=[indexset_1.name]
+        )
+
+        # Define a basic affected Parameter
+        unit = platform.units.create("Unit")
+        parameter = run.optimization.parameters.create(
+            "Parameter", constrained_to_indexsets=[indexset_1.name]
+        )
+        parameter.add(
+            {
+                indexset_1.name: ["mi", "fa", "so"],
+                "values": [1, 2, 3],
+                "units": [unit.name] * 3,
+            }
+        )
+
+        # Define a Parameter where only 1 dimension is affected
+        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        indexset_2.add(["foo", "bar", "baz"])
+        parameter_2 = run.optimization.parameters.create(
+            "Parameter 2", constrained_to_indexsets=[indexset_1.name, indexset_2.name]
+        )
+        parameter_2.add(
+            {
+                indexset_1.name: ["do", "do", "la", "ti"],
+                indexset_2.name: ["foo", "bar", "baz", "foo"],
+                "values": [1, 2, 3, 4],
+                "units": [unit.name] * 4,
+            }
+        )
+
+        # Define a Parameter with 2 affected dimensions
+        parameter_3 = run.optimization.parameters.create(
+            "Parameter 3",
+            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        parameter_3.add(
+            {
+                "Column 1": ["la", "la", "do", "ti"],
+                "Column 2": ["re", "fa", "mi", "do"],
+                "values": [1, 2, 3, 4],
+                "units": [unit.name, unit.name, unit.name, unit.name],
+            }
+        )
 
         # Test removing multiple arbitrary known data
-        remove_data = ["do", "mi", "la", "ti"]
+        remove_data = ["fa", "mi", "la", "ti"]
         expected = [data for data in test_data if data not in remove_data]
+        expected_table = [
+            data for data in table.data[indexset_1.name] if data not in remove_data
+        ]
+        expected_parameter = {
+            k: [
+                v[i]
+                for i in range(len(v))
+                if parameter.data[indexset_1.name][i] not in remove_data
+            ]
+            for k, v in parameter.data.items()
+        }
+        expected_parameter_2 = {
+            k: [
+                v[i]
+                for i in range(len(v))
+                if parameter_2.data[indexset_1.name][i] not in remove_data
+            ]
+            for k, v in parameter_2.data.items()
+        }
         indexset_1.remove(data=remove_data)
 
         assert indexset_1.data == expected
 
-        # Test removing single item
-        expected.remove("fa")
-        indexset_1.remove(data="fa")
+        # TODO Why do we need to reload items when using the rest API?
+        if isinstance(platform.backend, RestBackend):
+            table = run.optimization.tables.get(table.name)
+            parameter = run.optimization.parameters.get(parameter.name)
+            parameter_2 = run.optimization.parameters.get(parameter_2.name)
+            parameter_3 = run.optimization.parameters.get(parameter_3.name)
+
+        # Test effect on linked items
+        assert table.data[indexset_1.name] == expected_table
+        assert parameter.data == expected_parameter
+        assert parameter_2.data == expected_parameter_2
+        assert parameter_3.data == {}
+
+        # Test removing a single item
+        expected.remove("do")
+        expected_table.remove("do")
+        indexset_1.remove(data="do")
 
         assert indexset_1.data == expected
 
@@ -160,11 +248,28 @@ class TestCoreIndexset:
         indexset_1.remove(data=True)
 
         assert indexset_1.data == expected
+        if isinstance(platform.backend, RestBackend):
+            table = run.optimization.tables.get(table.name)
+            parameter_2 = run.optimization.parameters.get(parameter_2.name)
+
+        assert table.data[indexset_1.name] == expected_table
+        assert parameter_2.data == {}
 
         # Test removing all remaining data
-        indexset_1.remove(data=["so", "re"])
+        indexset_1.remove(data=["so", "re"], remove_dependent_data=False)
 
         assert indexset_1.data == []
+
+        if isinstance(platform.backend, RestBackend):
+            table = run.optimization.tables.get(table.name)
+            table_2 = run.optimization.tables.get(table_2.name)
+            parameter = run.optimization.parameters.get(parameter.name)
+
+        assert table_2.data == {}
+
+        # Test dependent items were not changed
+        assert table.data[indexset_1.name] == expected_table
+        assert parameter.data == expected_parameter
 
     def test_list_indexsets(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")

--- a/tests/data/test_optimization_equation.py
+++ b/tests/data/test_optimization_equation.py
@@ -454,6 +454,9 @@ class TestDataOptimizationEquation:
         platform.backend.optimization.equations.remove_data(
             id=equation.id, data=remove_data
         )
+        equation = platform.backend.optimization.equations.get(
+            run_id=run.id, name="Equation"
+        )
 
         assert equation.data == test_data_2
 

--- a/tests/data/test_optimization_indexset.py
+++ b/tests/data/test_optimization_indexset.py
@@ -5,6 +5,7 @@ import pytest
 import ixmp4
 from ixmp4.core.exceptions import OptimizationDataValidationError
 from ixmp4.data.abstract import IndexSet
+from ixmp4.data.backend.api import RestBackend
 
 from ..utils import assert_logs, create_indexsets_for_run
 
@@ -174,8 +175,8 @@ class TestDataOptimizationIndexSet:
         self, platform: ixmp4.Platform, caplog: pytest.LogCaptureFixture
     ) -> None:
         run = platform.backend.runs.create("Model", "Scenario")
-        (indexset,) = create_indexsets_for_run(
-            platform=platform, run_id=run.id, amount=1
+        (indexset, indexset_2) = create_indexsets_for_run(
+            platform=platform, run_id=run.id
         )
         test_data = ["do", "re", "mi", "fa", "so", "la", "ti"]
         platform.backend.optimization.indexsets.add_data(id=indexset.id, data=test_data)
@@ -188,29 +189,143 @@ class TestDataOptimizationIndexSet:
 
         assert indexset.data == test_data
 
+        # Define additional items affected by `remove_data`
+        # Define a basic affected Table
+        table = platform.backend.optimization.tables.create(
+            run_id=run.id, name="Table", constrained_to_indexsets=[indexset.name]
+        )
+        platform.backend.optimization.tables.add_data(
+            id=table.id, data={indexset.name: ["do", "re", "mi"]}
+        )
+
+        # Define an affected Table without data
+        table_2 = platform.backend.optimization.tables.create(
+            run_id=run.id, name="Table 2", constrained_to_indexsets=[indexset.name]
+        )
+
+        # Define a basic affected Parameter
+        unit = platform.units.create("Unit")
+        parameter = platform.backend.optimization.parameters.create(
+            run_id=run.id, name="Parameter", constrained_to_indexsets=[indexset.name]
+        )
+        platform.backend.optimization.parameters.add_data(
+            id=parameter.id,
+            data={
+                indexset.name: ["mi", "fa", "so"],
+                "values": [1, 2, 3],
+                "units": [unit.name] * 3,
+            },
+        )
+
+        # Define a Parameter where only 1 dimension is affected
+        platform.backend.optimization.indexsets.add_data(
+            id=indexset_2.id, data=["foo", "bar", "baz"]
+        )
+        parameter_2 = platform.backend.optimization.parameters.create(
+            run_id=run.id,
+            name="Parameter 2",
+            constrained_to_indexsets=[indexset.name, indexset_2.name],
+        )
+        platform.backend.optimization.parameters.add_data(
+            id=parameter_2.id,
+            data={
+                indexset.name: ["do", "do", "la", "ti"],
+                indexset_2.name: ["foo", "bar", "baz", "foo"],
+                "values": [1, 2, 3, 4],
+                "units": [unit.name] * 4,
+            },
+        )
+
+        # Define a Parameter with 2 affected dimensions
+        parameter_3 = platform.backend.optimization.parameters.create(
+            run_id=run.id,
+            name="Parameter 3",
+            constrained_to_indexsets=[indexset.name, indexset.name],
+            column_names=["Column 1", "Column 2"],
+        )
+        platform.backend.optimization.parameters.add_data(
+            id=parameter_3.id,
+            data={
+                "Column 1": ["la", "la", "do", "ti"],
+                "Column 2": ["re", "fa", "mi", "do"],
+                "values": [1, 2, 3, 4],
+                "units": [unit.name] * 4,
+            },
+        )
+
         # Test removing multiple arbitrary known data
-        remove_data = ["do", "mi", "la", "ti"]
+        remove_data = ["fa", "mi", "la", "ti"]
+
+        # Set expectations
         expected = [data for data in test_data if data not in remove_data]
+        table = platform.backend.optimization.tables.get(run_id=run.id, name=table.name)
+        parameter = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter.name
+        )
+        parameter_2 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter_2.name
+        )
+        parameter_3 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter_3.name
+        )
+        expected_table = [
+            data for data in table.data[indexset.name] if data not in remove_data
+        ]
+        expected_parameter = {
+            k: [
+                v[i]
+                for i in range(len(v))
+                if parameter.data[indexset.name][i] not in remove_data
+            ]
+            for k, v in parameter.data.items()
+        }
+        expected_parameter_2 = {
+            k: [
+                v[i]
+                for i in range(len(v))
+                if parameter_2.data[indexset.name][i] not in remove_data
+            ]
+            for k, v in parameter_2.data.items()
+        }
+
         platform.backend.optimization.indexsets.remove_data(
             id=indexset.id, data=remove_data
         )
         indexset = platform.backend.optimization.indexsets.get(
             run_id=run.id, name=indexset.name
         )
-
         assert indexset.data == expected
 
-        # Test removing single item
-        expected.remove("fa")
-        platform.backend.optimization.indexsets.remove_data(id=indexset.id, data="fa")
-        indexset = platform.backend.optimization.indexsets.get(
-            run_id=run.id, name=indexset.name
+        # Test effect on linked items
+        table = platform.backend.optimization.tables.get(run_id=run.id, name=table.name)
+        parameter = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter.name
         )
+        parameter_2 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter_2.name
+        )
+        parameter_3 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter_3.name
+        )
+        assert table.data[indexset.name] == expected_table
+        assert parameter.data == expected_parameter
+        assert parameter_2.data == expected_parameter_2
+        assert parameter_3.data == {}
+
+        # Test removing single item
+        expected.remove("do")
+        expected_table.remove("do")
+        platform.backend.optimization.indexsets.remove_data(id=indexset.id, data="do")
+        # TODO Why do we (only) need to reload items when using the rest API?
+        if isinstance(platform.backend, RestBackend):
+            indexset = platform.backend.optimization.indexsets.get(
+                run_id=run.id, name=indexset.name
+            )
 
         assert indexset.data == expected
 
         # Test removing non-existing data removes nothing
-        platform.backend.optimization.indexsets.remove_data(id=indexset.id, data="fa")
+        platform.backend.optimization.indexsets.remove_data(id=indexset.id, data="do")
         indexset = platform.backend.optimization.indexsets.get(
             run_id=run.id, name=indexset.name
         )
@@ -225,6 +340,13 @@ class TestDataOptimizationIndexSet:
         )
 
         assert indexset.data == expected
+
+        table = platform.backend.optimization.tables.get(run_id=run.id, name=table.name)
+        parameter_2 = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter_2.name
+        )
+        assert table.data[indexset.name] == expected_table
+        assert parameter_2.data == {}
 
         # Test removing unknown data logs messages
         with assert_logs(
@@ -241,18 +363,26 @@ class TestDataOptimizationIndexSet:
             )
             # Test partly unknown data
             platform.backend.optimization.indexsets.remove_data(
-                id=indexset.id, data=["foo", "so"]
+                id=indexset.id, data=["foo", "so"], remove_dependent_data=False
             )
 
         # Test removing all remaining data
         platform.backend.optimization.indexsets.remove_data(
-            id=indexset.id, data=["so", "re"]
+            id=indexset.id, data=["so", "re"], remove_dependent_data=False
         )
         indexset = platform.backend.optimization.indexsets.get(
             run_id=run.id, name=indexset.name
         )
-
         assert indexset.data == []
+        assert table_2.data == {}
+
+        # Test dependent items were not changed
+        table = platform.backend.optimization.tables.get(run_id=run.id, name=table.name)
+        parameter = platform.backend.optimization.parameters.get(
+            run_id=run.id, name=parameter.name
+        )
+        assert table.data[indexset.name] == expected_table
+        assert parameter.data == expected_parameter
 
     def test_list_indexsets(self, platform: ixmp4.Platform) -> None:
         run = platform.backend.runs.create("Model", "Scenario")


### PR DESCRIPTION
`message_ix.Scenario.remove_set()` expects that when an element from an `IndexSet` is removed, all corresponding keys from other optimization items (i.e. keys that contain this element from items linked the `IndexSet`) are also removed (because otherwise, the linked items would contain invalid data). This PR adds the functionality to provide the same behavior.

However, since I'm not a big of silently doing stuff in the background, our version of this comes with a flag to disable it. The default for this is `True` right now, i.e. to remove related data, but this is mainly because the function will for now mostly be called from message_ix, which needs this default. I'm happy to swap the default to `False` and have the shim layer request `True` every time it needs it if you think that's better.

The PR includes some preparatory cleanups and notes.