### PR TITLE
api.Run.created at nullability

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -133,7 +133,7 @@ jobs:
       #  install root project
       #------------------------
       - name: Install library
-        run: poetry install --no-interaction --with dev,server
+        run: poetry install --no-interaction
 
       #------------------
       #  run test suite

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -133,7 +133,7 @@ jobs:
       #  install root project
       #------------------------
       - name: Install library
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction --with dev,server
 
       #------------------
       #  run test suite

--- a/ixmp4/data/api/run.py
+++ b/ixmp4/data/api/run.py
@@ -34,7 +34,7 @@ class Run(base.BaseModel):
     is_default: bool
 
     created_at: datetime | None
-    created_by: str
+    created_by: str | None
 
     updated_at: datetime | None
     updated_by: str | None

--- a/ixmp4/db/migrations/versions/84b534bbc858_load_initial_version_data.py
+++ b/ixmp4/db/migrations/versions/84b534bbc858_load_initial_version_data.py
@@ -42,6 +42,8 @@ tables = [
     ("unit", "unit_version"),
 ]
 
+tabledata_chunksize = 10000
+
 
 def generate_initial_version_data(
     data_table_name: str, version_table_name: str, transaction_id: int
@@ -67,7 +69,13 @@ def generate_initial_version_data(
             autoload_with=conn,
         )
 
-        partitions = conn.execute(sa.select(data_table)).mappings().partitions(10000)
+        partitions = (
+            conn.execute(
+                sa.select(data_table).execution_options(yield_per=tabledata_chunksize)
+            )
+            .mappings()
+            .partitions(tabledata_chunksize)
+        )
         for res in partitions:
             initial_versions = [
                 {


### PR DESCRIPTION
There is a mistake in the `api.Run` model, namely that `created_by` is nullable in the database but not that model resulting in errors. 