### PR TITLE
Query by related entities with SUBQUERIES

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -253,7 +253,7 @@ docker-compose -f tests/docker-compose.yml up
 
 ### Benchmarks
 
-The tests contain two types of benchmarks:
+The tests contain three types of benchmarks:
 
 - `test_benchmarks.py`
   Simple throughput benchmarks for a
@@ -264,6 +264,11 @@ The tests contain two types of benchmarks:
 
 - `test_benchmark_filters.py`
   Benchmarks the retrieval of iamc data with different filters.
+  Primarily used for testing query speed.
+
+- `test_benchmark_rest_filters.py`
+  Benchmarks the retrieval of data with different filters
+  over the REST API.
   Primarily used for testing query speed.
 
 ### Profiling

--- a/ixmp4/data/db/iamc/variable/filter.py
+++ b/ixmp4/data/db/iamc/variable/filter.py
@@ -14,7 +14,26 @@ class VariableFilter(base.VariableFilter, metaclass=filters.FilterMeta):
         default=base.RunFilter(id=None, version=None, is_default=True)
     )
 
+    _remote_filters = {"run", "region", "unit"}
+    _remote_path = [
+        {
+            "target_model": Measurand,
+            "fk_attr": "variable__id",
+            "source_model": Variable,
+            "pk_attr": "id",
+        },
+        {
+            "target_model": TimeSeries,
+            "fk_attr": "measurand__id",
+            "source_model": Measurand,
+            "pk_attr": "id",
+        },
+    ]
+
     def join(self, exc: SelectType, session: Session | None = None) -> SelectType:
+        if self._should_use_subquery_optimization():
+            return exc
+
         if not utils.is_joined(exc, Measurand):
             exc = exc.join(Measurand, Measurand.variable__id == Variable.id)
 

--- a/ixmp4/db/filters.py
+++ b/ixmp4/db/filters.py
@@ -6,13 +6,29 @@ from typing import Any, ClassVar, Optional, TypeVar, Union, cast, get_args, get_
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from pydantic.fields import FieldInfo
 
-# TODO Import this from typing when dropping support for 3.10
-from typing_extensions import Self
+# TODO Import these from typing when dropping support for 3.10
+from typing_extensions import Protocol, Self, TypedDict
 
 from ixmp4 import db
 from ixmp4.core.exceptions import BadFilterArguments, ProgrammingError
 
 in_Type = TypeVar("in_Type")
+
+
+class RemotePathStep(TypedDict):
+    """Type definition for a single step in a remote filter join path."""
+
+    target_model: type
+    fk_attr: str
+    source_model: type
+    pk_attr: str
+
+
+class RemoteFilterConfig(Protocol):
+    """Protocol for classes that support remote filter optimization."""
+
+    _remote_filters: set[str]
+    _remote_path: list[RemotePathStep]
 
 
 def in_(
@@ -137,7 +153,57 @@ class FilterMeta(PydanticMeta):  # type: ignore[misc]
                 continue
             cls.process_field(namespace, name, annot)
 
-        return cast(FilterMeta, super().__new__(cls, name, bases, namespace, **kwargs))
+        new_class = cast(
+            FilterMeta, super().__new__(cls, name, bases, namespace, **kwargs)
+        )
+
+        cls._validate_remote_filter_config(new_class)
+
+        return new_class
+
+    @classmethod
+    def _validate_remote_filter_config(cls, filter_class: type["BaseFilter"]) -> None:
+        """Validate remote filter configuration at class definition time."""
+        class_dict = filter_class.__dict__
+        remote_filters: set[str] = class_dict.get("_remote_filters", set())
+        remote_path: list[RemotePathStep] = class_dict.get("_remote_path", [])
+
+        # Check consistency between remote_filters and remote_path
+        if remote_filters and not remote_path:
+            raise ProgrammingError(
+                f"{filter_class.__name__} defines _remote_filters "
+                "but missing _remote_path"
+            )
+
+        if remote_path and not remote_filters:
+            raise ProgrammingError(
+                f"{filter_class.__name__} defines _remote_path "
+                "but missing _remote_filters"
+            )
+
+        # Validate each step in the remote path
+        for i, step in enumerate(remote_path):
+            try:
+                target_model = step["target_model"]
+                fk_attr = step["fk_attr"]
+                source_model = step["source_model"]
+                pk_attr = step["pk_attr"]
+            except KeyError as e:
+                raise ProgrammingError(
+                    f"{filter_class.__name__} remote path step {i} "
+                    f"missing required key: {e}"
+                )
+
+            if not hasattr(target_model, fk_attr):
+                raise ProgrammingError(
+                    f"{filter_class.__name__} remote path step {i}: "
+                    f"{target_model.__name__} missing attribute '{fk_attr}'"
+                )
+            if not hasattr(source_model, pk_attr):
+                raise ProgrammingError(
+                    f"{filter_class.__name__} remote path step {i}: "
+                    f"{source_model.__name__} missing attribute '{pk_attr}'"
+                )
 
     @classmethod
     def build_lookups(
@@ -165,12 +231,14 @@ class FilterMeta(PydanticMeta):  # type: ignore[misc]
 
                     def lookup_func(
                         c: db.typing_column[Any],
-                        v: Integer
-                        | Float
-                        | Id
-                        | String
-                        | Boolean
-                        | list[Integer | Float | Id | String | Boolean],
+                        v: (
+                            Integer
+                            | Float
+                            | Id
+                            | String
+                            | Boolean
+                            | list[Integer | Float | Id | String | Boolean]
+                        ),
                         tuples: list[tuple[type, Callable[..., Any]]] = tuples,
                     ) -> Any:
                         for t, lf in tuples:
@@ -294,6 +362,22 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
     )
     sqla_model: ClassVar[type | None] = None
 
+    @classmethod
+    def setup_remote_filters(
+        cls,
+        remote_filters: set[str],
+        join_path: list[RemotePathStep],
+    ) -> None:
+        """Configure remote filters and join path for subquery optimization.
+
+        Args:
+            remote_filters: Set of filter field names that should use
+                subquery optimization
+            join_path: List of join steps to reach the remote tables
+        """
+        cls._remote_filters = remote_filters
+        cls._remote_path = join_path
+
     @model_validator(mode="before")
     @classmethod
     def expand_simple_filters(
@@ -321,38 +405,209 @@ class BaseFilter(BaseModel, metaclass=FilterMeta):
         model: object,
         session: db.Session,
     ) -> db.sql.Select[tuple[FilterType]]:
-        dict_model = dict(self)
+        if self._should_use_subquery_optimization():
+            return self._apply_with_subquery_optimization(exc, model, session)
+
+        return self._apply(exc, model, session)
+
+    def _should_use_subquery_optimization(self) -> bool:
+        """Check if subquery optimization should be used for this filter."""
+        remote_filters = getattr(self, "_remote_filters", None)
+        if not remote_filters:
+            return False
+
+        # Check if any remote filters are active
+        for name in remote_filters:
+            field_info = self.__class__.model_fields.get(name)
+            if field_info:
+                value = getattr(self, name, field_info.get_default())
+                if isinstance(value, BaseFilter) and self._is_filter_active(value):
+                    return True
+        return False
+
+    def _is_filter_active(self, filter_value: "BaseFilter") -> bool:
+        """Check if a filter has any active (non-None) values."""
+        field_values = filter_value.model_dump(exclude_none=True)
+        return bool(field_values)
+
+    def _apply(
+        self,
+        exc: db.sql.Select[tuple[FilterType]],
+        model: object,
+        session: db.Session,
+    ) -> db.sql.Select[tuple[FilterType]]:
+        """Standard apply logic."""
         for name, field_info in self.__class__.model_fields.items():
-            value = dict_model.get(name, field_info.get_default())
+            value = getattr(self, name, field_info.get_default())
             if isinstance(value, BaseFilter):
-                submodel = getattr(value, "sqla_model", None)
-                model_getter = getattr(value, "get_sqla_model", None)
-                if submodel is None and callable(model_getter):
-                    submodel = model_getter(session)
-
-                exc = value.join(exc, session=session)
-                exc = value.apply(exc, submodel, session)
+                exc = self._apply_nested_filter(exc, value, session)
             elif value is not None:
-                func_name = get_filter_func_name(name)
-                filter_func = getattr(self, func_name, None)
-                if filter_func is None:
-                    raise ProgrammingError
-
-                sqla_column: str | None = None
-                if isinstance(field_info.json_schema_extra, dict):
-                    jschema_col = field_info.json_schema_extra.get("sqla_column")
-                    if not isinstance(jschema_col, str):
-                        raise ProgrammingError(
-                            "Field argument `sqla_column` must be of type `str`."
-                        )
-                    sqla_column = jschema_col
-                else:
-                    sqla_column = None
-                column = (
-                    None if sqla_column is None else getattr(model, sqla_column, None)
-                )
-                exc = filter_func(exc, column, value, session=session)
+                exc = self._apply_field_filter(exc, name, value, model, session)
         return exc.distinct()
+
+    def _apply_with_subquery_optimization(
+        self,
+        exc: db.sql.Select[tuple[FilterType]],
+        model: object,
+        session: db.Session,
+    ) -> db.sql.Select[tuple[FilterType]]:
+        """Apply filters using subquery optimization for remote filters."""
+        remote_filters: set[str] = getattr(self, "_remote_filters", set())
+        remote_path: list[RemotePathStep] | None = getattr(self, "_remote_path", None)
+        if not remote_path:
+            raise ProgrammingError(
+                f"Filter {self.__class__.__name__} defines _remote_filters "
+                "but missing _remote_path"
+            )
+        if model is None:
+            return self._apply(exc, model, session)
+        active_remote_filters = self._collect_active_remote_filters(remote_filters)
+        if active_remote_filters:
+            exc = self._apply_subquery_filter(
+                exc, model, session, active_remote_filters, remote_path
+            )
+        exc = self._apply_local_filters(exc, model, session, remote_filters)
+        return exc.distinct()
+
+    def _collect_active_remote_filters(
+        self, remote_filters: set[str]
+    ) -> dict[str, "BaseFilter"]:
+        """Collect remote filters that are active."""
+        active_remote_filters = {}
+        for name in remote_filters:
+            value = getattr(self, name, None)
+            if isinstance(value, BaseFilter) and self._is_filter_active(value):
+                active_remote_filters[name] = value
+        return active_remote_filters
+
+    def _get_model_id_column(self, model: object) -> Any:
+        """Safely get the ID column from a model class."""
+        if not hasattr(model, "id"):
+            raise ProgrammingError(
+                f"Model {model.__class__.__name__} missing required 'id' column"
+            )
+        id_column = getattr(model, "id")
+        if not hasattr(id_column, "type"):
+            raise ProgrammingError(
+                f"Model {model.__class__.__name__}.id is not a SQLAlchemy column"
+            )
+        return id_column
+
+    def _apply_subquery_filter(
+        self,
+        exc: db.sql.Select[tuple[FilterType]],
+        model: object,
+        session: db.Session,
+        active_remote_filters: dict[str, "BaseFilter"],
+        remote_path: list[RemotePathStep],
+    ) -> db.sql.Select[tuple[FilterType]]:
+        """Apply remote filters using subquery."""
+        current_id_column = self._get_model_id_column(model)
+        subquery = db.sql.select(current_id_column)
+        subquery = self._build_subquery_joins(subquery, remote_path)
+        subquery = self._apply_filters_to_subquery(
+            subquery, active_remote_filters, session
+        )
+        model_id_column = self._get_model_id_column(
+            getattr(self, "sqla_model", None) or model
+        )
+        return exc.where(model_id_column.in_(subquery.scalar_subquery()))
+
+    def _build_subquery_joins(
+        self,
+        subquery: db.sql.Select[tuple[Any]],
+        remote_path: list[RemotePathStep],
+    ) -> db.sql.Select[tuple[Any]]:
+        """Build the join chain for the subquery."""
+        for step in remote_path:
+            target_model = step["target_model"]
+            fk_attr = step["fk_attr"]
+            source_model = step["source_model"]
+            pk_attr = step["pk_attr"]
+
+            fk_column = getattr(target_model, fk_attr)
+            pk_column = getattr(source_model, pk_attr)
+            join_condition = fk_column == pk_column
+            subquery = subquery.join(target_model, join_condition)
+        return subquery
+
+    def _apply_filters_to_subquery(
+        self,
+        subquery: db.sql.Select[tuple[Any]],
+        active_remote_filters: dict[str, "BaseFilter"],
+        session: db.Session,
+    ) -> db.sql.Select[tuple[Any]]:
+        """Apply remote filters to the subquery."""
+        for filter_value in active_remote_filters.values():
+            subquery = filter_value.join(subquery, session=session)
+            subquery = filter_value.apply(subquery, filter_value.sqla_model, session)
+        return subquery
+
+    def _apply_local_filters(
+        self,
+        exc: db.sql.Select[tuple[FilterType]],
+        model: object,
+        session: db.Session,
+        remote_filters: set[str],
+    ) -> db.sql.Select[tuple[FilterType]]:
+        """Apply local (non-remote) filters."""
+        for name, field_info in self.__class__.model_fields.items():
+            if name in remote_filters:
+                continue
+            value = getattr(self, name, field_info.get_default())
+            if isinstance(value, BaseFilter):
+                exc = self._apply_nested_filter(exc, value, session)
+            elif value is not None:
+                exc = self._apply_field_filter(exc, name, value, model, session)
+        return exc
+
+    def _apply_nested_filter(
+        self,
+        exc: db.sql.Select[tuple[FilterType]],
+        filter_value: "BaseFilter",
+        session: db.Session,
+    ) -> db.sql.Select[tuple[FilterType]]:
+        """Apply a nested filter."""
+        submodel = getattr(filter_value, "sqla_model", None)
+        model_getter = getattr(filter_value, "get_sqla_model", None)
+        if submodel is None and callable(model_getter):
+            submodel = model_getter(session)
+
+        exc = filter_value.join(exc, session=session)
+        return filter_value.apply(exc, submodel, session)
+
+    def _apply_field_filter(
+        self,
+        exc: db.sql.Select[tuple[FilterType]],
+        name: str,
+        value: Any,
+        model: object,
+        session: db.Session,
+    ) -> db.sql.Select[tuple[FilterType]]:
+        """Apply a field-level filter."""
+        func_name = get_filter_func_name(name)
+        filter_func = getattr(self, func_name, None)
+        if filter_func is None:
+            raise ProgrammingError
+
+        sqla_column = self._get_sqla_column(name)
+        column = None if sqla_column is None else getattr(model, sqla_column, None)
+        result = filter_func(exc, column, value, session=session)
+        if not isinstance(result, db.sql.Select):
+            raise ProgrammingError("Filter function must return a Select query")
+        return result
+
+    def _get_sqla_column(self, name: str) -> str | None:
+        """Get the SQLAlchemy column name for a field."""
+        field_info = self.__class__.model_fields.get(name)
+        if field_info and isinstance(field_info.json_schema_extra, dict):
+            jschema_col = field_info.json_schema_extra.get("sqla_column")
+            if not isinstance(jschema_col, str):
+                raise ProgrammingError(
+                    "Field argument `sqla_column` must be of type `str`."
+                )
+            return jschema_col
+        return None
 
 
 def expand_simple_filter(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ authors = [
     "Fridolin Glatter <glatter@iiasa.ac.at>",
     "Daniel Huppmann <huppmann@iiasa.ac.at>",
     "Philip Hackstock <hackstock@iiasa.ac.at>",
+    "Pino Mussak <mussak@iiasa.ac.at>"
 ]
 name = "ixmp4"
 version = "0.0.0"

--- a/tests/cli/test_platforms.py
+++ b/tests/cli/test_platforms.py
@@ -118,4 +118,4 @@ class TestPlatformGenerateCLI:
         result = runner.invoke(platforms.app, ["generate", "nonexistent-platform"])
 
         # We simply test whether the generate command errors
-        assert result.exit_code == 2
+        assert result.exit_code > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ backend_fixtures = {
     "platform_med": ["sqlite", "postgres", "rest-sqlite", "rest-postgres"],
     "platform_big": ["sqlite", "postgres", "rest-sqlite", "rest-postgres"],
     "db_platform_big": ["sqlite", "postgres"],
+    "rest_platform_big": ["rest-sqlite", "rest-postgres"],
     "platform": ["sqlite", "postgres", "rest-sqlite", "rest-postgres"],
     "db_platform": ["sqlite", "postgres"],
     "rest_platform": ["rest-sqlite", "rest-postgres"],
@@ -180,6 +181,10 @@ def td_platform_fixture(
 # class scope fixture with big test data
 db_platform_big = pytest.fixture(
     td_platform_fixture(big), scope="class", name="db_platform_big"
+)
+
+rest_platform_big = pytest.fixture(
+    td_platform_fixture(big), scope="class", name="rest_platform_big"
 )
 
 platform_med = pytest.fixture(

--- a/tests/test_benchmark_filters.py
+++ b/tests/test_benchmark_filters.py
@@ -10,6 +10,9 @@ from .fixtures import BigIamcDataset
 
 big = BigIamcDataset()
 
+WARMUP_ROUNDS = 5
+ROUNDS = 10
+
 
 @pytest.mark.parametrize(
     "filters",
@@ -57,5 +60,5 @@ def test_filter_datapoints_benchmark(
             # Not sure why mypy complains here, maybe about covariance?
             return platform.iamc.tabulate(**filters)  # type: ignore[arg-type]
 
-    df = benchmark.pedantic(run, warmup_rounds=5, rounds=10)
+    df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
     assert not df.empty

--- a/tests/test_benchmark_rest_filters.py
+++ b/tests/test_benchmark_rest_filters.py
@@ -1,0 +1,298 @@
+from typing import Any, cast
+
+import pytest
+
+import ixmp4
+from ixmp4.data.backend.api import RestBackend
+
+from .conftest import Profiled
+
+WARMUP_ROUNDS = 5
+ROUNDS = 10
+
+
+class TestBenchmarkRestFilters:
+    """Benchmark tests for various repository filters using big dataset."""
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"name": "Model 0"},
+            {"iamc": True},
+            {
+                "iamc": {"variable": {"name__like": "Variable 1*"}},
+            },
+            {
+                "iamc": {
+                    "scenario": {"name": "Scenario 0"},
+                    "run": {"default_only": False},
+                },
+            },
+            {
+                "name__like": "Model *",
+                "iamc": {
+                    "scenario": {"name__like": "Scenario *"},
+                    "unit": {"name__in": [f"Unit {i}" for i in range(10)]},
+                    "variable": {"name__like": "Variable 1*"},
+                    "region": {"name__in": [f"Region {i}" for i in range(10)]},
+                    "run": {"default_only": False},
+                },
+            },
+        ],
+    )
+    @pytest.mark.benchmark
+    def test_models_repository_benchmark(
+        self,
+        rest_platform_big: ixmp4.Platform,
+        profiled: Profiled,
+        benchmark: Any,
+        filters: dict[str, Any],
+    ) -> None:
+        """Benchmarks the models repository with various filters."""
+
+        client = cast(RestBackend, rest_platform_big.backend).client
+        endpoint = "models/"
+
+        def run() -> Any:
+            with profiled():
+                return client.get(endpoint, params=filters).json()
+
+        df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
+        assert df is not None
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"name": "Scenario 0"},
+            {"iamc": True},
+            {
+                "iamc": {"variable": {"name__like": "Variable 1*"}},
+            },
+            {
+                "iamc": {
+                    "model": {"name__like": "Model *"},
+                    "run": {"default_only": False},
+                },
+            },
+            {
+                "name__like": "Scenario *",
+                "iamc": {
+                    "model": {"name__like": "Model *"},
+                    "unit": {"name__in": [f"Unit {i}" for i in range(10)]},
+                    "variable": {"name__like": "Variable 1*"},
+                    "region": {"name__in": [f"Region {i}" for i in range(10)]},
+                    "run": {"default_only": False},
+                },
+            },
+        ],
+    )
+    @pytest.mark.benchmark
+    def test_scenarios_repository_benchmark(
+        self,
+        rest_platform_big: ixmp4.Platform,
+        profiled: Profiled,
+        benchmark: Any,
+        filters: dict[str, Any],
+    ) -> None:
+        """Benchmarks the scenarios repository with various filters."""
+
+        client = cast(RestBackend, rest_platform_big.backend).client
+        endpoint = "scenarios/"
+
+        def run() -> Any:
+            with profiled():
+                return client.get(endpoint, params=filters).json()
+
+        df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
+        assert df is not None
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"model": {"name": "Model 0"}},
+            {"scenario": {"name": "Scenario 0"}},
+            {"iamc": True},
+            {
+                "iamc": {"variable": {"name__like": "Variable 1*"}},
+            },
+            {
+                "iamc": {
+                    "scenario": {"name": "Scenario 0"},
+                    "model": {"name__like": "Model *"},
+                    "run": {"default_only": False},
+                },
+            },
+            {
+                "default_only": False,
+                "iamc": {
+                    "model": {"name__like": "Model *"},
+                    "scenario": {"name__like": "Scenario *"},
+                    "unit": {"name__in": [f"Unit {i}" for i in range(10)]},
+                    "variable": {"name__like": "Variable 1*"},
+                    "region": {"name__in": [f"Region {i}" for i in range(10)]},
+                    "run": {"default_only": False},
+                },
+            },
+        ],
+    )
+    @pytest.mark.benchmark
+    def test_runs_repository_benchmark(
+        self,
+        rest_platform_big: ixmp4.Platform,
+        profiled: Profiled,
+        benchmark: Any,
+        filters: dict[str, Any],
+    ) -> None:
+        """Benchmarks the runs repository with various filters."""
+
+        client = cast(RestBackend, rest_platform_big.backend).client
+        endpoint = "runs/"
+
+        def run() -> Any:
+            with profiled():
+                return client.get(endpoint, params=filters).json()
+
+        df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
+        assert df is not None
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"name": "Region 0"},
+            {"iamc": True},
+            {
+                "iamc": {"variable": {"name__like": "Variable 1*"}},
+            },
+            {
+                "iamc": {
+                    "scenario": {"name": "Scenario 0"},
+                    "model": {"name__like": "Model *"},
+                    "run": {"default_only": False},
+                },
+            },
+            {
+                "name__in": [f"Region {i}" for i in range(10)],
+                "iamc": {
+                    "model": {"name__like": "Model *"},
+                    "scenario": {"name__like": "Scenario *"},
+                    "unit": {"name__in": [f"Unit {i}" for i in range(10)]},
+                    "variable": {"name__like": "Variable 1*"},
+                    "run": {"default_only": False},
+                },
+            },
+        ],
+    )
+    @pytest.mark.benchmark
+    def test_regions_repository_benchmark(
+        self,
+        rest_platform_big: ixmp4.Platform,
+        profiled: Profiled,
+        benchmark: Any,
+        filters: dict[str, Any],
+    ) -> None:
+        """Benchmarks the regions repository with various filters."""
+
+        client = cast(RestBackend, rest_platform_big.backend).client
+        endpoint = "regions/"
+
+        def run() -> Any:
+            with profiled():
+                return client.get(endpoint, params=filters).json()
+
+        df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
+        assert df is not None
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"name": "Unit 0"},
+            {"iamc": True},
+            {
+                "iamc": {"variable": {"name__like": "Variable 1*"}},
+            },
+            {
+                "iamc": {
+                    "scenario": {"name": "Scenario 0"},
+                    "model": {"name__like": "Model *"},
+                    "run": {"default_only": False},
+                },
+            },
+            {
+                "name__in": [f"Unit {i}" for i in range(10)],
+                "iamc": {
+                    "model": {"name__like": "Model *"},
+                    "scenario": {"name__like": "Scenario *"},
+                    "variable": {"name__like": "Variable 1*"},
+                    "region": {"name__in": [f"Region {i}" for i in range(10)]},
+                    "run": {"default_only": False},
+                },
+            },
+        ],
+    )
+    @pytest.mark.benchmark
+    def test_units_repository_benchmark(
+        self,
+        rest_platform_big: ixmp4.Platform,
+        profiled: Profiled,
+        benchmark: Any,
+        filters: dict[str, Any],
+    ) -> None:
+        """Benchmarks the units repository with various filters."""
+
+        client = cast(RestBackend, rest_platform_big.backend).client
+        endpoint = "units/"
+
+        def run() -> Any:
+            with profiled():
+                return client.get(endpoint, params=filters).json()
+
+        df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
+        assert df is not None
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {},
+            {"name": "Variable 0"},
+            {"name__like": "Variable *"},
+            {"unit": {"name": "Unit 0"}},
+            {
+                "name__like": "Variable *",
+                "scenario": {"name": "Scenario 0"},
+                "model": {"name__like": "Model *"},
+                "run": {"default_only": False},
+            },
+            {
+                "name__like": "Variable *",
+                "model": {"name__like": "Model *"},
+                "scenario": {"name__like": "Scenario *"},
+                "variable": {"name__like": "Variable 1*"},
+                "region": {"name__in": [f"Region {i}" for i in range(10)]},
+                "run": {"default_only": False},
+            },
+        ],
+    )
+    @pytest.mark.benchmark
+    def test_variables_repository_benchmark(
+        self,
+        rest_platform_big: ixmp4.Platform,
+        profiled: Profiled,
+        benchmark: Any,
+        filters: dict[str, Any],
+    ) -> None:
+        """Benchmarks the variables repository with various filters."""
+
+        client = cast(RestBackend, rest_platform_big.backend).client
+        endpoint = "iamc/variables/"
+
+        def run() -> Any:
+            with profiled():
+                return client.get(endpoint, params=filters).json()
+
+        df = benchmark.pedantic(run, warmup_rounds=WARMUP_ROUNDS, rounds=ROUNDS)
+        assert df is not None


### PR DESCRIPTION
# Performance Optimization: Subquery-based Filtering
This PR addresses #197 by implementing a subquery optimization strategy to resolve performance issues with queries for non-timeseries data on platforms with large timeseries datasets, with the most significant impact on the `/iamc/variables/` endpoint performance.

## Problem Analysis
The `iamc/variables/` REST endpoint was experiencing 6+ second SQL query execution times for the platform `scenariocompass-dev` due to inefficient SQL generation. The current filtering approach creates massive result sets through direct joins before applying DISTINCT, resulting in expensive operations on large datasets as further explained in #197 

### Problematic SQL pattern:
```sql
SELECT DISTINCT iamc_variable.name, iamc_variable.id, iamc_variable.created_at, iamc_variable.created_by
FROM iamc_variable 
JOIN iamc_measurand ON iamc_measurand.variable__id = iamc_variable.id 
JOIN iamc_timeseries ON iamc_timeseries.measurand__id = iamc_measurand.id 
JOIN run ON run.id = iamc_timeseries.run__id
WHERE iamc_variable.name LIKE '%Final Energy%' AND run.is_default = true
```

## Solution
A configurable subquery ptimization system is introduced, which works with the notion of "remote filters" - filters that require joining another table for the sole reason of filtering and not for returning data of said table.

### Main features of solution
* **Detection Logic**: `_should_use_subquery_optimization` checks for active remote filters
* **Query Restructuring**: `_apply_subquery_filter` generates optimized queries using WHERE id IN (subquery) patterns
* **Path Configuration**: Remote filters define join paths via `_remote_filters` and `_remote_path` class attributes

### Optimized SQL Pattern
The new approach generates queries like:
```sql
SELECT iamc_variable.name, iamc_variable.id, iamc_variable.created_at, iamc_variable.created_by
FROM iamc_variable
WHERE iamc_variable.id IN (
    SELECT iamc_measurand.variable__id 
    FROM iamc_measurand
    JOIN iamc_timeseries ON iamc_timeseries.measurand__id = iamc_measurand.id
    JOIN run ON run.id = iamc_timeseries.run__id
    WHERE run.is_default
) AND iamc_variable.name LIKE '%Final Energy%' AND run.is_default = true
```

## Implementation Disadvantages
* **Data Model Duplication**: Relationship information is now duplicated between SQLAlchemy models and filter `_remote_path` configurations
* Maintenance Overhead: Schema changes require updates in multiple locations

## Design Decision Rationale
The explicit configuration approach was chosen over automatic relationship detection because:

* Auto-detection would require complex introspection of SQLAlchemy relationships
Performance-critical code benefits from explicit, predictable behavior
Manual configuration provides fine-grained control over optimization application
Validation logic in FilterMeta._validate_remote_filter_config() catches configuration errors at class definition time

## Benchmark
This PR adds the new benchmark test `test_benchmark_rest_filters` which benchmarks all repositories using the new SUBQUERY approach via the REST server.

**Results of `test_benchmark_rest_filters` SUBQUERY against BASELINE ([current main](https://github.com/iiasa/ixmp4/commit/50a887c3255e57218b22e8e289aff9f6ecde5225))**
<details>
<summary>
See results
</summary>
**SUMMARY**
We see that the existing bechmark with a datapoint table of a bout 70_000 rows does not show significant changes in the query times. The new SUBQUERY approach is even slightly slower, probably due to additional time spent creating the queries. Bear in mind the difference here are in the range of +/- 2 milliseconds. 
**DETAILS**
---------------------------------------------------------------------------- benchmark 'test_models_repository_benchmark[rest-postgres-filters0]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_models_repository_benchmark[rest-postgres-filters0] (0007_SUBQUER)     3.9827 (1.0)      4.7669 (1.04)     4.2537 (1.0)      0.2726 (1.92)     4.2260 (1.0)      0.3431 (1.70)          2;0  235.0879 (1.0)          10           1
test_models_repository_benchmark[rest-postgres-filters0] (0008_BASELIN)     4.1098 (1.03)     4.5649 (1.0)      4.3366 (1.02)     0.1420 (1.0)      4.3610 (1.03)     0.2014 (1.0)           3;0  230.5975 (0.98)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_models_repository_benchmark[rest-postgres-filters1]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_models_repository_benchmark[rest-postgres-filters1] (0007_SUBQUER)     3.9229 (1.0)      5.0309 (1.18)     4.4437 (1.07)     0.3123 (2.88)     4.4525 (1.07)     0.4107 (1.93)          2;0  225.0354 (0.93)         10           1
test_models_repository_benchmark[rest-postgres-filters1] (0008_BASELIN)     3.9750 (1.01)     4.2736 (1.0)      4.1404 (1.0)      0.1083 (1.0)      4.1428 (1.0)      0.2125 (1.0)           5;0  241.5228 (1.0)          10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_models_repository_benchmark[rest-postgres-filters2]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_models_repository_benchmark[rest-postgres-filters2] (0007_SUBQUER)     4.6198 (1.09)     7.7826 (1.54)     5.5458 (1.21)     0.9882 (3.16)     5.0641 (1.13)     0.8683 (1.56)          2;1  180.3153 (0.82)         10           1
test_models_repository_benchmark[rest-postgres-filters2] (0008_BASELIN)     4.2308 (1.0)      5.0621 (1.0)      4.5735 (1.0)      0.3127 (1.0)      4.4658 (1.0)      0.5569 (1.0)           3;0  218.6518 (1.0)          10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_models_repository_benchmark[rest-postgres-filters3]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_models_repository_benchmark[rest-postgres-filters3] (0007_SUBQUER)     4.4303 (1.07)     9.7793 (1.33)     5.9674 (1.20)     1.7737 (1.92)     5.2610 (1.11)     1.7423 (2.30)          2;1  167.5770 (0.84)         10           1
test_models_repository_benchmark[rest-postgres-filters3] (0008_BASELIN)     4.1488 (1.0)      7.3479 (1.0)      4.9842 (1.0)      0.9241 (1.0)      4.7524 (1.0)      0.7581 (1.0)           1;1  200.6347 (1.0)          10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_models_repository_benchmark[rest-postgres-filters4]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_models_repository_benchmark[rest-postgres-filters4] (0007_SUBQUER)     4.8687 (1.11)     7.2004 (1.38)     5.7228 (1.23)     0.8432 (2.95)     5.4436 (1.19)     1.1047 (3.35)          3;0  174.7391 (0.81)         10           1
test_models_repository_benchmark[rest-postgres-filters4] (0008_BASELIN)     4.3933 (1.0)      5.2254 (1.0)      4.6607 (1.0)      0.2860 (1.0)      4.5593 (1.0)      0.3299 (1.0)           2;0  214.5598 (1.0)          10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_models_repository_benchmark[rest-postgres-filters5]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_models_repository_benchmark[rest-postgres-filters5] (0007_SUBQUER)     5.3975 (1.11)     6.4874 (1.0)      5.8944 (1.0)      0.3736 (1.0)      5.8345 (1.0)      0.6373 (1.0)           4;0  169.6526 (1.0)          10           1
test_models_repository_benchmark[rest-postgres-filters5] (0008_BASELIN)     4.8706 (1.0)      8.2249 (1.27)     6.8204 (1.16)     1.2158 (3.25)     7.2358 (1.24)     2.1345 (3.35)          4;0  146.6183 (0.86)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_regions_repository_benchmark[rest-postgres-filters0]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_regions_repository_benchmark[rest-postgres-filters0] (0007_SUBQUER)     4.3957 (1.01)     6.8412 (1.0)      5.6642 (1.03)     0.6953 (1.0)      5.7073 (1.21)     0.9783 (1.0)           3;0  176.5466 (0.97)         10           1
test_regions_repository_benchmark[rest-postgres-filters0] (0008_BASELIN)     4.3383 (1.0)      7.4726 (1.09)     5.4967 (1.0)      1.3300 (1.91)     4.7336 (1.0)      2.4022 (2.46)          2;0  181.9264 (1.0)          10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_regions_repository_benchmark[rest-postgres-filters1]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_regions_repository_benchmark[rest-postgres-filters1] (0007_SUBQUER)     4.3264 (1.0)      5.3277 (1.0)      4.8282 (1.0)      0.3874 (1.0)      4.7261 (1.0)      0.7607 (1.0)           4;0  207.1151 (1.0)          10           1
test_regions_repository_benchmark[rest-postgres-filters1] (0008_BASELIN)     4.4150 (1.02)     6.4126 (1.20)     5.1619 (1.07)     0.7626 (1.97)     4.8813 (1.03)     1.4477 (1.90)          3;0  193.7262 (0.94)         10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_regions_repository_benchmark[rest-postgres-filters2]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_regions_repository_benchmark[rest-postgres-filters2] (0007_SUBQUER)     4.2729 (1.02)     7.1932 (1.37)     4.7761 (1.03)     0.9195 (2.63)     4.3396 (1.0)      0.3678 (1.0)           1;2  209.3760 (0.97)         10           1
test_regions_repository_benchmark[rest-postgres-filters2] (0008_BASELIN)     4.2061 (1.0)      5.2538 (1.0)      4.6149 (1.0)      0.3491 (1.0)      4.5680 (1.05)     0.4687 (1.27)          3;0  216.6898 (1.0)          10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_regions_repository_benchmark[rest-postgres-filters3]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_regions_repository_benchmark[rest-postgres-filters3] (0007_SUBQUER)     4.9732 (1.09)     7.0563 (1.18)     5.9679 (1.19)     0.6702 (1.25)     6.0153 (1.25)     1.1592 (2.83)          4;0  167.5633 (0.84)         10           1
test_regions_repository_benchmark[rest-postgres-filters3] (0008_BASELIN)     4.5551 (1.0)      5.9814 (1.0)      5.0066 (1.0)      0.5351 (1.0)      4.8147 (1.0)      0.4103 (1.0)           2;2  199.7363 (1.0)          10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_regions_repository_benchmark[rest-postgres-filters4]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_regions_repository_benchmark[rest-postgres-filters4] (0007_SUBQUER)     4.5527 (1.0)      5.4603 (1.0)      4.8995 (1.0)      0.3464 (1.0)      4.8187 (1.0)      0.6851 (1.0)           4;0  204.1033 (1.0)          10           1
test_regions_repository_benchmark[rest-postgres-filters4] (0008_BASELIN)     4.8504 (1.07)     7.2708 (1.33)     5.9182 (1.21)     0.9971 (2.88)     5.4322 (1.13)     1.8658 (2.72)          5;0  168.9689 (0.83)         10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_regions_repository_benchmark[rest-postgres-filters5]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                               Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_regions_repository_benchmark[rest-postgres-filters5] (0007_SUBQUER)     4.9323 (1.0)      6.5692 (1.0)      5.7796 (1.0)      0.5797 (1.0)      5.8069 (1.01)     0.9957 (1.52)          5;0  173.0236 (1.0)          10           1
test_regions_repository_benchmark[rest-postgres-filters5] (0008_BASELIN)     5.1873 (1.05)     7.2745 (1.11)     5.8592 (1.01)     0.5967 (1.03)     5.7745 (1.0)      0.6545 (1.0)           2;1  170.6711 (0.99)         10           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters0]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters0] (0007_SUBQUER)     4.3244 (1.01)     6.1447 (1.0)      5.0096 (1.0)      0.6034 (1.0)      4.8110 (1.00)     1.0214 (1.0)           3;0  199.6154 (1.0)          10           1
test_runs_repository_benchmark[rest-postgres-filters0] (0008_BASELIN)     4.2693 (1.0)      6.5704 (1.07)     5.0656 (1.01)     0.7691 (1.27)     4.8072 (1.0)      1.3452 (1.32)          3;0  197.4082 (0.99)         10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters1]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters1] (0007_SUBQUER)     4.7315 (1.08)     6.5179 (1.0)      5.3886 (1.0)      0.5538 (1.0)      5.1836 (1.0)      0.3062 (1.0)           3;2  185.5779 (1.0)          10           1
test_runs_repository_benchmark[rest-postgres-filters1] (0008_BASELIN)     4.3624 (1.0)      7.2920 (1.12)     5.4291 (1.01)     0.9989 (1.80)     5.2581 (1.01)     1.6435 (5.37)          3;0  184.1919 (0.99)         10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters2]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters2] (0007_SUBQUER)     4.5224 (1.07)     6.9750 (1.04)     5.8458 (1.08)     0.8061 (1.18)     5.8269 (1.08)     1.4149 (1.55)          3;0  171.0616 (0.93)         10           1
test_runs_repository_benchmark[rest-postgres-filters2] (0008_BASELIN)     4.2457 (1.0)      6.6793 (1.0)      5.4101 (1.0)      0.6828 (1.0)      5.4062 (1.0)      0.9110 (1.0)           2;0  184.8403 (1.0)          10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters3]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters3] (0007_SUBQUER)     5.2633 (1.17)     8.8955 (1.63)     6.8000 (1.38)     1.2562 (3.34)     6.5806 (1.38)     1.9153 (2.52)          4;0  147.0592 (0.72)         10           1
test_runs_repository_benchmark[rest-postgres-filters3] (0008_BASELIN)     4.5066 (1.0)      5.4567 (1.0)      4.9104 (1.0)      0.3757 (1.0)      4.7679 (1.0)      0.7606 (1.0)           4;0  203.6474 (1.0)          10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters4]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters4] (0007_SUBQUER)     4.6937 (1.04)     6.3673 (1.25)     5.4195 (1.13)     0.4801 (2.45)     5.3452 (1.12)     0.5360 (1.87)          3;0  184.5197 (0.89)         10           1
test_runs_repository_benchmark[rest-postgres-filters4] (0008_BASELIN)     4.5082 (1.0)      5.1059 (1.0)      4.8026 (1.0)      0.1959 (1.0)      4.7819 (1.0)      0.2870 (1.0)           3;0  208.2191 (1.0)          10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters5]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters5] (0007_SUBQUER)     4.5939 (1.04)     6.3151 (1.00)     5.2149 (1.05)     0.5720 (1.0)      5.0611 (1.07)     0.8942 (1.33)          3;0  191.7600 (0.96)         10           1
test_runs_repository_benchmark[rest-postgres-filters5] (0008_BASELIN)     4.4103 (1.0)      6.2868 (1.0)      4.9861 (1.0)      0.5774 (1.01)     4.7457 (1.0)      0.6745 (1.0)           1;0  200.5557 (1.0)          10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_runs_repository_benchmark[rest-postgres-filters6]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                            Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_runs_repository_benchmark[rest-postgres-filters6] (0007_SUBQUER)     5.5833 (1.05)     8.6305 (1.21)     6.7436 (1.18)     1.0357 (1.90)     6.4354 (1.16)     1.6284 (4.68)          4;0  148.2885 (0.85)         10           1
test_runs_repository_benchmark[rest-postgres-filters6] (0008_BASELIN)     5.3373 (1.0)      7.1301 (1.0)      5.7292 (1.0)      0.5460 (1.0)      5.5361 (1.0)      0.3481 (1.0)           1;1  174.5446 (1.0)          10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_scenarios_repository_benchmark[rest-postgres-filters0]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_scenarios_repository_benchmark[rest-postgres-filters0] (0007_SUBQUER)     4.5093 (1.06)     5.3536 (1.10)     4.9959 (1.12)     0.3076 (1.39)     5.0851 (1.17)     0.5931 (1.50)          5;0  200.1630 (0.89)         10           1
test_scenarios_repository_benchmark[rest-postgres-filters0] (0008_BASELIN)     4.2439 (1.0)      4.8708 (1.0)      4.4436 (1.0)      0.2213 (1.0)      4.3377 (1.0)      0.3961 (1.0)           3;0  225.0442 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_scenarios_repository_benchmark[rest-postgres-filters1]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_scenarios_repository_benchmark[rest-postgres-filters1] (0007_SUBQUER)     4.2989 (1.0)      5.3532 (1.0)      4.8193 (1.0)      0.4109 (1.0)      4.9076 (1.07)     0.8230 (2.21)          4;0  207.4986 (1.0)          10           1
test_scenarios_repository_benchmark[rest-postgres-filters1] (0008_BASELIN)     4.4144 (1.03)     6.0503 (1.13)     4.8325 (1.00)     0.5641 (1.37)     4.5969 (1.0)      0.3718 (1.0)           2;2  206.9309 (1.00)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_scenarios_repository_benchmark[rest-postgres-filters2]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_scenarios_repository_benchmark[rest-postgres-filters2] (0007_SUBQUER)     4.5357 (1.08)     5.8175 (1.0)      5.0278 (1.0)      0.5052 (1.0)      4.8006 (1.0)      0.9055 (1.10)          2;0  198.8949 (1.0)          10           1
test_scenarios_repository_benchmark[rest-postgres-filters2] (0008_BASELIN)     4.2067 (1.0)      6.6281 (1.14)     5.2391 (1.04)     0.7256 (1.44)     5.2000 (1.08)     0.8218 (1.0)           3;0  190.8722 (0.96)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_scenarios_repository_benchmark[rest-postgres-filters3]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_scenarios_repository_benchmark[rest-postgres-filters3] (0007_SUBQUER)     4.7352 (1.12)     7.2956 (1.01)     5.8129 (1.20)     0.8354 (1.0)      5.6251 (1.24)     1.4660 (5.14)          2;0  172.0305 (0.84)         10           1
test_scenarios_repository_benchmark[rest-postgres-filters3] (0008_BASELIN)     4.2361 (1.0)      7.2293 (1.0)      4.8560 (1.0)      0.8793 (1.05)     4.5436 (1.0)      0.2850 (1.0)           1;2  205.9307 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_scenarios_repository_benchmark[rest-postgres-filters4]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_scenarios_repository_benchmark[rest-postgres-filters4] (0007_SUBQUER)     4.9382 (1.07)     6.9292 (1.17)     5.4512 (1.05)     0.5656 (1.27)     5.3236 (1.02)     0.4228 (1.0)           1;1  183.4443 (0.95)         10           1
test_scenarios_repository_benchmark[rest-postgres-filters4] (0008_BASELIN)     4.6353 (1.0)      5.9427 (1.0)      5.1915 (1.0)      0.4457 (1.0)      5.2118 (1.0)      0.7522 (1.78)          3;0  192.6241 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_scenarios_repository_benchmark[rest-postgres-filters5]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_scenarios_repository_benchmark[rest-postgres-filters5] (0007_SUBQUER)     5.2329 (1.03)     6.4471 (1.0)      5.8845 (1.01)     0.4010 (1.0)      5.8471 (1.03)     0.6585 (1.10)          3;0  169.9387 (0.99)         10           1
test_scenarios_repository_benchmark[rest-postgres-filters5] (0008_BASELIN)     5.0858 (1.0)      6.6377 (1.03)     5.8217 (1.0)      0.4960 (1.24)     5.7021 (1.0)      0.5963 (1.0)           4;0  171.7698 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_units_repository_benchmark[rest-postgres-filters0]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_units_repository_benchmark[rest-postgres-filters0] (0007_SUBQUER)     4.2373 (1.0)      6.4379 (1.01)     4.9289 (1.0)      0.7221 (1.0)      4.6725 (1.0)      0.5828 (1.0)           2;2  202.8842 (1.0)          10           1
test_units_repository_benchmark[rest-postgres-filters0] (0008_BASELIN)     4.3719 (1.03)     6.3913 (1.0)      5.2430 (1.06)     0.8072 (1.12)     5.0350 (1.08)     1.5199 (2.61)          4;0  190.7303 (0.94)         10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_units_repository_benchmark[rest-postgres-filters1]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_units_repository_benchmark[rest-postgres-filters1] (0007_SUBQUER)     4.6021 (1.06)     7.7399 (1.49)     5.6163 (1.22)     1.0864 (4.13)     5.1824 (1.13)     1.9049 (5.21)          3;0  178.0542 (0.82)         10           1
test_units_repository_benchmark[rest-postgres-filters1] (0008_BASELIN)     4.3315 (1.0)      5.1790 (1.0)      4.6163 (1.0)      0.2629 (1.0)      4.5911 (1.0)      0.3656 (1.0)           2;0  216.6222 (1.0)          10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_units_repository_benchmark[rest-postgres-filters2]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_units_repository_benchmark[rest-postgres-filters2] (0007_SUBQUER)     4.2495 (1.0)      7.0130 (1.27)     5.3078 (1.13)     1.0781 (2.76)     4.7398 (1.03)     1.8714 (3.33)          2;0  188.4026 (0.89)         10           1
test_units_repository_benchmark[rest-postgres-filters2] (0008_BASELIN)     4.2897 (1.01)     5.5394 (1.0)      4.7114 (1.0)      0.3900 (1.0)      4.5848 (1.0)      0.5615 (1.0)           2;0  212.2527 (1.0)          10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_units_repository_benchmark[rest-postgres-filters3]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_units_repository_benchmark[rest-postgres-filters3] (0007_SUBQUER)     4.1992 (1.0)      6.1726 (1.23)     4.8218 (1.05)     0.6365 (2.37)     4.4966 (1.0)      0.8681 (2.16)          2;0  207.3926 (0.95)         10           1
test_units_repository_benchmark[rest-postgres-filters3] (0008_BASELIN)     4.2966 (1.02)     5.0354 (1.0)      4.5906 (1.0)      0.2685 (1.0)      4.5107 (1.00)     0.4022 (1.0)           3;0  217.8383 (1.0)          10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_units_repository_benchmark[rest-postgres-filters4]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_units_repository_benchmark[rest-postgres-filters4] (0007_SUBQUER)     4.5394 (1.07)     7.0466 (1.27)     6.1812 (1.33)     0.8970 (2.27)     6.3812 (1.39)     1.1169 (2.48)          2;0  161.7819 (0.75)         10           1
test_units_repository_benchmark[rest-postgres-filters4] (0008_BASELIN)     4.2277 (1.0)      5.5330 (1.0)      4.6363 (1.0)      0.3947 (1.0)      4.5779 (1.0)      0.4497 (1.0)           2;1  215.6906 (1.0)          10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_units_repository_benchmark[rest-postgres-filters5]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_units_repository_benchmark[rest-postgres-filters5] (0007_SUBQUER)     4.8420 (1.02)     5.5651 (1.03)     5.3023 (1.06)     0.2336 (1.00)     5.3064 (1.07)     0.2854 (1.01)          3;0  188.5971 (0.95)         10           1
test_units_repository_benchmark[rest-postgres-filters5] (0008_BASELIN)     4.7674 (1.0)      5.4110 (1.0)      5.0202 (1.0)      0.2327 (1.0)      4.9511 (1.0)      0.2813 (1.0)           3;0  199.1948 (1.0)          10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_variables_repository_benchmark[rest-postgres-filters0]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_variables_repository_benchmark[rest-postgres-filters0] (0007_SUBQUER)     4.4634 (1.06)     5.8278 (1.0)      4.9464 (1.0)      0.4438 (1.0)      4.8338 (1.05)     0.4764 (1.0)           3;0  202.1682 (1.0)          10           1
test_variables_repository_benchmark[rest-postgres-filters0] (0008_BASELIN)     4.2202 (1.0)      7.3162 (1.26)     5.3468 (1.08)     1.2711 (2.86)     4.6105 (1.0)      2.1977 (4.61)          2;0  187.0289 (0.93)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_variables_repository_benchmark[rest-postgres-filters1]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_variables_repository_benchmark[rest-postgres-filters1] (0007_SUBQUER)     4.8570 (1.10)     6.9924 (1.30)     6.1302 (1.30)     0.7997 (2.54)     6.4095 (1.40)     1.3693 (3.55)          3;0  163.1280 (0.77)         10           1
test_variables_repository_benchmark[rest-postgres-filters1] (0008_BASELIN)     4.4320 (1.0)      5.3773 (1.0)      4.7179 (1.0)      0.3144 (1.0)      4.5664 (1.0)      0.3855 (1.0)           2;0  211.9604 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_variables_repository_benchmark[rest-postgres-filters2]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                                                 Min                Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_variables_repository_benchmark[rest-postgres-filters2] (0007_SUBQUER)     4.2501 (1.0)       4.9865 (1.0)      4.6947 (1.0)      0.2105 (1.0)      4.7415 (1.0)      0.2515 (1.0)           2;0  213.0051 (1.0)          10           1
test_variables_repository_benchmark[rest-postgres-filters2] (0008_BASELIN)     6.2531 (1.47)     10.2923 (2.06)     7.2991 (1.55)     1.1787 (5.60)     6.9229 (1.46)     1.0430 (4.15)          1;1  137.0035 (0.64)         10           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_variables_repository_benchmark[rest-postgres-filters3]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_variables_repository_benchmark[rest-postgres-filters3] (0007_SUBQUER)     3.9116 (1.0)      5.1922 (1.0)      4.6362 (1.0)      0.3802 (1.06)     4.7037 (1.0)      0.4028 (1.0)           4;0  215.6935 (1.0)          10           1
test_variables_repository_benchmark[rest-postgres-filters3] (0008_BASELIN)     4.6371 (1.19)     5.8183 (1.12)     5.1132 (1.10)     0.3601 (1.0)      5.0919 (1.08)     0.6144 (1.53)          3;0  195.5739 (0.91)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_variables_repository_benchmark[rest-postgres-filters4]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_variables_repository_benchmark[rest-postgres-filters4] (0007_SUBQUER)     4.5510 (1.0)      7.0740 (1.30)     5.0585 (1.03)     0.7427 (2.61)     4.7753 (1.0)      0.4641 (1.14)          1;1  197.6877 (0.97)         10           1
test_variables_repository_benchmark[rest-postgres-filters4] (0008_BASELIN)     4.5550 (1.00)     5.4271 (1.0)      4.9227 (1.0)      0.2847 (1.0)      4.9306 (1.03)     0.4073 (1.0)           5;0  203.1411 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_variables_repository_benchmark[rest-postgres-filters5]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                                                 Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_variables_repository_benchmark[rest-postgres-filters5] (0007_SUBQUER)     5.4293 (1.14)     6.8425 (1.11)     6.0099 (1.19)     0.4318 (1.07)     5.8923 (1.18)     0.5762 (1.74)          3;0  166.3908 (0.84)         10           1
test_variables_repository_benchmark[rest-postgres-filters5] (0008_BASELIN)     4.7662 (1.0)      6.1395 (1.0)      5.0716 (1.0)      0.4032 (1.0)      4.9835 (1.0)      0.3312 (1.0)           1;1  197.1753 (1.0)          10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean

</details>

**Manual test of queries against the platform `scenariocompass-dev` specifically relevant for the Scenario Compass Platform**
<details>
<summary>
See results
</summary>

**SPECIFIC RELEVANT REQUESTS FOR LARGE PLATFORM scenariocompass-dev**

**1. FETCH ALL VARIABLES**

**Endpoint:**  
`PATCH /iamc/variables/?table=false`  
**Body:**  
_No body_

| MAIN   | OPTIMIZED |
|--------|-----------|
| ~15s   | ~2.2s     |

---

**2. FETCH MODELS WITH TIMESERIES DATA**

**Endpoint:**  
`PATCH /models/?table=false`  
**Body:**  
```json
{ "iamc": true }
```

| MAIN   | OPTIMIZED |
|--------|-----------|
| ~1.9s   | ~2s     |

**3. FETCH REGIONS WITH TIMESERIES DATA**
**Endpoint:**  
`PATCH /regions/?table=false`  
**Body:**  
```json
{ "iamc": {} }
```

| MAIN   | OPTIMIZED |
|--------|-----------|
| ~1.9s   | ~1.7s     |

**RESULT**
We see a huge performance improvement for querying variables and roughly the same query time for other queries which require joining timeseries data. 

</details>

## Affected Components
* `BaseFilter` core optimization system
All IAMC entity filters that require joins through timeseries and/or measurand tables:
* `VariableFilter`
* `IamcUnitFilter`
* `IamcScenarioFilter`
* `IamcRunFilter`
* `IamcRegionFilter`
* `IamcModelFilter`