### PR TITLE
Use `library` mode as default (module) logging behavior

### DIFF
--- a/ixmp4/conf/logging/library.json
+++ b/ixmp4/conf/logging/library.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "generic": {
+      "format": "[%(levelname)s] %(asctime)s - %(name)s: %(message)s",
+      "datefmt": "%H:%M:%S"
+    }
+  },
+  "loggers": {
+    "ixmp4": {
+      "level": "INFO",
+      "handlers": [
+        "console"
+      ]
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "level": "NOTSET",
+      "formatter": "generic"
+    }
+  }
+}

--- a/ixmp4/conf/settingsmodel.py
+++ b/ixmp4/conf/settingsmodel.py
@@ -24,9 +24,12 @@ root = Path(__root__file__).parent.parent
 
 
 class Settings(BaseSettings):
-    mode: Literal["production"] | Literal["development"] | Literal["debug"] = (
-        "production"
-    )
+    mode: (
+        Literal["library"]
+        | Literal["production"]
+        | Literal["development"]
+        | Literal["debug"]
+    ) = "library"
     storage_directory: Path = Field(Path("~/.local/share/ixmp4/"))
     secret_hs256: str = "default_secret_hs256"
     migration_db_uri: str = "sqlite:///./run/db.sqlite"


### PR DESCRIPTION
Per our discussion on preferred logging behavior by ixmp4 (only using a module-logger in library mode), this PR adds a new mode "library" and assigns it as default.

Is that what you had in mind @meksor?

FYI @phackstock @glatterf42 