### PR TITLE
Enable vaing mixed IAMC datatpoints in a Run

### DIFF
--- a/ixmp4/data/db/base.py
+++ b/ixmp4/data/db/base.py
@@ -421,6 +421,7 @@ class BulkOperator(Tabulator[ModelType]):
     ) -> pd.DataFrame:
         columns = db.utils.get_columns(self.model_class)
         primary_key_columns = db.utils.get_pk_columns(self.model_class)
+        existing_df.dropna(axis=1, inplace=True)
         on = (
             (
                 set(existing_df.columns) & set(df.columns) & set(columns.keys())

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -52,6 +52,8 @@ class SmallIamcDataset:
     categorical = pd.read_csv(here / "small/categorical.csv")
     datetime = pd.read_csv(here / "small/datetime.csv")
     datetime["step_datetime"] = pd.to_datetime(datetime["step_datetime"])
+    mixed = pd.read_csv(here / "small/mixed.csv")
+    mixed["step_datetime"] = pd.to_datetime(mixed["step_datetime"])
 
     @classmethod
     def load_regions(cls, platform: ixmp4.Platform) -> None:

--- a/tests/fixtures/small/mixed.csv
+++ b/tests/fixtures/small/mixed.csv
@@ -1,0 +1,5 @@
+region,variable,unit,step_year,step_datetime,value
+Region 1,Variable 1,Unit 1,2000,,0.5
+Region 1,Variable 1,Unit 2,,2010-01-01 00:00:00,1.0
+Region 3,Variable 4,Unit 2,,2020-01-01 00:00:00,1.7
+Region 3,Variable 3,Unit 3,2020,,1.5


### PR DESCRIPTION
This PR enables adding different `DataPoint`-types to a **Run** (one type after the other using separate calls of `Run.iamc.add()`.

Turns out that the having mixed datapoint-types and querying them already worked implicitly.

Request for specific feedback:
1. With some tinkering, I found that simply adding 
   ```python
    existing_df.dropna(axis=1, inplace=True)
    ```
    is sufficient to enable adding datapoints of a type to a Run that already has datapoints of another type. Without that additional line, this raises an error. However, with that line removed, the `meta` tests fail. Any better idea?
2. I extended the workhorse of the iamc-datapoints-tests `do_run_datapoints()` to split the dataframe by type if necessary. This could be simplified to always split by type (avoiding four if-else statements), but that may have other side effects.
3. I didn't test this yet with categorical data.
