### PR TITLE
Add `timeout` parameter to `Run.transact()`

### DIFF
--- a/tests/core/test_transact.py
+++ b/tests/core/test_transact.py
@@ -1,0 +1,70 @@
+import threading
+import time
+
+import pytest
+
+import ixmp4
+from ixmp4.core.exceptions import RunIsLocked
+
+
+class TestCoreTransact:
+    def test_transact_timeout(self, platform: ixmp4.Platform) -> None:
+        _ = platform.runs.create("Model", "Scenario")
+        run1 = platform.runs.get("Model", "Scenario", version=1)
+        run2 = platform.runs.get("Model", "Scenario", version=1)
+
+        def background_task() -> None:
+            with run1.transact("Background transaction"):
+                time.sleep(0.2)
+
+        thread = threading.Thread(target=background_task)
+        thread.start()
+
+        time.sleep(0.1)
+
+        with run2.transact("Test transaction", timeout=1):
+            run2.meta["mstr"] = "baz"
+
+        assert run2.meta["mstr"] == "baz"
+        thread.join()
+
+    def test_transact_timeout_failure(self, platform: ixmp4.Platform) -> None:
+        _ = platform.runs.create("Model", "Scenario")
+        run1 = platform.runs.get("Model", "Scenario", version=1)
+        run2 = platform.runs.get("Model", "Scenario", version=1)
+
+        def background_task() -> None:
+            with run1.transact("Background transaction"):
+                time.sleep(1)
+
+        thread = threading.Thread(target=background_task)
+        thread.start()
+
+        time.sleep(0.1)
+
+        with pytest.raises(RunIsLocked):
+            with run2.transact("Test transaction", timeout=0.5):
+                run2.meta["mstr"] = "baz"
+
+        assert run2.meta == {}
+        thread.join()
+
+    def test_transact_is_locked(self, platform: ixmp4.Platform) -> None:
+        _ = platform.runs.create("Model", "Scenario")
+        run1 = platform.runs.get("Model", "Scenario", version=1)
+        run2 = platform.runs.get("Model", "Scenario", version=1)
+
+        def background_task() -> None:
+            with run1.transact("Background transaction"):
+                time.sleep(1)
+
+        thread = threading.Thread(target=background_task)
+        thread.start()
+
+        time.sleep(0.1)
+
+        with pytest.raises(RunIsLocked):
+            with run2.transact("Test transaction"):
+                run2.meta["mstr"] = "baz"
+
+        thread.join()


### PR DESCRIPTION
Like the title says, this PR adds a timeout parameter to the newly added `Run.transact` context manager. 
The docstring I added pretty much sums up what it does: 

```py
    @contextmanager
    def transact(
        self, message: str, timeout: float | None = None
    ) -> Generator[None, None, None]:
        """
        Context manager to lock the run before yielding control
        back to the caller. The run is unlocked and a checkpoint
        with the provided `message` is created after the context
        manager exits.
        If an exception occurs, the run is reverted to the last
        checkpoint or if no checkpoint exists, to the transaction
        the run was locked at.

        If the run is already locked, the context manager will
        throw `Run.IsLocked` or if `timeout` is provided retry until
        the timeout has passed (and then throw the original
        `Run.IsLocked` exception).

        Parameters
        ----------
        messsage : str
            The message for the checkpoint created after
            conclusion of the context manager.
        timeout : int, optional
            Timeout in seconds.

        Raises
        ------
        :class:`ixmp4.core.exceptions.RunIsLocked`
            If the run is already locked and no timeout is provided
            or the provided timeout is exceeded.
        """
```

The timeout is computed as follows for each iteration (no maximum for the amount of iterations is set):

```py
sleep_time = elapsed_time * 2
sleep_time = min(sleep_time, self.maximum_lock_timeout)
sleep_time = max(sleep_time, self.minimum_lock_timeout)
sleep_time = min(sleep_time, remaining_time)
```
Where `maximum_lock_timeout = 5.` and `minimum_lock_timeout = .1`.

This means for a timeout of `1` the logic will try to aquire the lock at the following times after the call to `transact`:
- 0 s (immediately)
- 0.1 s (minimum_lock_timeout)
- 0.3 s (0.1 + (0.1*2))
- 0.9 s (0.3 + (0.3*2))
- 1 s (`timeout`)

Does this fit your requirements @khaeru @glatterf42 ?