### PR TITLE
Require Run lock for certain "optimization" operations

### DIFF
--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -60,7 +60,7 @@ class RunIamcData(BaseFacade):
 
     def add(self, df: pd.DataFrame, type: DataPointModel.Type | None = None) -> None:
         self.run.require_lock()
-        df = AddDataPointFrameSchema.validate(df)  # type: ignore[assignment]
+        df = AddDataPointFrameSchema.validate(df)
         df["run__id"] = self.run.id
         df = self._get_or_create_ts(df)
         substitute_type(df, type)
@@ -68,7 +68,7 @@ class RunIamcData(BaseFacade):
 
     def remove(self, df: pd.DataFrame, type: DataPointModel.Type | None = None) -> None:
         self.run.require_lock()
-        df = RemoveDataPointFrameSchema.validate(df)  # type: ignore[assignment]
+        df = RemoveDataPointFrameSchema.validate(df)
         df["run__id"] = self.run.id
         df = self._get_or_create_ts(df)
         substitute_type(df, type)

--- a/ixmp4/core/optimization/data.py
+++ b/ixmp4/core/optimization/data.py
@@ -1,4 +1,5 @@
-from ixmp4.data.abstract import Run
+from typing import TYPE_CHECKING
+
 from ixmp4.data.backend import Backend
 
 from ..base import BaseFacade
@@ -8,6 +9,9 @@ from .parameter import ParameterRepository
 from .scalar import ScalarRepository
 from .table import TableRepository
 from .variable import VariableRepository
+
+if TYPE_CHECKING:
+    from ixmp4.core.run import Run
 
 
 class OptimizationData(BaseFacade):
@@ -21,7 +25,7 @@ class OptimizationData(BaseFacade):
     tables: TableRepository
     variables: VariableRepository
 
-    def __init__(self, run: Run, **kwargs: Backend) -> None:
+    def __init__(self, run: "Run", **kwargs: Backend) -> None:
         super().__init__(**kwargs)
         self.equations = EquationRepository(_backend=self.backend, _run=run)
         self.indexsets = IndexSetRepository(_backend=self.backend, _run=run)
@@ -30,6 +34,7 @@ class OptimizationData(BaseFacade):
         self.tables = TableRepository(_backend=self.backend, _run=run)
         self.variables = VariableRepository(_backend=self.backend, _run=run)
 
+    # TODO Improve performance by writing dedicated queries
     def remove_solution(self) -> None:
         for equation in self.equations.list():
             equation.remove_data()

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -48,7 +48,7 @@ class Run(BaseModelFacade):
 
         self.iamc = RunIamcData(_backend=self.backend, run=self)
         self._meta = RunMetaFacade(_backend=self.backend, run=self)
-        self.optimization = OptimizationData(_backend=self.backend, run=self._model)
+        self.optimization = OptimizationData(_backend=self.backend, run=self)
         self.checkpoints = RunCheckpoints(_backend=self.backend, run=self)
 
     @property

--- a/ixmp4/data/api/base.py
+++ b/ixmp4/data/api/base.py
@@ -92,8 +92,7 @@ def df_to_dict(df: pd.DataFrame) -> DataFrameDict:
         index=df.index.to_list(),
         columns=columns,
         dtypes=dtypes,
-        # https://github.com/numpy/numpy/issues/27944
-        data=df.values.tolist(),  # type: ignore[arg-type]
+        data=df.values.tolist(),
     )
 
 

--- a/ixmp4/data/db/meta/repository.py
+++ b/ixmp4/data/db/meta/repository.py
@@ -235,7 +235,7 @@ class RunMetaEntryRepository(
             # This cast should always be a no-op
             col = RunMetaEntry._column_map[cast(str, type_)]
             null_cols = set(RunMetaEntry._column_map.values()) - set([col])
-            type_df["dtype"] = type_df["dtype"].map(lambda x: x.value)  # type: ignore[union-attr]
+            type_df["dtype"] = type_df["dtype"].map(lambda x: x.value)
             type_df = type_df.rename(columns={"value": col})
 
             # ensure all other columns are overwritten

--- a/ixmp4/data/db/optimization/indexset/model.py
+++ b/ixmp4/data/db/optimization/indexset/model.py
@@ -30,7 +30,7 @@ class IndexSet(base.BaseModel):
         return (
             []
             if self._data_type is None
-            else np.array([d.value for d in self._data], dtype=self._data_type).tolist()  # type: ignore[return-value]
+            else np.array([d.value for d in self._data], dtype=self._data_type).tolist()
         )
 
     @data.setter

--- a/ixmp4/db/__init__.py
+++ b/ixmp4/db/__init__.py
@@ -104,9 +104,7 @@ IndexSet__IdType = Annotated[
     ),
 ]
 JsonType = JSON()
-# NOTE sqlalchemy's JSON is untyped, but we may not need it if we redesign the opt DB
-# model
-JsonType = JsonType.with_variant(JSONB(), "postgresql")  # type:ignore[no-untyped-call]
+JsonType = JsonType.with_variant(JSONB(), "postgresql")
 NameType = Annotated[str, Column(String(255), nullable=False, unique=False)]
 OptimizationVariableIdType = Annotated[
     int,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ requires = ["poetry-core>=1.2.0", "poetry-dynamic-versioning"]
 
 [tool.mypy]
 exclude = ['^ixmp4\/db\/migrations\/']
-disable_error_code = ['override', 'unused-ignore']
+disable_error_code = ['override']
 show_error_codes = true
 plugins = ['pandera.mypy', 'pydantic.mypy']
 # The following are equivalent to --strict mypy as seen in 

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -15,10 +15,7 @@ def test_run_meta(platform: ixmp4.Platform) -> None:
 
     with run1.transact("Add meta data"):
         # set and update different types of meta indicators
-        # NOTE mypy doesn't support setters taking a different type than
-        # their property https://github.com/python/mypy/issues/3004
-
-        run1.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}  # type: ignore[assignment]
+        run1.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
         run1.meta["mfloat"] = -1.9
 
     run2 = platform.runs.get("Model 1", "Scenario 1")
@@ -40,7 +37,7 @@ def test_run_meta(platform: ixmp4.Platform) -> None:
 
     # remove all meta indicators and set a new indicator
     with run1.transact("Update meta data"):
-        run1.meta = {"mnew": "bar"}  # type: ignore[assignment]
+        run1.meta = {"mnew": "bar"}
 
     run2 = platform.runs.get("Model 1", "Scenario 1")
 
@@ -68,9 +65,9 @@ def test_run_meta(platform: ixmp4.Platform) -> None:
 
     run2 = platform.runs.create("Model 2", "Scenario 2")
     with run1.transact("Update meta data"):
-        run1.meta = {"mstr": "baz"}  # type: ignore[assignment]
+        run1.meta = {"mstr": "baz"}
     with run2.transact("Update meta data"):
-        run2.meta = {"mfloat": 3.1415926535897}  # type: ignore[assignment]
+        run2.meta = {"mfloat": 3.1415926535897}
 
     # test default_only run filter
     exp = pd.DataFrame(
@@ -104,7 +101,7 @@ def test_run_meta(platform: ixmp4.Platform) -> None:
 
     # test filter by key
     with run1.transact("Update meta data"):
-        run1.meta = {"mstr": "baz", "mfloat": 3.1415926535897}  # type: ignore[assignment]
+        run1.meta = {"mstr": "baz", "mfloat": 3.1415926535897}
 
     exp = pd.DataFrame(
         [["Model 1", "Scenario 1", 1, "mstr", "baz"]], columns=EXP_META_COLS
@@ -132,12 +129,12 @@ def test_run_meta_numpy(
 
     # set multiple meta indicators of same type ("value"-column of numpy-type)
     with run1.transact("Add meta data"):
-        run1.meta = {"key": npvalue1, "other key": npvalue1}  # type: ignore[assignment]
+        run1.meta = {"key": npvalue1, "other key": npvalue1}
     assert run1.meta["key"] == pyvalue1
 
     # set meta indicators of different types ("value"-column of type `object`)
     with run1.transact("Update meta data"):
-        run1.meta = {"key": npvalue1, "other key": "some value"}  # type: ignore[assignment]
+        run1.meta = {"key": npvalue1, "other key": "some value"}
     assert run1.meta["key"] == pyvalue1
 
     # set meta via setter
@@ -158,7 +155,7 @@ def test_run_meta_rollback(platform: ixmp4.Platform) -> None:
     run = platform.runs.create("Model 1", "Scenario 1")
 
     with run.transact("Add meta data"):
-        run.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}  # type: ignore[assignment]
+        run.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
         run.meta["mfloat"] = -1.9
 
     try:
@@ -197,10 +194,10 @@ def test_meta_requires_lock(platform: ixmp4.Platform) -> None:
         run.meta["mint"] = 13
 
     with pytest.raises(RunLockRequired):
-        run.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}  # type: ignore[assignment]
+        run.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
 
     with run.transact("Add meta data"):
-        run.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}  # type: ignore[assignment]
+        run.meta = {"mint": 13, "mfloat": 0.0, "mstr": "foo"}
 
     # Attempt to remove data without owning a lock
     with pytest.raises(RunLockRequired):
@@ -216,7 +213,7 @@ def test_run_meta_none(platform: ixmp4.Platform, nonevalue: float | None) -> Non
 
     # set multiple indicators where one value is None
     with run1.transact("Add meta data with `None`"):
-        run1.meta = {"mint": 13, "mnone": nonevalue}  # type: ignore[assignment]
+        run1.meta = {"mint": 13, "mnone": nonevalue}
     assert run1.meta["mint"] == 13
     with pytest.raises(KeyError, match="'mnone'"):
         run1.meta["mnone"]

--- a/tests/core/test_optimization_equation.py
+++ b/tests/core/test_optimization_equation.py
@@ -42,7 +42,8 @@ class TestCoreEquation:
         run = platform.runs.create("Model", "Scenario")
 
         # Test creation without indexset
-        equation_1 = run.optimization.equations.create("Equation 1")
+        with run.transact("Test equations.create() scalar"):
+            equation_1 = run.optimization.equations.create("Equation 1")
         assert equation_1.run_id == run.id
         assert equation_1.name == "Equation 1"
         assert equation_1.data == {}
@@ -53,13 +54,14 @@ class TestCoreEquation:
 
         # Test creation with indexset
         indexset_1, _ = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        equation_2 = run.optimization.equations.create(
-            name="Equation 2",
-            constrained_to_indexsets=[indexset_1.name],
-        )
+        with run.transact("Test equations.create() linked"):
+            equation_2 = run.optimization.equations.create(
+                name="Equation 2",
+                constrained_to_indexsets=[indexset_1.name],
+            )
 
         assert equation_2.run_id == run.id
         assert equation_2.name == "Equation 2"
@@ -69,61 +71,63 @@ class TestCoreEquation:
         assert equation_2.levels == []
         assert equation_2.marginals == []
 
-        # Test duplicate name raises
-        with pytest.raises(Equation.NotUnique):
-            _ = run.optimization.equations.create(
-                "Equation 1", constrained_to_indexsets=[indexset_1.name]
-            )
-        with pytest.raises(Equation.NotUnique):
-            _ = run.optimization.equations.create(
-                "Equation 1",
+        with run.transact("Test equations.create() errors and column_names"):
+            # Test duplicate name raises
+            with pytest.raises(Equation.NotUnique):
+                _ = run.optimization.equations.create(
+                    "Equation 1", constrained_to_indexsets=[indexset_1.name]
+                )
+            with pytest.raises(Equation.NotUnique):
+                _ = run.optimization.equations.create(
+                    "Equation 1",
+                    constrained_to_indexsets=[indexset_1.name],
+                    column_names=["Column 1"],
+                )
+
+            # Test that giving column_names, but not constrained_to_indexsets raises
+            with pytest.raises(
+                OptimizationItemUsageError,
+                match="Received `column_names` to name columns, but no "
+                "`constrained_to_indexsets`",
+            ):
+                _ = run.optimization.equations.create(
+                    "Equation 0",
+                    column_names=["Dimension 1"],
+                )
+
+            # Test mismatch in constrained_to_indexsets and column_names raises
+            with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
+                _ = run.optimization.equations.create(
+                    "Equation 2",
+                    constrained_to_indexsets=[indexset_1.name],
+                    column_names=["Dimension 1", "Dimension 2"],
+                )
+
+            # Test columns_names are used for names if given
+            equation_3 = run.optimization.equations.create(
+                "Equation 3",
                 constrained_to_indexsets=[indexset_1.name],
                 column_names=["Column 1"],
             )
-
-        # Test that giving column_names, but not constrained_to_indexsets raises
-        with pytest.raises(
-            OptimizationItemUsageError,
-            match="Received `column_names` to name columns, but no "
-            "`constrained_to_indexsets`",
-        ):
-            _ = run.optimization.equations.create(
-                "Equation 0",
-                column_names=["Dimension 1"],
-            )
-
-        # Test mismatch in constrained_to_indexsets and column_names raises
-        with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
-            _ = run.optimization.equations.create(
-                "Equation 2",
-                constrained_to_indexsets=[indexset_1.name],
-                column_names=["Dimension 1", "Dimension 2"],
-            )
-
-        # Test columns_names are used for names if given
-        equation_3 = run.optimization.equations.create(
-            "Equation 3",
-            constrained_to_indexsets=[indexset_1.name],
-            column_names=["Column 1"],
-        )
         assert equation_3.column_names == ["Column 1"]
 
-        # Test duplicate column_names raise
-        with pytest.raises(
-            OptimizationItemUsageError, match="`column_names` are not unique"
-        ):
-            _ = run.optimization.equations.create(
+        with run.transact("Test equations.create() multiple column_names"):
+            # Test duplicate column_names raise
+            with pytest.raises(
+                OptimizationItemUsageError, match="`column_names` are not unique"
+            ):
+                _ = run.optimization.equations.create(
+                    name="Equation 4",
+                    constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                    column_names=["Column 1", "Column 1"],
+                )
+
+            # Test using different column names for same indexset
+            equation_4 = run.optimization.equations.create(
                 name="Equation 4",
                 constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-                column_names=["Column 1", "Column 1"],
+                column_names=["Column 1", "Column 2"],
             )
-
-        # Test using different column names for same indexset
-        equation_4 = run.optimization.equations.create(
-            name="Equation 4",
-            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-            column_names=["Column 1", "Column 2"],
-        )
 
         assert equation_4.column_names == ["Column 1", "Column 2"]
         assert equation_4.indexset_names == [indexset_1.name, indexset_1.name]
@@ -131,47 +135,51 @@ class TestCoreEquation:
     def test_delete_equation(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
 
-        equation_1 = run.optimization.equations.create(name="Equation 1")
+        with run.transact("Test equations.delete() scalar"):
+            equation_1 = run.optimization.equations.create(name="Equation 1")
 
-        # Test deletion without linked IndexSets
-        run.optimization.equations.delete(item=equation_1.name)
+            # Test deletion without linked IndexSets
+            run.optimization.equations.delete(item=equation_1.name)
 
         assert run.optimization.equations.tabulate().empty
 
         (indexset_1,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        equation_2 = run.optimization.equations.create(
-            name="Equation 2", constrained_to_indexsets=[indexset_1.name]
-        )
+        with run.transact("Test equations.delete() linked"):
+            equation_2 = run.optimization.equations.create(
+                name="Equation 2", constrained_to_indexsets=[indexset_1.name]
+            )
 
-        # TODO How to check that DeletionPrevented is raised? No other object uses
-        # Equation.id, so nothing could prevent the deletion.
+            # TODO How to check that DeletionPrevented is raised? No other object uses
+            # Equation.id, so nothing could prevent the deletion.
 
-        # Test unknown name raises
-        with pytest.raises(Equation.NotFound):
-            run.optimization.equations.delete(item="does not exist")
+            # Test unknown name raises
+            with pytest.raises(Equation.NotFound):
+                run.optimization.equations.delete(item="does not exist")
 
-        # Test normal deletion
-        run.optimization.equations.delete(item=equation_2.name)
+            # Test normal deletion
+            run.optimization.equations.delete(item=equation_2.name)
 
         assert run.optimization.equations.tabulate().empty
 
         # Confirm that IndexSet has not been deleted
         assert not run.optimization.indexsets.tabulate().empty
 
-        # Test that association table rows are deleted
-        # If they haven't, this would raise DeletionPrevented
-        run.optimization.indexsets.delete(item=indexset_1.id)
+        with run.transact("Test equations.delete() indexset linkage"):
+            # Test that association table rows are deleted
+            # If they haven't, this would raise DeletionPrevented
+            run.optimization.indexsets.delete(item=indexset_1.id)
 
     def test_get_equation(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        _ = run.optimization.equations.create(
-            name="Equation", constrained_to_indexsets=[indexset.name]
-        )
+        with run.transact("Test equations.get()"):
+            _ = run.optimization.equations.create(
+                name="Equation", constrained_to_indexsets=[indexset.name]
+            )
         equation = run.optimization.equations.get(name="Equation")
         assert equation.run_id == run.id
         assert equation.id == 1
@@ -188,11 +196,9 @@ class TestCoreEquation:
     def test_equation_add_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        indexset.add(data=["foo", "bar", ""])
-        indexset_2.add(data=[1, 2, 3])
         # pandas can only convert dicts to dataframes if the values are lists
         # or if index is given. But maybe using read_json instead of from_dict
         # can remedy this. Or maybe we want to catch the resulting
@@ -204,91 +210,102 @@ class TestCoreEquation:
             "levels": [3.14],
             "marginals": [0.000314],
         }
-        equation = run.optimization.equations.create(
-            "Equation",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-        equation.add(data=test_data_1)
+        with run.transact("Test Equation.add()"):
+            indexset.add(data=["foo", "bar", ""])
+            indexset_2.add(data=[1, 2, 3])
+            equation = run.optimization.equations.create(
+                "Equation",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            equation.add(data=test_data_1)
         assert equation.data == test_data_1
         assert equation.levels == test_data_1["levels"]
         assert equation.marginals == test_data_1["marginals"]
 
-        equation_2 = run.optimization.equations.create(
-            name="Equation 2",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-
-        with pytest.raises(
-            OptimizationItemUsageError,
-            match=r"must include the column\(s\): marginals!",
-        ):
-            equation_2.add(
-                pd.DataFrame(
-                    {
-                        indexset.name: ["foo"],
-                        indexset_2.name: [2],
-                        "levels": [1],
-                    }
-                ),
-            )
-
-        with pytest.raises(
-            OptimizationItemUsageError, match=r"must include the column\(s\): levels!"
-        ):
-            equation_2.add(
-                data=pd.DataFrame(
-                    {
-                        indexset.name: ["foo"],
-                        indexset_2.name: [2],
-                        "marginals": [0],
-                    }
-                ),
-            )
-
-        # By converting data to pd.DataFrame, we automatically enforce equal length
-        # of new columns, raises All arrays must be of the same length otherwise:
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="All arrays must be of the same length",
-        ):
-            equation_2.add(
-                data={
-                    indexset.name: ["foo", "foo"],
-                    indexset_2.name: [2, 2],
-                    "levels": [1, 2],
-                    "marginals": [3],
-                },
-            )
-
-        with pytest.raises(
-            OptimizationDataValidationError, match="contains duplicate rows"
-        ):
-            equation_2.add(
-                data={
-                    indexset.name: ["foo", "foo"],
-                    indexset_2.name: [2, 2],
-                    "levels": [1, 2],
-                    "marginals": [3.4, 5.6],
-                },
-            )
-
-        # Test that order is conserved
         test_data_2 = {
             indexset.name: ["", "", "foo", "foo", "bar", "bar"],
             indexset_2.name: [3, 1, 2, 1, 2, 3],
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [1, 3, 5, 6, 4, 2],
         }
-        equation_2.add(test_data_2)
+
+        with run.transact("Test Equation.add() errors and order"):
+            equation_2 = run.optimization.equations.create(
+                name="Equation 2",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+
+            with pytest.raises(
+                OptimizationItemUsageError,
+                match=r"must include the column\(s\): marginals!",
+            ):
+                equation_2.add(
+                    pd.DataFrame(
+                        {
+                            indexset.name: ["foo"],
+                            indexset_2.name: [2],
+                            "levels": [1],
+                        }
+                    ),
+                )
+
+            with pytest.raises(
+                OptimizationItemUsageError,
+                match=r"must include the column\(s\): levels!",
+            ):
+                equation_2.add(
+                    data=pd.DataFrame(
+                        {
+                            indexset.name: ["foo"],
+                            indexset_2.name: [2],
+                            "marginals": [0],
+                        }
+                    ),
+                )
+
+            # By converting data to pd.DataFrame, we automatically enforce equal length
+            # of new columns, raises All arrays must be of the same length otherwise:
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="All arrays must be of the same length",
+            ):
+                equation_2.add(
+                    data={
+                        indexset.name: ["foo", "foo"],
+                        indexset_2.name: [2, 2],
+                        "levels": [1, 2],
+                        "marginals": [3],
+                    },
+                )
+
+            with pytest.raises(
+                OptimizationDataValidationError, match="contains duplicate rows"
+            ):
+                equation_2.add(
+                    data={
+                        indexset.name: ["foo", "foo"],
+                        indexset_2.name: [2, 2],
+                        "levels": [1, 2],
+                        "marginals": [3.4, 5.6],
+                    },
+                )
+
+            # Test adding to scalar equation raises
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="Trying to add data to unknown columns!",
+            ):
+                equation_5 = run.optimization.equations.create("Equation 5")
+                equation_5.add(data={"foo": ["bar"], "levels": [1], "marginals": [0]})
+
+            # Test that order is conserved
+            equation_2.add(test_data_2)
+
         assert equation_2.data == test_data_2
         assert equation_2.levels == test_data_2["levels"]
         assert equation_2.marginals == test_data_2["marginals"]
 
         # Test updating of existing keys
-        equation_4 = run.optimization.equations.create(
-            name="Equation 4",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
         # NOTE entries for levels and marginals must be convertible to one of
         # (float, int, str)
         test_data_6 = {
@@ -297,14 +314,21 @@ class TestCoreEquation:
             "levels": [0.00001, "2", 2.3, 400000],
             "marginals": [6, 7.8, 9, 0],
         }
-        equation_4.add(data=test_data_6)
         test_data_7 = {
             indexset.name: ["foo", "foo", "bar", "bar", "bar"],
             indexset_2.name: [1, 2, 3, 2, 1],
             "levels": [0.00001, 2.3, 3, "400000", "5"],
             "marginals": [6, 7.8, 9, "0", 3],
         }
-        equation_4.add(data=test_data_7)
+
+        with run.transact("Test Equation.add() update"):
+            equation_4 = run.optimization.equations.create(
+                name="Equation 4",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            equation_4.add(data=test_data_6)
+            equation_4.add(data=test_data_7)
+
         expected = (
             pd.DataFrame(test_data_7)
             .set_index([indexset.name, indexset_2.name])
@@ -322,32 +346,27 @@ class TestCoreEquation:
             expected, pd.DataFrame(equation_4.data), check_dtype=False
         )
 
-        # Test adding to scalar equation raises
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="Trying to add data to unknown columns!",
-        ):
-            equation_5 = run.optimization.equations.create("Equation 5")
-            equation_5.add(data={"foo": ["bar"], "levels": [1], "marginals": [0]})
-
         # Test adding with column_names
-        equation_6 = run.optimization.equations.create(
-            name="Equation 6",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-            column_names=["Column 1", "Column 2"],
-        )
         test_data_8 = {
             "Column 1": ["", "", "foo", "foo", "bar", "bar"],
             "Column 2": [3, 1, 2, 1, 2, 3],
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [0.5] * 6,
         }
-        equation_6.add(data=test_data_8)
+
+        with run.transact("Test Equation.add() column_names"):
+            equation_6 = run.optimization.equations.create(
+                name="Equation 6",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+                column_names=["Column 1", "Column 2"],
+            )
+            equation_6.add(data=test_data_8)
 
         assert equation_6.data == test_data_8
 
         # Test adding empty data works
-        equation_6.add(pd.DataFrame())
+        with run.transact("Test Equation.add() empty data"):
+            equation_6.add(pd.DataFrame())
 
         assert equation_6.data == test_data_8
 
@@ -355,60 +374,69 @@ class TestCoreEquation:
         self, platform: ixmp4.Platform, caplog: pytest.LogCaptureFixture
     ) -> None:
         run = platform.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
-        indexset.add(data=["foo", "bar"])
-        test_data: dict[str, list[float | int | str]] = {
-            indexset.name: ["bar", "foo"],
-            "levels": [2.3, 1],
-            "marginals": [0, 4.2],
-        }
-        equation = run.optimization.equations.create(
-            "Equation",
-            constrained_to_indexsets=[indexset.name],
-        )
-        equation.add(test_data)
+        with run.transact("Test Equation.remove_data() -- preparation"):
+            indexset = run.optimization.indexsets.create("Indexset")
+            indexset.add(data=["foo", "bar"])
+            test_data: dict[str, list[float | int | str]] = {
+                indexset.name: ["bar", "foo"],
+                "levels": [2.3, 1],
+                "marginals": [0, 4.2],
+            }
+            equation = run.optimization.equations.create(
+                "Equation",
+                constrained_to_indexsets=[indexset.name],
+            )
+            equation.add(test_data)
         assert equation.data == test_data
 
         # Test removing empty data removes nothing
-        equation.remove_data(data={})
+        with run.transact("Test Equation.remove_data() empty"):
+            equation.remove_data(data={})
 
         assert equation.data == test_data
 
-        # Test incomplete index raises...
-        with pytest.raises(
-            OptimizationItemUsageError, match="data to be removed must specify"
-        ):
-            equation.remove_data(data={"foo": ["bar"]})
-
-        # ...even when removing a column that's known in principle
-        with pytest.raises(
-            OptimizationItemUsageError, match="data to be removed must specify"
-        ):
-            equation.remove_data(data={"levels": [2.3]})
-
-        # Test removing one row
         remove_data = {indexset.name: [test_data[indexset.name][0]]}
         test_data_2 = {k: [v[1]] for k, v in test_data.items()}
-        equation.remove_data(data=remove_data)
+
+        with run.transact("Test Equation.remove_data() errors and single"):
+            # Test incomplete index raises...
+            with pytest.raises(
+                OptimizationItemUsageError, match="data to be removed must specify"
+            ):
+                equation.remove_data(data={"foo": ["bar"]})
+
+            # ...even when removing a column that's known in principle
+            with pytest.raises(
+                OptimizationItemUsageError, match="data to be removed must specify"
+            ):
+                equation.remove_data(data={"levels": [2.3]})
+
+            # Test removing one row
+            equation.remove_data(data=remove_data)
+
         assert equation.data == test_data_2
 
         # Test removing non-existing (but correctly formatted) data works, even with
         # additional/unused columns
         remove_data["levels"] = [1]
-        equation.remove_data(data=remove_data)
+        with run.transact("Test Equation.remove_data() non-existing"):
+            equation.remove_data(data=remove_data)
 
         assert equation.data == test_data_2
 
         # Test removing all rows
-        equation.remove_data()
+        with run.transact("Test Equation.remove_data() all data"):
+            equation.remove_data()
+
         assert equation.data == {}
 
         # Test removing specific data from unindexed Equation warns
-        equation_2 = run.optimization.equations.create("Equation 2")
+        with run.transact("Test Equation.remove_data() warn unindexed"):
+            equation_2 = run.optimization.equations.create("Equation 2")
 
-        caplog.clear()
-        with caplog.at_level("WARNING", logger=logger.name):
-            equation_2.remove_data(data=test_data_2)
+            caplog.clear()
+            with caplog.at_level("WARNING", logger=logger.name):
+                equation_2.remove_data(data=test_data_2)
 
         expected = [
             f"Trying to remove {test_data_2} from Equation '{equation_2.name}', but "
@@ -418,25 +446,26 @@ class TestCoreEquation:
 
     def test_list_equation(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
-        # Per default, list() lists scalars for `default` version runs:
-        run.set_as_default()
         indexset, indexset_2 = create_indexsets_for_run(
             platform=platform, run_id=run.id
         )
-        equation = run.optimization.equations.create(
-            "Equation", constrained_to_indexsets=[indexset.name]
-        )
-        equation_2 = run.optimization.equations.create(
-            "Equation 2", constrained_to_indexsets=[indexset_2.name]
-        )
+        with run.transact("Test equations.list()"):
+            equation = run.optimization.equations.create(
+                "Equation", constrained_to_indexsets=[indexset.name]
+            )
+            equation_2 = run.optimization.equations.create(
+                "Equation 2", constrained_to_indexsets=[indexset_2.name]
+            )
+
         # Create new run to test listing equations of specific run
         run_2 = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run_2.id, amount=1
         )
-        run_2.optimization.equations.create(
-            "Equation", constrained_to_indexsets=[indexset.name]
-        )
+        with run_2.transact("Test equations.list() for specific run"):
+            run_2.optimization.equations.create(
+                "Equation", constrained_to_indexsets=[indexset.name]
+            )
         expected_ids = [equation.id, equation_2.id]
         list_ids = [equation.id for equation in run.optimization.equations.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -451,47 +480,52 @@ class TestCoreEquation:
     def test_tabulate_equation(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        equation = run.optimization.equations.create(
-            name="Equation",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-        equation_2 = run.optimization.equations.create(
-            name="Equation 2",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
+        with run.transact("Test equations.tabulate()"):
+            equation = run.optimization.equations.create(
+                name="Equation",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            equation_2 = run.optimization.equations.create(
+                name="Equation 2",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+
         # Create new run to test tabulating equations of specific run
         run_2 = platform.runs.create("Model", "Scenario")
         (indexset_3,) = create_indexsets_for_run(
             platform=platform, run_id=run_2.id, amount=1
         )
-        run_2.optimization.equations.create(
-            "Equation", constrained_to_indexsets=[indexset_3.name]
-        )
+        with run_2.transact("Test equations.tabulate() for specific run"):
+            run_2.optimization.equations.create(
+                "Equation", constrained_to_indexsets=[indexset_3.name]
+            )
         pd.testing.assert_frame_equal(
             df_from_list([equation_2]),
             run.optimization.equations.tabulate(name="Equation 2"),
         )
 
-        indexset.add(data=["foo", "bar"])
-        indexset_2.add(data=[1, 2, 3])
         test_data_1 = {
             indexset.name: ["foo"],
             indexset_2.name: [1],
             "levels": [314],
             "marginals": [2.0],
         }
-        equation.add(data=test_data_1)
-
         test_data_2 = {
             indexset_2.name: [2, 3],
             indexset.name: ["foo", "bar"],
             "levels": [1, -2.0],
             "marginals": [0, 10],
         }
-        equation_2.add(data=test_data_2)
+
+        with run.transact("Test equations.tabulate() with data"):
+            indexset.add(data=["foo", "bar"])
+            indexset_2.add(data=[1, 2, 3])
+            equation.add(data=test_data_1)
+            equation_2.add(data=test_data_2)
+
         pd.testing.assert_frame_equal(
             df_from_list([equation, equation_2]),
             run.optimization.equations.tabulate(),
@@ -500,14 +534,15 @@ class TestCoreEquation:
     def test_equation_docs(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(
                 platform=platform, run_id=run.id, amount=1
             )
         )
-        equation_1 = run.optimization.equations.create(
-            "Equation 1", constrained_to_indexsets=[indexset.name]
-        )
+        with run.transact("Test Equation.docs"):
+            equation_1 = run.optimization.equations.create(
+                "Equation 1", constrained_to_indexsets=[indexset.name]
+            )
         docs = "Documentation of Equation 1"
         equation_1.docs = docs
         assert equation_1.docs == docs

--- a/tests/core/test_optimization_equation.py
+++ b/tests/core/test_optimization_equation.py
@@ -6,6 +6,7 @@ from ixmp4.core import Equation, IndexSet
 from ixmp4.core.exceptions import (
     OptimizationDataValidationError,
     OptimizationItemUsageError,
+    RunLockRequired,
 )
 from ixmp4.data.backend.api import RestBackend
 from ixmp4.data.db.optimization.equation.repository import logger
@@ -51,6 +52,10 @@ class TestCoreEquation:
         assert equation_1.column_names is None
         assert equation_1.levels == []
         assert equation_1.marginals == []
+
+        # Test create without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.equations.create("Equation 2")
 
         # Test creation with indexset
         indexset_1, _ = tuple(
@@ -171,6 +176,10 @@ class TestCoreEquation:
             # If they haven't, this would raise DeletionPrevented
             run.optimization.indexsets.delete(item=indexset_1.id)
 
+        # Test delete without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.equations.delete(item="Equation 2")
+
     def test_get_equation(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
@@ -228,6 +237,10 @@ class TestCoreEquation:
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [1, 3, 5, 6, 4, 2],
         }
+
+        # Test add without run lock raises
+        with pytest.raises(RunLockRequired):
+            equation.add(data=test_data_2)
 
         with run.transact("Test Equation.add() errors and order"):
             equation_2 = run.optimization.equations.create(
@@ -394,6 +407,10 @@ class TestCoreEquation:
             equation.remove_data(data={})
 
         assert equation.data == test_data
+
+        # Test remove without run lock raises
+        with pytest.raises(RunLockRequired):
+            equation.remove_data(data={})
 
         remove_data = {indexset.name: [test_data[indexset.name][0]]}
         test_data_2 = {k: [v[1]] for k, v in test_data.items()}

--- a/tests/core/test_optimization_indexset.py
+++ b/tests/core/test_optimization_indexset.py
@@ -45,40 +45,46 @@ def df_from_list(indexsets: list[IndexSet]) -> pd.DataFrame:
 class TestCoreIndexset:
     def test_create_indexset(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
-        indexset_1 = run.optimization.indexsets.create("Indexset 1")
+        with run.transact("Test indexsets.create()"):
+            indexset_1 = run.optimization.indexsets.create("Indexset 1")
         assert indexset_1.id == 1
         assert indexset_1.name == "Indexset 1"
 
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
+        with run.transact("Test indexsets.create() 2"):
+            indexset_2 = run.optimization.indexsets.create("Indexset 2")
         assert indexset_1.id != indexset_2.id
 
-        with pytest.raises(IndexSet.NotUnique):
-            _ = run.optimization.indexsets.create("Indexset 1")
+        with run.transact("Test indexsets.create() error"):
+            with pytest.raises(IndexSet.NotUnique):
+                _ = run.optimization.indexsets.create("Indexset 1")
 
     def test_delete_indexset(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
-        indexset_1 = run.optimization.indexsets.create(name="Indexset")
-        run.optimization.indexsets.delete(item=indexset_1.name)
+        with run.transact("Test indexsets.delete()"):
+            indexset_1 = run.optimization.indexsets.create(name="Indexset")
+            run.optimization.indexsets.delete(item=indexset_1.name)
 
         # Test normal deletion
         assert run.optimization.indexsets.tabulate().empty
 
-        # Test unknown id raises
-        with pytest.raises(IndexSet.NotFound):
-            run.optimization.indexsets.delete(item="does not exist")
+        with run.transact("Test indexsets.delete() NotFound"):
+            # Test unknown id raises
+            with pytest.raises(IndexSet.NotFound):
+                run.optimization.indexsets.delete(item="does not exist")
 
         # Test DeletionPrevented is raised when IndexSet is used somewhere
         (indexset_2,) = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(
                 platform=platform, run_id=run.id, amount=1
             )
         )
-        with pytest.raises(DeletionPrevented):
-            _ = run.optimization.tables.create(
-                name="Table 1", constrained_to_indexsets=[indexset_2.name]
-            )
-            run.optimization.indexsets.delete(item=indexset_2.id)
+        with run.transact("Test indexsets.create() DeletionPrevented"):
+            with pytest.raises(DeletionPrevented):
+                _ = run.optimization.tables.create(
+                    name="Table 1", constrained_to_indexsets=[indexset_2.name]
+                )
+                run.optimization.indexsets.delete(item=indexset_2.id)
 
     def test_get_indexset(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
@@ -93,104 +99,58 @@ class TestCoreIndexset:
     def test_add_elements(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         test_data = ["foo", "bar"]
-        indexset_1 = run.optimization.indexsets.create("Indexset 1")
-        indexset_1.add(test_data)
-        run.optimization.indexsets.create("Indexset 2").add(test_data)
-        indexset_2 = run.optimization.indexsets.get("Indexset 2")
+        with run.transact("Test Indexset.add()"):
+            indexset_1 = run.optimization.indexsets.create("Indexset 1")
+            indexset_1.add(test_data)
+            run.optimization.indexsets.create("Indexset 2").add(test_data)
+            indexset_2 = run.optimization.indexsets.get("Indexset 2")
 
         assert indexset_1.data == indexset_2.data
 
-        with pytest.raises(OptimizationDataValidationError):
-            indexset_1.add(["baz", "foo"])
+        with run.transact("Test Indexset.add() errors"):
+            with pytest.raises(OptimizationDataValidationError):
+                indexset_1.add(["baz", "foo"])
 
-        with pytest.raises(OptimizationDataValidationError):
-            indexset_2.add(["baz", "baz"])
+            with pytest.raises(OptimizationDataValidationError):
+                indexset_2.add(["baz", "baz"])
 
         # Test data types are conserved
-        indexset_3 = run.optimization.indexsets.create("Indexset 3")
         test_data_2 = [1.2, 3.4, 5.6]
-        indexset_3.add(data=test_data_2)
+        with run.transact("Test Indexset.add() data types"):
+            indexset_3 = run.optimization.indexsets.create("Indexset 3")
+            indexset_3.add(data=test_data_2)
 
         assert indexset_3.data == test_data_2
         assert type(indexset_3.data[0]).__name__ == "float"
 
-        indexset_4 = run.optimization.indexsets.create("Indexset 4")
         test_data_3 = [0, 1, 2]
-        indexset_4.add(data=test_data_3)
+        with run.transact("Test Indexset.add() data types 2"):
+            indexset_4 = run.optimization.indexsets.create("Indexset 4")
+            indexset_4.add(data=test_data_3)
 
         assert indexset_4.data == test_data_3
         assert type(indexset_4.data[0]).__name__ == "int"
 
-        # Test adding empty data works
-        indexset_4.add(data=[])
+        with run.transact("Test Indexset.add() empty data"):
+            # Test adding empty data works
+            indexset_4.add(data=[])
 
         assert indexset_4.data == test_data_3
 
     def test_remove_elements(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         test_data = ["do", "re", "mi", "fa", "so", "la", "ti"]
-        indexset_1 = run.optimization.indexsets.create("Indexset 1")
-        indexset_1.add(test_data)
+        with run.transact("Test Indexset.remove()"):
+            indexset_1 = run.optimization.indexsets.create("Indexset 1")
+            indexset_1.add(test_data)
 
-        # Test removing an empty list removes nothing
-        indexset_1.remove(data=[])
+            # Test removing an empty list removes nothing
+            indexset_1.remove(data=[])
 
         assert indexset_1.data == test_data
+
         # Define additional items affected by `remove_data`
-        # Define a basic affected Table
-        table = run.optimization.tables.create(
-            "Table", constrained_to_indexsets=[indexset_1.name]
-        )
-        table.add({indexset_1.name: ["do", "re", "mi"]})
-
-        # Define an affected Table without data
-        table_2 = run.optimization.tables.create(
-            "Table 2", constrained_to_indexsets=[indexset_1.name]
-        )
-
-        # Define a basic affected Parameter
         unit = platform.units.create("Unit")
-        parameter = run.optimization.parameters.create(
-            "Parameter", constrained_to_indexsets=[indexset_1.name]
-        )
-        parameter.add(
-            {
-                indexset_1.name: ["mi", "fa", "so"],
-                "values": [1, 2, 3],
-                "units": [unit.name] * 3,
-            }
-        )
-
-        # Define a Parameter where only 1 dimension is affected
-        indexset_2 = run.optimization.indexsets.create("Indexset 2")
-        indexset_2.add(["foo", "bar", "baz"])
-        parameter_2 = run.optimization.parameters.create(
-            "Parameter 2", constrained_to_indexsets=[indexset_1.name, indexset_2.name]
-        )
-        parameter_2.add(
-            {
-                indexset_1.name: ["do", "do", "la", "ti"],
-                indexset_2.name: ["foo", "bar", "baz", "foo"],
-                "values": [1, 2, 3, 4],
-                "units": [unit.name] * 4,
-            }
-        )
-
-        # Define a Parameter with 2 affected dimensions
-        parameter_3 = run.optimization.parameters.create(
-            "Parameter 3",
-            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-            column_names=["Column 1", "Column 2"],
-        )
-        parameter_3.add(
-            {
-                "Column 1": ["la", "la", "do", "ti"],
-                "Column 2": ["re", "fa", "mi", "do"],
-                "values": [1, 2, 3, 4],
-                "units": [unit.name, unit.name, unit.name, unit.name],
-            }
-        )
-
         # Test removing multiple arbitrary known data
         remove_data = ["fa", "mi", "la", "ti"]
         expected = ["do", "re", "so"]
@@ -200,13 +160,62 @@ class TestCoreIndexset:
             "values": [3],
             "units": [unit.name],
         }
-        expected_parameter_2 = {
-            indexset_1.name: ["do", "do"],
-            indexset_2.name: ["foo", "bar"],
-            "values": [1, 2],
-            "units": [unit.name] * 2,
-        }
-        indexset_1.remove(data=remove_data)
+        with run.transact("Test Indexset.remove() linked items"):
+            # Define a basic affected Table
+            table = run.optimization.tables.create(
+                "Table", constrained_to_indexsets=[indexset_1.name]
+            )
+            table.add({indexset_1.name: ["do", "re", "mi"]})
+
+            # Define an affected Table without data
+            table_2 = run.optimization.tables.create(
+                "Table 2", constrained_to_indexsets=[indexset_1.name]
+            )
+
+            # Define a basic affected Parameter
+            parameter = run.optimization.parameters.create(
+                "Parameter", constrained_to_indexsets=[indexset_1.name]
+            )
+            parameter.add(
+                {
+                    indexset_1.name: ["mi", "fa", "so"],
+                    "values": [1, 2, 3],
+                    "units": [unit.name] * 3,
+                }
+            )
+
+            # Define a Parameter where only 1 dimension is affected
+            indexset_2 = run.optimization.indexsets.create("Indexset 2")
+            indexset_2.add(["foo", "bar", "baz"])
+            parameter_2 = run.optimization.parameters.create(
+                "Parameter 2",
+                constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            )
+            parameter_2.add(
+                {
+                    indexset_1.name: ["do", "do", "la", "ti"],
+                    indexset_2.name: ["foo", "bar", "baz", "foo"],
+                    "values": [1, 2, 3, 4],
+                    "units": [unit.name] * 4,
+                }
+            )
+
+            # Define a Parameter with 2 affected dimensions
+            parameter_3 = run.optimization.parameters.create(
+                "Parameter 3",
+                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                column_names=["Column 1", "Column 2"],
+            )
+            parameter_3.add(
+                {
+                    "Column 1": ["la", "la", "do", "ti"],
+                    "Column 2": ["re", "fa", "mi", "do"],
+                    "values": [1, 2, 3, 4],
+                    "units": [unit.name, unit.name, unit.name, unit.name],
+                }
+            )
+
+            indexset_1.remove(data=remove_data)
 
         assert indexset_1.data == expected
 
@@ -220,6 +229,12 @@ class TestCoreIndexset:
         parameter_3 = run.optimization.parameters.get(parameter_3.name)
 
         # Test effect on linked items
+        expected_parameter_2 = {
+            indexset_1.name: ["do", "do"],
+            indexset_2.name: ["foo", "bar"],
+            "values": [1, 2],
+            "units": [unit.name] * 2,
+        }
         assert table.data[indexset_1.name] == expected_table
         assert parameter.data == expected_parameter
         assert parameter_2.data == expected_parameter_2
@@ -228,18 +243,21 @@ class TestCoreIndexset:
         # Test removing a single item
         expected.remove("do")
         expected_table.remove("do")
-        indexset_1.remove(data="do")
+        with run.transact("Test Indexset.remove() linked items single"):
+            indexset_1.remove(data="do")
 
         assert indexset_1.data == expected
 
-        # Test removing non-existing data removes nothing
-        indexset_1.remove(data="fa")
+        with run.transact("Test Indexset.remove() linked items non-existing"):
+            # Test removing non-existing data removes nothing
+            indexset_1.remove(data="fa")
 
         assert indexset_1.data == expected
 
-        # Test removing wrong type removes nothing (through conversion to unknown str)
-        # NOTE Why does mypy not prevent this?
-        indexset_1.remove(data=True)
+        with run.transact("Test Indexset.remove() linked items wrong type"):
+            # Test removing wrong type removes nothing (via conversion to unknown str)
+            # NOTE Why does mypy not prevent this?
+            indexset_1.remove(data=True)
 
         assert indexset_1.data == expected
 
@@ -249,8 +267,9 @@ class TestCoreIndexset:
         assert table.data[indexset_1.name] == expected_table
         assert parameter_2.data == {}
 
-        # Test removing all remaining data
-        indexset_1.remove(data=["so", "re"], remove_dependent_data=False)
+        with run.transact("Test Indexset.remove() linked items all data"):
+            # Test removing all remaining data
+            indexset_1.remove(data=["so", "re"], remove_dependent_data=False)
 
         assert indexset_1.data == []
 
@@ -270,9 +289,9 @@ class TestCoreIndexset:
             platform=platform, run_id=run.id
         )
         # Create indexset in another run to test listing indexsets for specific run
-        platform.runs.create("Model", "Scenario").optimization.indexsets.create(
-            "Indexset 1"
-        )
+        run_2 = platform.runs.create("Model", "Scenario")
+        with run_2.transact("Test indexsets.list()"):
+            run_2.optimization.indexsets.create("Indexset 1")
         expected_ids = [indexset_1.id, indexset_2.id]
         list_ids = [indexset.id for indexset in run.optimization.indexsets.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -288,13 +307,13 @@ class TestCoreIndexset:
     def test_tabulate_indexsets(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset_1, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
         # Create indexset in another run to test tabulating indexsets for specific run
-        platform.runs.create("Model", "Scenario").optimization.indexsets.create(
-            "Indexset 1"
-        )
+        run_2 = platform.runs.create("Model", "Scenario")
+        with run_2.transact("Test indexsets.tabulate()"):
+            run_2.optimization.indexsets.create("Indexset 1")
 
         expected = df_from_list(indexsets=[indexset_1, indexset_2])
         result = run.optimization.indexsets.tabulate()
@@ -309,7 +328,7 @@ class TestCoreIndexset:
     def test_indexset_docs(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset_1,) = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(
                 platform=platform, run_id=run.id, amount=1
             )

--- a/tests/core/test_optimization_scalar.py
+++ b/tests/core/test_optimization_scalar.py
@@ -3,6 +3,7 @@ import pytest
 
 import ixmp4
 from ixmp4.core import Scalar
+from ixmp4.core.exceptions import RunLockRequired
 
 from ..utils import assert_unordered_equality
 
@@ -48,6 +49,10 @@ class TestCoreScalar:
         # assert scalar_1.unit == unit
         assert scalar_1.unit.id == unit.id
 
+        # Test create without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.scalars.create("Scalar 2", value=20)
+
         unit2 = platform.units.create("Test Unit 2")
         with run.transact("Test scalars.create() errors"):
             with pytest.raises(Scalar.NotUnique):
@@ -92,6 +97,10 @@ class TestCoreScalar:
 
         assert run.optimization.scalars.tabulate().empty
 
+        # Test delete without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.scalars.delete(item=1)
+
     def test_get_scalar(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
@@ -115,7 +124,7 @@ class TestCoreScalar:
         assert scalar.unit.id == unit.id
 
         with run.transact("Test Scalar update()"):
-            scalar.value = 30
+            scalar.value = 3.0
             scalar.unit = "Test Unit"
         # NOTE: doesn't work for some reason (but doesn't either for e.g. model.get())
         # assert scalar == run.optimization.scalars.get("Scalar")
@@ -123,8 +132,14 @@ class TestCoreScalar:
 
         assert scalar.id == result.id
         assert scalar.name == result.name
-        assert scalar.value == result.value == 30
+        assert scalar.value == result.value == 3.0
         assert scalar.unit.id == result.unit.id == 1
+
+        # Test update without run lock raises
+        with pytest.raises(RunLockRequired):
+            scalar.value = 1
+        with pytest.raises(RunLockRequired):
+            scalar.unit = "1"
 
     def test_list_scalars(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")

--- a/tests/core/test_optimization_scalar.py
+++ b/tests/core/test_optimization_scalar.py
@@ -116,9 +116,7 @@ class TestCoreScalar:
 
         with run.transact("Test Scalar update()"):
             scalar.value = 30
-            # NOTE mypy doesn't support setters taking a different type than
-            # their property https://github.com/python/mypy/issues/3004
-            scalar.unit = "Test Unit"  # type: ignore[assignment]
+            scalar.unit = "Test Unit"
         # NOTE: doesn't work for some reason (but doesn't either for e.g. model.get())
         # assert scalar == run.optimization.scalars.get("Scalar")
         result = run.optimization.scalars.get("Scalar")

--- a/tests/core/test_optimization_scalar.py
+++ b/tests/core/test_optimization_scalar.py
@@ -37,9 +37,10 @@ class TestCoreScalar:
     def test_create_scalar(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
-        scalar_1 = run.optimization.scalars.create(
-            "Scalar 1", value=10, unit="Test Unit"
-        )
+        with run.transact("Test scalars.create()"):
+            scalar_1 = run.optimization.scalars.create(
+                "Scalar 1", value=10, unit="Test Unit"
+            )
         assert scalar_1.id == 1
         assert scalar_1.name == "Scalar 1"
         assert scalar_1.value == 10
@@ -47,41 +48,55 @@ class TestCoreScalar:
         # assert scalar_1.unit == unit
         assert scalar_1.unit.id == unit.id
 
-        with pytest.raises(Scalar.NotUnique):
-            scalar_2 = run.optimization.scalars.create(
-                "Scalar 1", value=20, unit=unit.name
-            )
+        unit2 = platform.units.create("Test Unit 2")
+        with run.transact("Test scalars.create() errors"):
+            with pytest.raises(Scalar.NotUnique):
+                # Test creation with a different value
+                scalar_2 = run.optimization.scalars.create(
+                    "Scalar 1", value=20, unit=unit.name
+                )
 
-        with pytest.raises(TypeError):
-            # Testing a missing parameter on purpose
-            _ = run.optimization.scalars.create("Scalar 2")  # type: ignore[call-arg]
+            with pytest.raises(Scalar.NotUnique):
+                # Test creation with a different unit
+                _ = run.optimization.scalars.create(
+                    "Scalar 1", value=20, unit=unit2.name
+                )
 
-        scalar_2 = run.optimization.scalars.create("Scalar 2", value=20, unit=unit)
+            with pytest.raises(TypeError):
+                # Testing a missing parameter on purpose
+                _ = run.optimization.scalars.create("Scalar 2")  # type: ignore[call-arg]
+
+            scalar_2 = run.optimization.scalars.create("Scalar 2", value=20, unit=unit)
         assert scalar_1.id != scalar_2.id
 
-        scalar_3 = run.optimization.scalars.create("Scalar 3", value=1)
+        with run.transact("Test scalars.create() dimensionless"):
+            scalar_3 = run.optimization.scalars.create("Scalar 3", value=1)
         assert scalar_3.unit.name == ""
 
     def test_delete_scalar(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Unit")
-        scalar_1 = run.optimization.scalars.create(name="Scalar", value=3.14, unit=unit)
+        with run.transact("Test scalars.delete()"):
+            scalar_1 = run.optimization.scalars.create(
+                name="Scalar", value=3.14, unit=unit
+            )
 
-        # Test unknown name raises
-        with pytest.raises(Scalar.NotFound):
-            run.optimization.scalars.delete(item="does not exist")
+            # Test unknown name raises
+            with pytest.raises(Scalar.NotFound):
+                run.optimization.scalars.delete(item="does not exist")
 
-        # TODO How to check that DeletionPrevented is raised?
+            # TODO How to check that DeletionPrevented is raised?
 
-        # Test normal deletion
-        run.optimization.scalars.delete(item=scalar_1.name)
+            # Test normal deletion
+            run.optimization.scalars.delete(item=scalar_1.name)
 
         assert run.optimization.scalars.tabulate().empty
 
     def test_get_scalar(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
-        scalar = run.optimization.scalars.create("Scalar", value=10, unit=unit.name)
+        with run.transact("Test scalars.get()"):
+            scalar = run.optimization.scalars.create("Scalar", value=10, unit=unit.name)
         result = run.optimization.scalars.get(scalar.name)
         assert scalar.id == result.id
         assert scalar.name == result.name
@@ -94,18 +109,16 @@ class TestCoreScalar:
     def test_update_scalar(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
-        unit2 = platform.units.create("Test Unit 2")
-        scalar = run.optimization.scalars.create("Scalar", value=10, unit=unit.name)
+        with run.transact("Test Scalar update() -- preparation"):
+            scalar = run.optimization.scalars.create("Scalar", value=10, unit=unit.name)
         assert scalar.value == 10
         assert scalar.unit.id == unit.id
 
-        with pytest.raises(Scalar.NotUnique):
-            _ = run.optimization.scalars.create("Scalar", value=20, unit=unit2.name)
-
-        scalar.value = 30
-        # NOTE mypy doesn't support setters taking a different type than
-        # their property https://github.com/python/mypy/issues/3004
-        scalar.unit = "Test Unit"  # type: ignore[assignment]
+        with run.transact("Test Scalar update()"):
+            scalar.value = 30
+            # NOTE mypy doesn't support setters taking a different type than
+            # their property https://github.com/python/mypy/issues/3004
+            scalar.unit = "Test Unit"  # type: ignore[assignment]
         # NOTE: doesn't work for some reason (but doesn't either for e.g. model.get())
         # assert scalar == run.optimization.scalars.get("Scalar")
         result = run.optimization.scalars.get("Scalar")
@@ -118,14 +131,18 @@ class TestCoreScalar:
     def test_list_scalars(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
-        scalar_1 = run.optimization.scalars.create(
-            "Scalar 1", value=1, unit="Test Unit"
-        )
-        scalar_2 = run.optimization.scalars.create("Scalar 2", value=2, unit=unit.name)
+        with run.transact("Test scalars.list()"):
+            scalar_1 = run.optimization.scalars.create(
+                "Scalar 1", value=1, unit="Test Unit"
+            )
+            scalar_2 = run.optimization.scalars.create(
+                "Scalar 2", value=2, unit=unit.name
+            )
+
         # Create scalar in another run to test listing scalars for specific run
-        platform.runs.create("Model", "Scenario").optimization.scalars.create(
-            "Scalar 1", value=1, unit=unit
-        )
+        run_2 = platform.runs.create("Model 2", "Scenario 2")
+        with run_2.transact("Test scalars.list() 2"):
+            run_2.optimization.scalars.create("Scalar 1", value=1, unit=unit)
 
         expected_ids = [scalar_1.id, scalar_2.id]
         list_ids = [scalar.id for scalar in run.optimization.scalars.list()]
@@ -141,12 +158,18 @@ class TestCoreScalar:
     def test_tabulate_scalars(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
-        scalar_1 = run.optimization.scalars.create("Scalar 1", value=1, unit=unit.name)
-        scalar_2 = run.optimization.scalars.create("Scalar 2", value=2, unit=unit.name)
+        with run.transact("Test scalars.tabulate()"):
+            scalar_1 = run.optimization.scalars.create(
+                "Scalar 1", value=1, unit=unit.name
+            )
+            scalar_2 = run.optimization.scalars.create(
+                "Scalar 2", value=2, unit=unit.name
+            )
+
         # Create scalar in another run to test tabulating scalars for specific run
-        platform.runs.create("Model", "Scenario").optimization.scalars.create(
-            "Scalar 1", value=1, unit=unit
-        )
+        run_2 = platform.runs.create("Model", "Scenario")
+        with run_2.transact("Test scalars.tabulate() 2"):
+            run_2.optimization.scalars.create("Scalar 1", value=1, unit=unit)
 
         expected = df_from_list(scalars=[scalar_1, scalar_2])
         result = run.optimization.scalars.tabulate()
@@ -159,7 +182,10 @@ class TestCoreScalar:
     def test_scalar_docs(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         unit = platform.units.create("Test Unit")
-        scalar = run.optimization.scalars.create("Scalar 1", value=4, unit=unit.name)
+        with run.transact("Test Scalar.docs"):
+            scalar = run.optimization.scalars.create(
+                "Scalar 1", value=4, unit=unit.name
+            )
         docs = "Documentation of Scalar 1"
         scalar.docs = docs
         assert scalar.docs == docs

--- a/tests/core/test_optimization_table.py
+++ b/tests/core/test_optimization_table.py
@@ -6,6 +6,7 @@ from ixmp4.core import IndexSet, Table
 from ixmp4.core.exceptions import (
     OptimizationDataValidationError,
     OptimizationItemUsageError,
+    RunLockRequired,
 )
 
 from ..utils import create_indexsets_for_run
@@ -57,6 +58,12 @@ class TestCoreTable:
         assert table.data == {}
         assert table.indexset_names == [indexset_1.name]
         assert table.column_names is None
+
+        # Test create without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.tables.create(
+                "Table 2", constrained_to_indexsets=[indexset_1.name]
+            )
 
         with run.transact("Test tables.create() errors and column_names"):
             # Test duplicate name raises
@@ -132,6 +139,10 @@ class TestCoreTable:
             # If they haven't, this would raise DeletionPrevented
             run.optimization.indexsets.delete(item=indexset_1.id)
 
+        # Test delete without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.tables.delete(item="Table 2")
+
     def test_get_table(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
@@ -174,6 +185,10 @@ class TestCoreTable:
         assert table.data == test_data_1
 
         test_data_2 = {indexset.name: [""], indexset_2.name: [3]}
+
+        # Test add without run lock raises
+        with pytest.raises(RunLockRequired):
+            table.add(data=test_data_2)
 
         with run.transact("Test Table.add() errors"):
             table_2 = run.optimization.tables.create(
@@ -321,6 +336,10 @@ class TestCoreTable:
             indexset_1.name: ["foo"],
             indexset_2.name: [1],
         }
+
+        # Test remove without run lock raises
+        with pytest.raises(RunLockRequired):
+            table.remove(data=remove_data_1)
 
         with run.transact("Test Table.remove() errors and single"):
             # Test incomplete index raises

--- a/tests/core/test_optimization_table.py
+++ b/tests/core/test_optimization_table.py
@@ -43,13 +43,14 @@ class TestCoreTable:
 
         # Test normal creation
         indexset_1, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        table = run.optimization.tables.create(
-            "Table 1",
-            constrained_to_indexsets=[indexset_1.name],
-        )
+        with run.transact("Test tables.create()"):
+            table = run.optimization.tables.create(
+                "Table 1",
+                constrained_to_indexsets=[indexset_1.name],
+            )
         assert table.run_id == run.id
         assert table.id == 1
         assert table.name == "Table 1"
@@ -57,44 +58,46 @@ class TestCoreTable:
         assert table.indexset_names == [indexset_1.name]
         assert table.column_names is None
 
-        # Test duplicate name raises
-        with pytest.raises(Table.NotUnique):
-            _ = run.optimization.tables.create(
-                "Table 1", constrained_to_indexsets=[indexset_1.name]
-            )
+        with run.transact("Test tables.create() errors and column_names"):
+            # Test duplicate name raises
+            with pytest.raises(Table.NotUnique):
+                _ = run.optimization.tables.create(
+                    "Table 1", constrained_to_indexsets=[indexset_1.name]
+                )
 
-        # Test mismatch in constrained_to_indexsets and column_names raises
-        with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
-            _ = run.optimization.tables.create(
+            # Test mismatch in constrained_to_indexsets and column_names raises
+            with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
+                _ = run.optimization.tables.create(
+                    name="Table 2",
+                    constrained_to_indexsets=[indexset_1.name],
+                    column_names=["Dimension 1", "Dimension 2"],
+                )
+
+            # Test columns_names are used for names if given
+            table_2 = run.optimization.tables.create(
                 name="Table 2",
                 constrained_to_indexsets=[indexset_1.name],
-                column_names=["Dimension 1", "Dimension 2"],
+                column_names=["Column 1"],
             )
+        assert table_2.column_names == ["Column 1"]
 
-        # Test columns_names are used for names if given
-        table_2 = run.optimization.tables.create(
-            name="Table 2",
-            constrained_to_indexsets=[indexset_1.name],
-            column_names=["Column 1"],
-        )
-        table_2.column_names == ["Column 1"]
+        with run.transact("Test tables.create() multiple column_names"):
+            # Test duplicate column_names raise
+            with pytest.raises(
+                OptimizationItemUsageError, match="`column_names` are not unique"
+            ):
+                _ = run.optimization.tables.create(
+                    name="Table 3",
+                    constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                    column_names=["Column 1", "Column 1"],
+                )
 
-        # Test duplicate column_names raise
-        with pytest.raises(
-            OptimizationItemUsageError, match="`column_names` are not unique"
-        ):
-            _ = run.optimization.tables.create(
+            # Test using different column names for same indexset
+            table_3 = run.optimization.tables.create(
                 name="Table 3",
                 constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-                column_names=["Column 1", "Column 1"],
+                column_names=["Column 1", "Column 2"],
             )
-
-        # Test using different column names for same indexset
-        table_3 = run.optimization.tables.create(
-            name="Table 3",
-            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-            column_names=["Column 1", "Column 2"],
-        )
 
         assert table_3.column_names == ["Column 1", "Column 2"]
         assert table_3.indexset_names == [indexset_1.name, indexset_1.name]
@@ -104,37 +107,40 @@ class TestCoreTable:
         (indexset_1,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        table = run.optimization.tables.create(
-            name="Table", constrained_to_indexsets=[indexset_1.name]
-        )
+        with run.transact("Test tables.delete()"):
+            table = run.optimization.tables.create(
+                name="Table", constrained_to_indexsets=[indexset_1.name]
+            )
 
-        # TODO How to check that DeletionPrevented is raised? No other object uses
-        # Table.id, so nothing could prevent the deletion.
+            # TODO How to check that DeletionPrevented is raised? No other object uses
+            # Table.id, so nothing could prevent the deletion.
 
-        # Test unknown name raises
-        with pytest.raises(Table.NotFound):
-            run.optimization.tables.delete(item="does not exist")
+            # Test unknown name raises
+            with pytest.raises(Table.NotFound):
+                run.optimization.tables.delete(item="does not exist")
 
-        # Test normal deletion
-        run.optimization.tables.delete(item=table.name)
+            # Test normal deletion
+            run.optimization.tables.delete(item=table.name)
 
         assert run.optimization.tables.tabulate().empty
 
         # Confirm that IndexSet has not been deleted
         assert not run.optimization.indexsets.tabulate().empty
 
-        # Test that association table rows are deleted
-        # If they haven't, this would raise DeletionPrevented
-        run.optimization.indexsets.delete(item=indexset_1.id)
+        with run.transact("Test tables.delete() indexset linkage"):
+            # Test that association table rows are deleted
+            # If they haven't, this would raise DeletionPrevented
+            run.optimization.indexsets.delete(item=indexset_1.id)
 
     def test_get_table(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        _ = run.optimization.tables.create(
-            name="Table", constrained_to_indexsets=[indexset.name]
-        )
+        with run.transact("Test tables.get()"):
+            _ = run.optimization.tables.create(
+                name="Table", constrained_to_indexsets=[indexset.name]
+            )
         table = run.optimization.tables.get("Table")
         assert table.run_id == run.id
         assert table.id == 1
@@ -148,126 +154,141 @@ class TestCoreTable:
     def test_table_add_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        indexset.add(data=["foo", "bar", ""])
-        indexset_2.add([1, 2, 3])
-        # pandas can only convert dicts to dataframes if the values are lists
-        # or if index is given. But maybe using read_json instead of from_dict
-        # can remedy this. Or maybe we want to catch the resulting
-        # "ValueError: If using all scalar values, you must pass an index" and
-        # reraise a custom informative error?
-        test_data_1 = {indexset.name: ["foo"], indexset_2.name: [1]}
-        table = run.optimization.tables.create(
-            "Table",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-        table.add(data=test_data_1)
+        with run.transact("Test Table.add()"):
+            indexset.add(data=["foo", "bar", ""])
+            indexset_2.add([1, 2, 3])
+            # pandas can only convert dicts to dataframes if the values are lists
+            # or if index is given. But maybe using read_json instead of from_dict
+            # can remedy this. Or maybe we want to catch the resulting
+            # "ValueError: If using all scalar values, you must pass an index" and
+            # reraise a custom informative error?
+            test_data_1 = {indexset.name: ["foo"], indexset_2.name: [1]}
+            table = run.optimization.tables.create(
+                "Table",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            table.add(data=test_data_1)
         assert table.data == test_data_1
 
-        table_2 = run.optimization.tables.create(
-            name="Table 2",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-
-        with pytest.raises(OptimizationDataValidationError, match="missing values"):
-            table_2.add(
-                pd.DataFrame({indexset.name: [None], indexset_2.name: [2]}),
-                # empty string is allowed for now, but None or NaN raise
-            )
-
-        with pytest.raises(
-            OptimizationDataValidationError, match="contains duplicate rows"
-        ):
-            table_2.add(
-                data={indexset.name: ["foo", "foo"], indexset_2.name: [2, 2]},
-            )
-
-        # Test raising on unrecognised data.values()
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="contains values that are not allowed",
-        ):
-            table_2.add(
-                data={indexset.name: ["foo"], indexset_2.name: [0]},
-            )
-
         test_data_2 = {indexset.name: [""], indexset_2.name: [3]}
-        table_2.add(data=test_data_2)
+
+        with run.transact("Test Table.add() errors"):
+            table_2 = run.optimization.tables.create(
+                name="Table 2",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+
+            with pytest.raises(OptimizationDataValidationError, match="missing values"):
+                table_2.add(
+                    pd.DataFrame({indexset.name: [None], indexset_2.name: [2]}),
+                    # empty string is allowed for now, but None or NaN raise
+                )
+
+            with pytest.raises(
+                OptimizationDataValidationError, match="contains duplicate rows"
+            ):
+                table_2.add(
+                    data={indexset.name: ["foo", "foo"], indexset_2.name: [2, 2]},
+                )
+
+            # Test raising on unrecognised data.values()
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="contains values that are not allowed",
+            ):
+                table_2.add(
+                    data={indexset.name: ["foo"], indexset_2.name: [0]},
+                )
+
+            table_2.add(data=test_data_2)
         assert table_2.data == test_data_2
 
         # Test overwriting column names
-        table_3 = run.optimization.tables.create(
-            name="Table 3",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-            column_names=["Column 1", "Column 2"],
-        )
-        with pytest.raises(
-            OptimizationDataValidationError, match="Data is missing for some columns!"
-        ):
-            table_3.add(data={"Column 1": ["bar"]})
-
         test_data_3 = {"Column 1": ["bar"], "Column 2": [2]}
-        table_3.add(data=test_data_3)
+        with run.transact("Test Table.add() column_names"):
+            table_3 = run.optimization.tables.create(
+                name="Table 3",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+                column_names=["Column 1", "Column 2"],
+            )
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="Data is missing for some columns!",
+            ):
+                table_3.add(data={"Column 1": ["bar"]})
+
+            table_3.add(data=test_data_3)
         assert table_3.data == test_data_3
 
-        # Test data is expanded when Column.name is already present
-        table_3.add(
-            data=pd.DataFrame({"Column 1": ["foo"], "Column 2": [3]}),
-        )
+        with run.transact("Test Table.add() column_names insert"):
+            # Test raising on non-existing Column.name
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="Trying to add data to unknown columns!",
+            ):
+                table_3.add(
+                    {"Column 1": ["not there"], "Column 2": [2], "Column 3": [1]}
+                )
+
+            # Test data is expanded when Column.name is already present
+            table_3.add(
+                data=pd.DataFrame({"Column 1": ["foo"], "Column 2": [3]}),
+            )
         assert table_3.data == {"Column 1": ["bar", "foo"], "Column 2": [2, 3]}
 
-        # Test raising on non-existing Column.name
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="Trying to add data to unknown columns!",
-        ):
-            table_3.add({"Column 1": ["not there"], "Column 2": [2], "Column 3": [1]})
-
-        # Test that order is not important...
-        table_4 = run.optimization.tables.create(
-            name="Table 4",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-            column_names=["Column 1", "Column 2"],
-        )
         test_data_4 = {"Column 2": [2], "Column 1": ["bar"]}
-        table_4.add(data=test_data_4)
+
+        with run.transact("Test Table.add() order"):
+            # Test that order is not important...
+            table_4 = run.optimization.tables.create(
+                name="Table 4",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+                column_names=["Column 1", "Column 2"],
+            )
+            table_4.add(data=test_data_4)
         assert table_4.data == test_data_4
 
-        # ...even for expanding
-        table_4.add(data={"Column 1": ["foo"], "Column 2": [1]})
+        with run.transact("Test Table.add() order expanding"):
+            # ...even for expanding
+            table_4.add(data={"Column 1": ["foo"], "Column 2": [1]})
         assert table_4.data == {"Column 2": [2, 1], "Column 1": ["bar", "foo"]}
 
-        # This doesn't seem to test a distinct case compared to the above
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="Trying to add data to unknown columns!",
-        ):
-            table_4.add(
-                data={
-                    "Column 1": ["bar"],
-                    "Column 2": [3],
-                    "Indexset": ["foo"],
-                },
-            )
+        with run.transact("Test Table.add() another error"):
+            # This doesn't seem to test a distinct case compared to the above
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="Trying to add data to unknown columns!",
+            ):
+                table_4.add(
+                    data={
+                        "Column 1": ["bar"],
+                        "Column 2": [3],
+                        "Indexset": ["foo"],
+                    },
+                )
 
-        # Test various data types
-        indexset_3 = run.optimization.indexsets.create(name="Indexset 3")
-        test_data_5 = {
-            indexset.name: ["foo", "foo", "bar"],
-            indexset_3.name: [1.0, 2.2, 3.14],
-        }
-        indexset_3.add(data=[1.0, 2.2, 3.14])
-        table_5 = run.optimization.tables.create(
-            name="Table 5",
-            constrained_to_indexsets=[indexset.name, indexset_3.name],
-        )
-        table_5.add(test_data_5)
+        with run.transact("Test Table.add() order"):
+            # Test various data types
+            indexset_3 = run.optimization.indexsets.create(name="Indexset 3")
+
+            indexset_3.add(data=[1.0, 2.2, 3.14])
+            table_5 = run.optimization.tables.create(
+                name="Table 5",
+                constrained_to_indexsets=[indexset.name, indexset_3.name],
+            )
+            test_data_5 = {
+                indexset.name: ["foo", "foo", "bar"],
+                indexset_3.name: [1.0, 2.2, 3.14],
+            }
+            table_5.add(test_data_5)
         assert table_5.data == test_data_5
 
-        # Test adding nothing is a no-op
-        table_5.add(data={})
+        with run.transact("Test Table.add() empty"):
+            # Test adding nothing is a no-op
+            table_5.add(data={})
         assert table_5.data == test_data_5
 
     def test_table_remove_data(self, platform: ixmp4.Platform) -> None:
@@ -275,44 +296,47 @@ class TestCoreTable:
 
         # Prepare a table containing some test data
         indexset_1, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        indexset_1.add(data=["foo", "bar", ""])
-        indexset_2.add(data=[1, 2, 3])
         initial_data: dict[str, list[int] | list[str]] = {
             indexset_1.name: ["foo", "foo", "foo", "bar", "bar", "bar"],
             indexset_2.name: [1, 2, 3, 1, 2, 3],
         }
-        table = run.optimization.tables.create(
-            name="Table",
-            constrained_to_indexsets=[indexset_1.name, indexset_2.name],
-        )
-        table.add(data=initial_data)
+        with run.transact("Test Table.remove()"):
+            indexset_1.add(data=["foo", "bar", ""])
+            indexset_2.add(data=[1, 2, 3])
+            table = run.optimization.tables.create(
+                name="Table",
+                constrained_to_indexsets=[indexset_1.name, indexset_2.name],
+            )
+            table.add(data=initial_data)
 
-        # Test removing empty data removes nothing
-        table.remove(data={})
+            # Test removing empty data removes nothing
+            table.remove(data={})
 
         assert table.data == initial_data
 
-        # Test incomplete index raises
-        with pytest.raises(
-            OptimizationItemUsageError, match="data to be removed must specify"
-        ):
-            table.remove(data={indexset_1.name: ["foo"]})
-
-        # Test unknown keys without indexed columns raises
-        with pytest.raises(
-            OptimizationItemUsageError, match="data to be removed must specify"
-        ):
-            table.remove(data={"foo": ["bar"]})
-
-        # Test removing one row
         remove_data_1: dict[str, list[int] | list[str]] = {
             indexset_1.name: ["foo"],
             indexset_2.name: [1],
         }
-        table.remove(data=remove_data_1)
+
+        with run.transact("Test Table.remove() errors and single"):
+            # Test incomplete index raises
+            with pytest.raises(
+                OptimizationItemUsageError, match="data to be removed must specify"
+            ):
+                table.remove(data={indexset_1.name: ["foo"]})
+
+            # Test unknown keys without indexed columns raises
+            with pytest.raises(
+                OptimizationItemUsageError, match="data to be removed must specify"
+            ):
+                table.remove(data={"foo": ["bar"]})
+
+            # Test removing one row
+            table.remove(data=remove_data_1)
 
         # Prepare the expectation from the original test data
         # You can confirm manually that only the correct types are removed
@@ -324,7 +348,8 @@ class TestCoreTable:
         # Test removing non-existing (but correctly formatted) data works, even with
         # additional/unused columns
         remove_data_1["foo"] = ["bar"]
-        table.remove(data=remove_data_1)
+        with run.transact("Test Table.remove() non-existing"):
+            table.remove(data=remove_data_1)
 
         assert table.data == initial_data
 
@@ -332,7 +357,8 @@ class TestCoreTable:
         remove_data_2 = pd.DataFrame(
             {indexset_1.name: ["foo", "bar", "bar"], indexset_2.name: [3, 1, 3]}
         )
-        table.remove(data=remove_data_2)
+        with run.transact("Test Table.remove() multiple"):
+            table.remove(data=remove_data_2)
 
         # Prepare the expectation
         expected = {indexset_1.name: ["foo", "bar"], indexset_2.name: [2, 2]}
@@ -341,25 +367,29 @@ class TestCoreTable:
 
         # Test removing all remaining data
         remove_data_3 = {indexset_1.name: ["foo", "bar"], indexset_2.name: [2, 2]}
-        table.remove(data=remove_data_3)
+        with run.transact("Test Table.remove() all data"):
+            table.remove(data=remove_data_3)
 
         assert table.data == {}
 
     def test_list_tables(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         create_indexsets_for_run(platform=platform, run_id=run.id)
-        table = run.optimization.tables.create(
-            "Table", constrained_to_indexsets=["Indexset 1"]
-        )
-        table_2 = run.optimization.tables.create(
-            "Table 2", constrained_to_indexsets=["Indexset 2"]
-        )
+        with run.transact("Test tables.list()"):
+            table = run.optimization.tables.create(
+                "Table", constrained_to_indexsets=["Indexset 1"]
+            )
+            table_2 = run.optimization.tables.create(
+                "Table 2", constrained_to_indexsets=["Indexset 2"]
+            )
+
         # Create table in another run to test listing tables for specific run
         run_2 = platform.runs.create("Model", "Scenario")
-        indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
-        run_2.optimization.tables.create(
-            "Table 1", constrained_to_indexsets=[indexset_3.name]
-        )
+        with run_2.transact("Test tables.list() 2"):
+            indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
+            run_2.optimization.tables.create(
+                "Table 1", constrained_to_indexsets=[indexset_3.name]
+            )
 
         expected_ids = [table.id, table_2.id]
         list_ids = [table.id for table in run.optimization.tables.list()]
@@ -373,35 +403,40 @@ class TestCoreTable:
     def test_tabulate_table(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        table = run.optimization.tables.create(
-            name="Table",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-        table_2 = run.optimization.tables.create(
-            name="Table 2",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
+        with run.transact("Test tables.tabulate()"):
+            table = run.optimization.tables.create(
+                name="Table",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            table_2 = run.optimization.tables.create(
+                name="Table 2",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+
         # Create table in another run to test listing tables for specific run
         run_2 = platform.runs.create("Model", "Scenario")
-        indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
-        run_2.optimization.tables.create(
-            "Table 1", constrained_to_indexsets=[indexset_3.name]
-        )
+        with run_2.transact("Test tables.tabulate() 2"):
+            indexset_3 = run_2.optimization.indexsets.create("Indexset 3")
+            run_2.optimization.tables.create(
+                "Table 1", constrained_to_indexsets=[indexset_3.name]
+            )
 
         pd.testing.assert_frame_equal(
             df_from_list([table_2]),
             run.optimization.tables.tabulate(name="Table 2"),
         )
 
-        indexset.add(["foo", "bar"])
-        indexset_2.add([1, 2, 3])
-        test_data_1 = {indexset.name: ["foo"], indexset_2.name: [1]}
-        table.add(test_data_1)
-        test_data_2 = {indexset_2.name: [2, 3], indexset.name: ["foo", "bar"]}
-        table_2.add(test_data_2)
+        with run.transact("Test tables.tabulate() with data"):
+            indexset.add(["foo", "bar"])
+            indexset_2.add([1, 2, 3])
+            test_data_1 = {indexset.name: ["foo"], indexset_2.name: [1]}
+            table.add(test_data_1)
+            test_data_2 = {indexset_2.name: [2, 3], indexset.name: ["foo", "bar"]}
+            table_2.add(test_data_2)
+
         pd.testing.assert_frame_equal(
             df_from_list([table, table_2]),
             run.optimization.tables.tabulate(),
@@ -412,9 +447,10 @@ class TestCoreTable:
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        table_1 = run.optimization.tables.create(
-            "Table 1", constrained_to_indexsets=[indexset.name]
-        )
+        with run.transact("Test Table.docs"):
+            table_1 = run.optimization.tables.create(
+                "Table 1", constrained_to_indexsets=[indexset.name]
+            )
         docs = "Documentation of Table 1"
         table_1.docs = docs
         assert table_1.docs == docs

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -42,7 +42,8 @@ class TestCoreVariable:
         run = platform.runs.create("Model", "Scenario")
 
         # Test creation without indexset
-        variable = run.optimization.variables.create("Variable")
+        with run.transact("Test creating scalar Variable"):
+            variable = run.optimization.variables.create("Variable")
         assert variable.run_id == run.id
         assert variable.name == "Variable"
         assert variable.data == {}
@@ -53,13 +54,14 @@ class TestCoreVariable:
 
         # Test creation with indexset
         indexset_1, _ = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_run=run, _backend=platform.backend, _model=model)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        variable_2 = run.optimization.variables.create(
-            name="Variable 2",
-            constrained_to_indexsets=[indexset_1.name],
-        )
+        with run.transact("Test creating indexed Variable"):
+            variable_2 = run.optimization.variables.create(
+                name="Variable 2",
+                constrained_to_indexsets=[indexset_1.name],
+            )
 
         assert variable_2.run_id == run.id
         assert variable_2.name == "Variable 2"
@@ -69,61 +71,65 @@ class TestCoreVariable:
         assert variable_2.levels == []
         assert variable_2.marginals == []
 
-        # Test duplicate name raises
-        with pytest.raises(OptimizationVariable.NotUnique):
-            _ = run.optimization.variables.create(
-                "Variable", constrained_to_indexsets=[indexset_1.name]
-            )
-        with pytest.raises(OptimizationVariable.NotUnique):
-            _ = run.optimization.variables.create(
-                "Variable",
+        with run.transact("Test raising various errors for optimization Variable"):
+            # Test duplicate name raises
+            with pytest.raises(OptimizationVariable.NotUnique):
+                _ = run.optimization.variables.create(
+                    "Variable", constrained_to_indexsets=[indexset_1.name]
+                )
+            with pytest.raises(OptimizationVariable.NotUnique):
+                _ = run.optimization.variables.create(
+                    "Variable",
+                    constrained_to_indexsets=[indexset_1.name],
+                    column_names=["Column 1"],
+                )
+
+            # Test that giving column_names, but not constrained_to_indexsets raises
+            with pytest.raises(
+                OptimizationItemUsageError,
+                match="Received `column_names` to name columns, but no "
+                "`constrained_to_indexsets`",
+            ):
+                _ = run.optimization.variables.create(
+                    "Variable 0",
+                    column_names=["Dimension 1"],
+                )
+
+            # Test mismatch in constrained_to_indexsets and column_names raises
+            with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
+                _ = run.optimization.variables.create(
+                    "Variable 0",
+                    constrained_to_indexsets=[indexset_1.name],
+                    column_names=["Dimension 1", "Dimension 2"],
+                )
+
+        with run.transact("Test creating Variable with column_names"):
+            # Test columns_names are used for names if given
+            variable_3 = run.optimization.variables.create(
+                "Variable 3",
                 constrained_to_indexsets=[indexset_1.name],
                 column_names=["Column 1"],
             )
-
-        # Test that giving column_names, but not constrained_to_indexsets raises
-        with pytest.raises(
-            OptimizationItemUsageError,
-            match="Received `column_names` to name columns, but no "
-            "`constrained_to_indexsets`",
-        ):
-            _ = run.optimization.variables.create(
-                "Variable 0",
-                column_names=["Dimension 1"],
-            )
-
-        # Test mismatch in constrained_to_indexsets and column_names raises
-        with pytest.raises(OptimizationItemUsageError, match="not equal in length"):
-            _ = run.optimization.variables.create(
-                "Variable 0",
-                constrained_to_indexsets=[indexset_1.name],
-                column_names=["Dimension 1", "Dimension 2"],
-            )
-
-        # Test columns_names are used for names if given
-        variable_3 = run.optimization.variables.create(
-            "Variable 3",
-            constrained_to_indexsets=[indexset_1.name],
-            column_names=["Column 1"],
-        )
         assert variable_3.column_names == ["Column 1"]
 
-        # Test duplicate column_names raise
-        with pytest.raises(
-            OptimizationItemUsageError, match="`column_names` are not unique"
-        ):
-            _ = run.optimization.variables.create(
-                name="Variable 0",
-                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-                column_names=["Column 1", "Column 1"],
-            )
+        with run.transact("Test duplicate column_names for opt.Var"):
+            # Test duplicate column_names raise
+            with pytest.raises(
+                OptimizationItemUsageError, match="`column_names` are not unique"
+            ):
+                _ = run.optimization.variables.create(
+                    name="Variable 0",
+                    constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                    column_names=["Column 1", "Column 1"],
+                )
 
-        # Test using different column names for same indexset
-        variable_4 = run.optimization.variables.create(
-            name="Variable 4",
-            constrained_to_indexsets=[indexset_1.name, indexset_1.name],
-            column_names=["Column 1", "Column 2"],
-        )
+        with run.transact("Test opt.Var with different column_names for same indexset"):
+            # Test using different column names for same indexset
+            variable_4 = run.optimization.variables.create(
+                name="Variable 4",
+                constrained_to_indexsets=[indexset_1.name, indexset_1.name],
+                column_names=["Column 1", "Column 2"],
+            )
 
         assert variable_4.column_names == ["Column 1", "Column 2"]
         assert variable_4.indexset_names == [indexset_1.name, indexset_1.name]
@@ -131,29 +137,31 @@ class TestCoreVariable:
     def test_delete_variable(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
 
-        variable_1 = run.optimization.variables.create(name="Variable 1")
+        with run.transact("Test deletion of scalar Variable"):
+            variable_1 = run.optimization.variables.create(name="Variable 1")
 
-        # Test deletion without linked IndexSets
-        run.optimization.variables.delete(item=variable_1.name)
+            # Test deletion without linked IndexSets
+            run.optimization.variables.delete(item=variable_1.name)
 
         assert run.optimization.variables.tabulate().empty
 
         (indexset_1,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        variable_2 = run.optimization.variables.create(
-            name="Variable 2", constrained_to_indexsets=[indexset_1.name]
-        )
+        with run.transact("Test deletion of indexed Variable"):
+            variable_2 = run.optimization.variables.create(
+                name="Variable 2", constrained_to_indexsets=[indexset_1.name]
+            )
 
-        # TODO How to check that DeletionPrevented is raised? No other object uses
-        # Variable.id, so nothing could prevent the deletion.
+            # TODO How to check that DeletionPrevented is raised? No other object uses
+            # Variable.id, so nothing could prevent the deletion.
 
-        # Test unknown name raises
-        with pytest.raises(OptimizationVariable.NotFound):
-            run.optimization.variables.delete(item="does not exist")
+            # Test unknown name raises
+            with pytest.raises(OptimizationVariable.NotFound):
+                run.optimization.variables.delete(item="does not exist")
 
-        # Test normal deletion
-        run.optimization.variables.delete(item=variable_2.name)
+            # Test normal deletion
+            run.optimization.variables.delete(item=variable_2.name)
 
         assert run.optimization.variables.tabulate().empty
 
@@ -162,16 +170,18 @@ class TestCoreVariable:
 
         # Test that association table rows are deleted
         # If they haven't, this would raise DeletionPrevented
-        run.optimization.indexsets.delete(item=indexset_1.id)
+        with run.transact("Test indexsets.delete() in variables.delete()"):
+            run.optimization.indexsets.delete(item=indexset_1.id)
 
     def test_get_variable(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        _ = run.optimization.variables.create(
-            name="Variable", constrained_to_indexsets=[indexset.name]
-        )
+        with run.transact("Test get Variable"):
+            _ = run.optimization.variables.create(
+                name="Variable", constrained_to_indexsets=[indexset.name]
+            )
         variable = run.optimization.variables.get(name="Variable")
         assert variable.run_id == run.id
         assert variable.id == 1
@@ -188,11 +198,9 @@ class TestCoreVariable:
     def test_variable_add_data(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        indexset.add(data=["foo", "bar", ""])
-        indexset_2.add(data=[1, 2, 3])
         # pandas can only convert dicts to dataframes if the values are lists
         # or if index is given. But maybe using read_json instead of from_dict
         # can remedy this. Or maybe we want to catch the resulting
@@ -204,91 +212,93 @@ class TestCoreVariable:
             "levels": [3.14],
             "marginals": [0.000314],
         }
-        variable = run.optimization.variables.create(
-            "Variable",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-        variable.add(data=test_data_1)
+
+        with run.transact("Test Variable.add()"):
+            indexset.add(data=["foo", "bar", ""])
+            indexset_2.add(data=[1, 2, 3])
+            variable = run.optimization.variables.create(
+                "Variable",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            variable.add(data=test_data_1)
         assert variable.data == test_data_1
         assert variable.levels == test_data_1["levels"]
         assert variable.marginals == test_data_1["marginals"]
 
-        variable_2 = run.optimization.variables.create(
-            name="Variable 2",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-
-        with pytest.raises(
-            OptimizationItemUsageError,
-            match=r"must include the column\(s\): marginals!",
-        ):
-            variable_2.add(
-                pd.DataFrame(
-                    {
-                        indexset.name: ["foo"],
-                        indexset_2.name: [2],
-                        "levels": [1],
-                    }
-                ),
-            )
-
-        with pytest.raises(
-            OptimizationItemUsageError, match=r"must include the column\(s\): levels!"
-        ):
-            variable_2.add(
-                data=pd.DataFrame(
-                    {
-                        indexset.name: ["foo"],
-                        indexset_2.name: [2],
-                        "marginals": [0],
-                    }
-                ),
-            )
-
-        # By converting data to pd.DataFrame, we automatically enforce equal length
-        # of new columns, raises All arrays must be of the same length otherwise:
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="All arrays must be of the same length",
-        ):
-            variable_2.add(
-                data={
-                    indexset.name: ["foo", "foo"],
-                    indexset_2.name: [2, 2],
-                    "levels": [1, 2],
-                    "marginals": [3],
-                },
-            )
-
-        with pytest.raises(
-            OptimizationDataValidationError, match="contains duplicate rows"
-        ):
-            variable_2.add(
-                data={
-                    indexset.name: ["foo", "foo"],
-                    indexset_2.name: [2, 2],
-                    "levels": [1, 2],
-                    "marginals": [3.4, 5.6],
-                },
-            )
-
-        # Test that order is conserved
         test_data_2 = {
             indexset.name: ["", "", "foo", "foo", "bar", "bar"],
             indexset_2.name: [3, 1, 2, 1, 2, 3],
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [1, 3, 5, 6, 4, 2],
         }
-        variable_2.add(test_data_2)
+
+        with run.transact("Test Variable.add() errors and order"):
+            variable_2 = run.optimization.variables.create(
+                name="Variable 2",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+
+            with pytest.raises(
+                OptimizationItemUsageError,
+                match=r"must include the column\(s\): marginals!",
+            ):
+                variable_2.add(
+                    pd.DataFrame(
+                        {
+                            indexset.name: ["foo"],
+                            indexset_2.name: [2],
+                            "levels": [1],
+                        }
+                    ),
+                )
+
+            with pytest.raises(
+                OptimizationItemUsageError,
+                match=r"must include the column\(s\): levels!",
+            ):
+                variable_2.add(
+                    data=pd.DataFrame(
+                        {
+                            indexset.name: ["foo"],
+                            indexset_2.name: [2],
+                            "marginals": [0],
+                        }
+                    ),
+                )
+
+            # By converting data to pd.DataFrame, we automatically enforce equal length
+            # of new columns, raises All arrays must be of the same length otherwise:
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="All arrays must be of the same length",
+            ):
+                variable_2.add(
+                    data={
+                        indexset.name: ["foo", "foo"],
+                        indexset_2.name: [2, 2],
+                        "levels": [1, 2],
+                        "marginals": [3],
+                    },
+                )
+
+            with pytest.raises(
+                OptimizationDataValidationError, match="contains duplicate rows"
+            ):
+                variable_2.add(
+                    data={
+                        indexset.name: ["foo", "foo"],
+                        indexset_2.name: [2, 2],
+                        "levels": [1, 2],
+                        "marginals": [3.4, 5.6],
+                    },
+                )
+
+            # Test that order is conserved
+            variable_2.add(test_data_2)
         assert variable_2.data == test_data_2
         assert variable_2.levels == test_data_2["levels"]
         assert variable_2.marginals == test_data_2["marginals"]
 
-        # Test updating of existing keys
-        variable_4 = run.optimization.variables.create(
-            name="Variable 4",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
         # NOTE entries for levels and marginals must be convertible to one of
         # (float, int, str)
         test_data_6 = {
@@ -297,14 +307,21 @@ class TestCoreVariable:
             "levels": [0.00001, "2", 2.3, 400000],
             "marginals": [6, 7.8, 9, 0],
         }
-        variable_4.add(data=test_data_6)
         test_data_7 = {
             indexset.name: ["foo", "foo", "bar", "bar", "bar"],
             indexset_2.name: [1, 2, 3, 2, 1],
             "levels": [0.00001, 2.3, 3, "400000", "5"],
             "marginals": [6, 7.8, 9, "0", 3],
         }
-        variable_4.add(data=test_data_7)
+
+        # Test updating of existing keys
+        with run.transact("Test Variable upsert"):
+            variable_4 = run.optimization.variables.create(
+                name="Variable 4",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            variable_4.add(data=test_data_6)
+            variable_4.add(data=test_data_7)
         expected = (
             pd.DataFrame(test_data_7)
             .set_index([indexset.name, indexset_2.name])
@@ -323,31 +340,35 @@ class TestCoreVariable:
         )
 
         # Test adding to scalar variable raises
-        with pytest.raises(
-            OptimizationDataValidationError,
-            match="Trying to add data to unknown columns!",
-        ):
-            variable_5 = run.optimization.variables.create("Variable 5")
-            variable_5.add(data={"foo": ["bar"], "levels": [1], "marginals": [0]})
+        with run.transact("Test raising on adding to scalar Variable"):
+            with pytest.raises(
+                OptimizationDataValidationError,
+                match="Trying to add data to unknown columns!",
+            ):
+                variable_5 = run.optimization.variables.create("Variable 5")
+                variable_5.add(data={"foo": ["bar"], "levels": [1], "marginals": [0]})
 
-        # Test adding with column_names
-        variable_6 = run.optimization.variables.create(
-            name="Variable 6",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-            column_names=["Column 1", "Column 2"],
-        )
         test_data_8 = {
             "Column 1": ["", "", "foo", "foo", "bar", "bar"],
             "Column 2": [3, 1, 2, 1, 2, 3],
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [0.5] * 6,
         }
-        variable_6.add(data=test_data_8)
+
+        # Test adding with column_names
+        with run.transact("Test Variable.add() with column_names"):
+            variable_6 = run.optimization.variables.create(
+                name="Variable 6",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+                column_names=["Column 1", "Column 2"],
+            )
+            variable_6.add(data=test_data_8)
 
         assert variable_6.data == test_data_8
 
         # Test adding empty data works
-        variable_6.add(pd.DataFrame())
+        with run.transact("Test Variable.add() with empty data"):
+            variable_6.add(pd.DataFrame())
 
         assert variable_6.data == test_data_8
 
@@ -355,60 +376,67 @@ class TestCoreVariable:
         self, platform: ixmp4.Platform, caplog: pytest.LogCaptureFixture
     ) -> None:
         run = platform.runs.create("Model", "Scenario")
-        indexset = run.optimization.indexsets.create("Indexset")
-        indexset.add(data=["foo", "bar"])
         test_data: dict[str, list[float | int | str]] = {
             "Indexset": ["bar", "foo"],
             "levels": [2.3, 1],
             "marginals": [0, 4.2],
         }
-        variable = run.optimization.variables.create(
-            "Variable",
-            constrained_to_indexsets=[indexset.name],
-        )
-        variable.add(test_data)
+
+        with run.transact("Test Variable.remove_data() -- preparation"):
+            indexset = run.optimization.indexsets.create("Indexset")
+            indexset.add(data=["foo", "bar"])
+            variable = run.optimization.variables.create(
+                "Variable",
+                constrained_to_indexsets=[indexset.name],
+            )
+            variable.add(test_data)
         assert variable.data == test_data
 
         # Test removing empty data removes nothing
-        variable.remove_data(data={})
+        with run.transact("Test Variable.remove_data()"):
+            variable.remove_data(data={})
 
         assert variable.data == test_data
 
-        # Test incomplete index raises...
-        with pytest.raises(
-            OptimizationItemUsageError, match="data to be removed must specify"
-        ):
-            variable.remove_data(data={"foo": ["bar"]})
+        with run.transact("Test Variable.remove_data() errors"):
+            # Test incomplete index raises...
+            with pytest.raises(
+                OptimizationItemUsageError, match="data to be removed must specify"
+            ):
+                variable.remove_data(data={"foo": ["bar"]})
 
-        # ...even when removing a column that's known in principle
-        with pytest.raises(
-            OptimizationItemUsageError, match="data to be removed must specify"
-        ):
-            variable.remove_data(data={"levels": [2.3]})
+            # ...even when removing a column that's known in principle
+            with pytest.raises(
+                OptimizationItemUsageError, match="data to be removed must specify"
+            ):
+                variable.remove_data(data={"levels": [2.3]})
 
-        # Test removing one row
-        remove_data = {indexset.name: [test_data[indexset.name][0]]}
-        test_data_2 = {k: [v[1]] for k, v in test_data.items()}
-        variable.remove_data(data=remove_data)
+            # Test removing one row
+            remove_data = {indexset.name: [test_data[indexset.name][0]]}
+            test_data_2 = {k: [v[1]] for k, v in test_data.items()}
+            variable.remove_data(data=remove_data)
         assert variable.data == test_data_2
 
         # Test removing non-existing (but correctly formatted) data works, even with
         # additional/unused columns
         remove_data["levels"] = [1]
-        variable.remove_data(data=remove_data)
+        with run.transact("Test Variable.remove_data() for non-existing data"):
+            variable.remove_data(data=remove_data)
 
         assert variable.data == test_data_2
 
         # Test removing all rows
-        variable.remove_data()
+        with run.transact("Test Variable.remove_data() for all data"):
+            variable.remove_data()
         assert variable.data == {}
 
         # Test removing specific data from unindexed Equation warns
-        variable_2 = run.optimization.variables.create("Variable 2")
+        with run.transact("Test Variable.remove_data() warns on scalar Variable"):
+            variable_2 = run.optimization.variables.create("Variable 2")
 
-        caplog.clear()
-        with caplog.at_level("WARNING", logger=logger.name):
-            variable_2.remove_data(data=test_data_2)
+            caplog.clear()
+            with caplog.at_level("WARNING", logger=logger.name):
+                variable_2.remove_data(data=test_data_2)
 
         expected = [
             f"Trying to remove {test_data_2} from Variable '{variable_2.name}', but "
@@ -421,20 +449,23 @@ class TestCoreVariable:
         indexset, indexset_2 = create_indexsets_for_run(
             platform=platform, run_id=run.id
         )
-        variable = run.optimization.variables.create(
-            "Variable", constrained_to_indexsets=[indexset.name]
-        )
-        variable_2 = run.optimization.variables.create(
-            "Variable 2", constrained_to_indexsets=[indexset_2.name]
-        )
+        with run.transact("Test variables.list()"):
+            variable = run.optimization.variables.create(
+                "Variable", constrained_to_indexsets=[indexset.name]
+            )
+            variable_2 = run.optimization.variables.create(
+                "Variable 2", constrained_to_indexsets=[indexset_2.name]
+            )
+
         # Create new run to test listing variables for specific run
         run_2 = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run_2.id, amount=1
         )
-        run_2.optimization.variables.create(
-            "Variable", constrained_to_indexsets=[indexset.name]
-        )
+        with run_2.transact("Test variables.list() for specific run"):
+            run_2.optimization.variables.create(
+                "Variable", constrained_to_indexsets=[indexset.name]
+            )
         expected_ids = [variable.id, variable_2.id]
         list_ids = [variable.id for variable in run.optimization.variables.list()]
         assert not (set(expected_ids) ^ set(list_ids))
@@ -449,47 +480,51 @@ class TestCoreVariable:
     def test_tabulate_variable(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         indexset, indexset_2 = tuple(
-            IndexSet(_backend=platform.backend, _model=model)
+            IndexSet(_backend=platform.backend, _model=model, _run=run)
             for model in create_indexsets_for_run(platform=platform, run_id=run.id)
         )
-        variable = run.optimization.variables.create(
-            name="Variable",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
-        variable_2 = run.optimization.variables.create(
-            name="Variable 2",
-            constrained_to_indexsets=[indexset.name, indexset_2.name],
-        )
+        with run.transact("Test variables.tabulate()"):
+            variable = run.optimization.variables.create(
+                name="Variable",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+            variable_2 = run.optimization.variables.create(
+                name="Variable 2",
+                constrained_to_indexsets=[indexset.name, indexset_2.name],
+            )
+
         # Create new run to test tabulating variables for specific run
         run_2 = platform.runs.create("Model", "Scenario")
         (indexset_3,) = create_indexsets_for_run(
             platform=platform, run_id=run_2.id, amount=1
         )
-        run_2.optimization.variables.create(
-            "Variable", constrained_to_indexsets=[indexset_3.name]
-        )
+        with run_2.transact("Test variables.tabulate() for specific run"):
+            run_2.optimization.variables.create(
+                "Variable", constrained_to_indexsets=[indexset_3.name]
+            )
         pd.testing.assert_frame_equal(
             df_from_list([variable_2]),
             run.optimization.variables.tabulate(name="Variable 2"),
         )
 
-        indexset.add(data=["foo", "bar"])
-        indexset_2.add(data=[1, 2, 3])
         test_data_1 = {
             indexset.name: ["foo"],
             indexset_2.name: [1],
             "levels": [314],
             "marginals": [2.0],
         }
-        variable.add(data=test_data_1)
-
         test_data_2 = {
             indexset_2.name: [2, 3],
             indexset.name: ["foo", "bar"],
             "levels": [1, -2.0],
             "marginals": [0, 10],
         }
-        variable_2.add(data=test_data_2)
+        with run.transact("Test variables.tabulate() with data"):
+            indexset.add(data=["foo", "bar"])
+            indexset_2.add(data=[1, 2, 3])
+            variable.add(data=test_data_1)
+            variable_2.add(data=test_data_2)
+
         pd.testing.assert_frame_equal(
             df_from_list([variable, variable_2]),
             run.optimization.variables.tabulate(),
@@ -500,9 +535,10 @@ class TestCoreVariable:
         (indexset,) = create_indexsets_for_run(
             platform=platform, run_id=run.id, amount=1
         )
-        variable_1 = run.optimization.variables.create(
-            "Variable 1", constrained_to_indexsets=[indexset.name]
-        )
+        with run.transact("Test Variable.docs"):
+            variable_1 = run.optimization.variables.create(
+                "Variable 1", constrained_to_indexsets=[indexset.name]
+            )
         docs = "Documentation of Variable 1"
         variable_1.docs = docs
         assert variable_1.docs == docs

--- a/tests/core/test_optimization_variable.py
+++ b/tests/core/test_optimization_variable.py
@@ -6,6 +6,7 @@ from ixmp4.core import IndexSet, OptimizationVariable
 from ixmp4.core.exceptions import (
     OptimizationDataValidationError,
     OptimizationItemUsageError,
+    RunLockRequired,
 )
 from ixmp4.data.backend.api import RestBackend
 from ixmp4.data.db.optimization.variable.repository import logger
@@ -51,6 +52,10 @@ class TestCoreVariable:
         assert variable.column_names is None
         assert variable.levels == []
         assert variable.marginals == []
+
+        # Test create without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.variables.create("Variable 2")
 
         # Test creation with indexset
         indexset_1, _ = tuple(
@@ -173,6 +178,10 @@ class TestCoreVariable:
         with run.transact("Test indexsets.delete() in variables.delete()"):
             run.optimization.indexsets.delete(item=indexset_1.id)
 
+        # Test delete without run lock raises
+        with pytest.raises(RunLockRequired):
+            run.optimization.variables.delete(item="Variable 2")
+
     def test_get_variable(self, platform: ixmp4.Platform) -> None:
         run = platform.runs.create("Model", "Scenario")
         (indexset,) = create_indexsets_for_run(
@@ -231,6 +240,10 @@ class TestCoreVariable:
             "levels": [6, 5, 4, 3, 2, 1],
             "marginals": [1, 3, 5, 6, 4, 2],
         }
+
+        # Test add without run lock raises
+        with pytest.raises(RunLockRequired):
+            variable.add(data=test_data_2)
 
         with run.transact("Test Variable.add() errors and order"):
             variable_2 = run.optimization.variables.create(
@@ -397,6 +410,10 @@ class TestCoreVariable:
             variable.remove_data(data={})
 
         assert variable.data == test_data
+
+        # Test remove without run lock raises
+        with pytest.raises(RunLockRequired):
+            variable.remove_data(data={})
 
         with run.transact("Test Variable.remove_data() errors"):
             # Test incomplete index raises...

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -77,17 +77,16 @@ class SmallIamcDataset:
         datapoints = cls.annual.copy()
         with run1.transact("Add iamc data"):
             run1.iamc.add(datapoints, type=ixmp4.DataPoint.Type.ANNUAL)
-        # NOTE mypy doesn't support setters taking a different type than
-        # their property https://github.com/python/mypy/issues/3004
+
         with run1.transact("Add meta data"):
-            run1.meta = {"run": 1, "test": 0.1293, "bool": True}  # type: ignore[assignment]
+            run1.meta = {"run": 1, "test": 0.1293, "bool": True}
 
         datapoints["variable"] = "Variable 4"
         with run2.transact("Add iamc data"):
             run2.iamc.add(datapoints, type=ixmp4.DataPoint.Type.ANNUAL)
 
         with run2.transact("Add meta data"):
-            run2.meta = {"run": 2, "test": "string", "bool": False}  # type: ignore[assignment]
+            run2.meta = {"run": 2, "test": "string", "bool": False}
 
         return run1, run2
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -245,10 +245,7 @@ class TestAuthContext:
 
                     with pytest.raises(Forbidden):
                         with run.transact("Add meta data"):
-                            # NOTE mypy doesn't support setters taking a different
-                            # type than their property
-                            # https://github.com/python/mypy/issues/3004
-                            run.meta = {"meta": "test"}  # type: ignore[assignment]
+                            run.meta = {"meta": "test"}
 
                     with pytest.raises(Forbidden):
                         _ = run.clone()
@@ -314,7 +311,7 @@ class TestAuthContext:
         with run.transact("Add iamc data"):
             run.iamc.add(annual_dps, type=ixmp4.DataPoint.Type.ANNUAL)
         with run.transact("Add meta data"):
-            run.meta = {"meta": "test"}  # type: ignore[assignment]
+            run.meta = {"meta": "test"}
         run.set_as_default()
 
         with backend.auth(user, self.mock_manager, platform_info):
@@ -332,7 +329,7 @@ class TestAuthContext:
                             type=ixmp4.DataPoint.Type.ANNUAL,
                         )
                     with run.transact("Add meta data"):
-                        run.meta = {"meta": "test"}  # type: ignore[assignment]
+                        run.meta = {"meta": "test"}
 
                     # Test run.clone() uses auth()
                     clone_with_solution = run.clone()
@@ -355,7 +352,7 @@ class TestAuthContext:
 
                     with pytest.raises(Forbidden):
                         with run.transact("Add meta data"):
-                            run.meta = {"meta": "test"}  # type: ignore[assignment]
+                            run.meta = {"meta": "test"}
 
                     with pytest.raises(Forbidden):
                         _ = run.clone()


### PR DESCRIPTION
The "optimization" part still needs versioning, change log and Run locking as the rest of the code got in #166. This PR begins this process by adding `run.require_lock()` to the operations where I think it makes sense: `create()`, `delete()`, `add_data()`, and `remove_data()` (or their equivalents).

It also re-enables mypy's warnings about unused `type: ignore` statements as I think this is useful and works well with the latest versions of mypy and numpy. This immediately produced 24 errors in 9 files, all of which I resolved again.

Please note that this PR may look huge, but actually isn't. The vast majority of changed lines originates from the test suite, where many lines had to be adjusted to suit the `with run.transact()` context manager in formatting only, so you can likely skip all `test_` files when reviewing :)