### PR TITLE
Fix loading of alembic configuration while using the CLI

### DIFF
--- a/ixmp4/cli/platforms.py
+++ b/ixmp4/cli/platforms.py
@@ -36,7 +36,7 @@ def validate_dsn(dsn: str | None) -> str | None:
     match = re.match(r"^(sqlite|postgresql\+psycopg|https|http)(\:\/\/)", dsn)
     if match is None:
         raise typer.BadParameter(
-            "Platform dsn must be a valid URl or database connection string."
+            "Platform dsn must be a valid URL or database connection string."
         )
     else:
         return dsn
@@ -100,7 +100,7 @@ def prompt_sqlite_removal(dsn: str) -> None:
     path = Path(dsn.replace("sqlite://", ""))
     path_str = typer.style(path, fg=typer.colors.CYAN)
     if typer.confirm(
-        "Do you want to remove the associated database file at " f"{path_str} as well?"
+        f"Do you want to remove the associated database file at {path_str} as well?"
     ):
         path.unlink()
         utils.echo("\nDatabase file deleted.")

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -43,14 +43,7 @@ class Settings(BaseSettings):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        self.storage_directory.mkdir(parents=True, exist_ok=True)
-
-        self.database_dir = self.storage_directory / "databases"
-        self.database_dir.mkdir(exist_ok=True)
-
-        self.log_dir = self.storage_directory / "log"
-        self.log_dir.mkdir(exist_ok=True)
-
+        self.setup_directories()
         self.configure_logging(self.mode)
 
         self._credentials: Credentials | None = None
@@ -92,6 +85,15 @@ class Settings(BaseSettings):
         if self._manager is None:
             self.load_manager_config()
         return self._manager  # type: ignore[return-value]
+
+    def setup_directories(self) -> None:
+        self.storage_directory.mkdir(parents=True, exist_ok=True)
+
+        self.database_dir = self.storage_directory / "databases"
+        self.database_dir.mkdir(exist_ok=True)
+
+        self.log_dir = self.storage_directory / "log"
+        self.log_dir.mkdir(exist_ok=True)
 
     def load_credentials(self) -> None:
         credentials_config = self.storage_directory / "credentials.toml"

--- a/ixmp4/db/utils/alembic.py
+++ b/ixmp4/db/utils/alembic.py
@@ -1,10 +1,18 @@
+from pathlib import Path
+
 from alembic import command
 from alembic.config import Config
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine
 
-alembic_config = Config("alembic.ini")
+from ixmp4 import __file__
+
+root = Path(__file__).parent.parent
+alembic_config = Config(root / "alembic.ini")
+alembic_config.set_main_option(
+    "script_location", str(root / "ixmp4" / "db" / "migrations")
+)
 
 
 def get_database_revision(dsn: str) -> str | None:

--- a/ixmp4/db/utils/sqlite.py
+++ b/ixmp4/db/utils/sqlite.py
@@ -3,13 +3,16 @@ from pathlib import Path
 
 from ixmp4.conf import settings
 
-database_dir = settings.storage_directory / "databases"
+
+def get_database_dir() -> Path:
+    """Returns the path to the local sqlite database directory."""
+    return settings.storage_directory / "databases"
 
 
 def yield_databases() -> Generator[Path, None, None]:
     """Yields all local sqlite database files."""
 
-    databases = database_dir.glob("*.sqlite3")
+    databases = get_database_dir().glob("*.sqlite3")
     return databases
 
 
@@ -18,7 +21,7 @@ def get_database_path(name: str) -> Path:
     Does not check whether or not the file actually exists."""
 
     file_name = name + ".sqlite3"
-    return database_dir / file_name
+    return get_database_dir() / file_name
 
 
 def get_dsn(database_path: Path) -> str:

--- a/tests/cli/test_platforms.py
+++ b/tests/cli/test_platforms.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ixmp4.cli import platforms
+from ixmp4.conf import settings
+
+runner = CliRunner()
+
+
+class TestAddPlatformCLI:
+    def test_add_platform(self, clean_storage_directory: Path) -> None:
+        result = runner.invoke(platforms.app, ["add", "test"], input="y")
+        assert result.exit_code == 0
+
+        # Assert command output
+        assert (
+            "No DSN supplied, assuming you want to add a local sqlite database..."
+            in result.stdout
+        )
+        assert (
+            "No file at the standard filesystem location for name 'test' exists. "
+            "Do you want to create a new database?"
+        ) in result.stdout
+        assert "[alembic.runtime.migration] Running upgrade" in result.stdout
+
+        assert "Platform added successfully." in result.stdout
+
+        # Check if the database file was created
+        database_file = clean_storage_directory / "databases" / "test.sqlite3"
+        assert database_file.is_file()
+
+        # Assert that the toml object now contains the new platform
+        platform_info = settings.toml.get_platform("test")
+        assert platform_info.name == "test"
+        assert "test.sqlite3" in platform_info.dsn
+
+    def test_add_platform_sqlite_dsn(self, clean_storage_directory: Path) -> None:
+        alternative_path = (
+            clean_storage_directory / "databases" / "test-alternative.sqlite3"
+        )
+        result = runner.invoke(
+            platforms.app,
+            ["add", "test", f"--dsn=sqlite://{alternative_path}"],
+            input="y",
+        )
+        assert result.exit_code == 0
+        assert "Platform added successfully." in result.stdout
+
+        # Ensure no database is created when a DSN is supplied
+        assert (
+            "No DSN supplied, assuming you want to add a local sqlite database..."
+            not in result.stdout
+        )
+        assert (
+            "No file at the standard filesystem location for name 'test' exists. "
+            "Do you want to create a new database?"
+        ) not in result.stdout
+        assert "[alembic.runtime.migration] Running upgrade" not in result.stdout
+        assert not alternative_path.is_file()
+
+    def test_add_platform_from_anywhere(
+        self, clean_storage_directory: Path, tmp_working_directory: Path
+    ) -> None:
+        # Ensure we are NOT in the ixmp4 root directory
+        assert not (tmp_working_directory / "ixmp4" / "db" / "migrations").exists()
+
+        # Assert platform creation still works
+        result = runner.invoke(platforms.app, ["add", "test"], input="y")
+        assert result.exit_code == 0
+        assert "Platform added successfully." in result.stdout
+        assert (clean_storage_directory / "databases" / "test.sqlite3").is_file()
+
+    def test_add_platform_duplicate(self, clean_storage_directory: Path) -> None:
+        runner.invoke(platforms.app, ["add", "test"], input="y").stdout
+        # Ensure the first platform is created
+        assert (clean_storage_directory / "databases" / "test.sqlite3").is_file()
+
+        # Assert failure when trying to add the same platform again
+        result = runner.invoke(platforms.app, ["add", "test"], input="y")
+        assert result.exit_code == 2
+        assert (
+            "Invalid value: Platform with name 'test' already exists."
+        ) in result.stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,16 @@
 import cProfile
+import os
 import pstats
 from collections.abc import Callable, Generator
 from contextlib import _GeneratorContextManager, contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, TypeAlias
 
 import pytest
 
 from ixmp4 import Platform
+from ixmp4.conf import settings
 from ixmp4.conf.base import PlatformInfo
 from ixmp4.core.exceptions import ProgrammingError
 from ixmp4.data.backend import RestTestBackend, SqliteTestBackend
@@ -220,3 +223,27 @@ def profiled(
 
 
 Profiled: TypeAlias = Callable[[], _GeneratorContextManager[None]]
+
+
+@pytest.fixture(scope="function")
+def clean_storage_directory() -> Generator[Path, None, None]:
+    """Fixture to create a temporary ixmp4 storage directory for tests."""
+    orginial_storage_dir = settings.storage_directory
+
+    with TemporaryDirectory() as temp_dir:
+        settings.storage_directory = Path(temp_dir)
+        settings.setup_directories()
+        settings.load_toml_config()
+        yield settings.storage_directory
+
+    settings.storage_directory = orginial_storage_dir
+
+
+@pytest.fixture(scope="function")
+def tmp_working_directory() -> Generator[Path, None, None]:
+    """Fixture to create and enter a temporary working directory for tests."""
+    with TemporaryDirectory() as temp_dir:
+        orginal_dir = os.getcwd()
+        os.chdir(temp_dir)
+        yield Path(temp_dir)
+        os.chdir(orginal_dir)


### PR DESCRIPTION
Attempts to address issue #147 by fixing the filesystem path of the alembic configuration.
For now, the configuration is loaded relative to the file of the `ixmp4` root module:
```py
from ixmp4 import __file__
root = Path(__file__).parent.parent
alembic_config = Config(root / "alembic.ini")
alembic_config.set_main_option("script_location", str(root / "ixmp4" / "db" / "migrations"))
```
Generating the `AlembicConfig` object outright is also an option, although more effort and already implemented in [`scse-toolkit`](https://github.com/iiasa/scse-toolkit/blob/main/toolkit/db/alembic/controller.py).

Also adds ! brand new ! tests for the `ixmp4 platforms add` command. 

Closes #147 