### PR TITLE
move `configure_logging` call from settings to __main__.py

### DIFF
--- a/ixmp4/__init__.py
+++ b/ixmp4/__init__.py
@@ -1,5 +1,3 @@
-import importlib.metadata
-
 from ixmp4.core import IndexSet as IndexSet
 from ixmp4.core import Model as Model
 from ixmp4.core import Parameter as Parameter

--- a/ixmp4/__main__.py
+++ b/ixmp4/__main__.py
@@ -1,4 +1,7 @@
 from ixmp4.cli import app
+from ixmp4.conf import settings
 
 if __name__ == "__main__":
+    settings.configure_logging(settings.mode)
+
     app()

--- a/ixmp4/conf/logging/debug.json
+++ b/ixmp4/conf/logging/debug.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
-  "disable_existing_loggers": false,
-  "formatters":{
+  "disable_existing_loggers": true,
+  "formatters": {
     "generic": {
       "format": "[%(levelname)s] %(asctime)s - %(name)s: %(message)s",
       "datefmt": "%H:%M:%S"
-    } 
+    }
   },
   "root": {
     "level": "DEBUG",
     "handlers": ["console"]
   },
-  "handlers":{
-    "console":{
+  "handlers": {
+    "console": {
       "class": "logging.StreamHandler",
       "level": "NOTSET",
       "formatter": "generic"
@@ -20,6 +20,9 @@
   },
   "loggers": {
     "sqlalchemy": {
+      "level": "NOTSET"
+    },
+    "ixmp4": {
       "level": "NOTSET"
     }
   }

--- a/ixmp4/conf/logging/debug.json
+++ b/ixmp4/conf/logging/debug.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "disable_existing_loggers": true,
+  "disable_existing_loggers": false,
   "formatters": {
     "generic": {
       "format": "[%(levelname)s] %(asctime)s - %(name)s: %(message)s",

--- a/ixmp4/conf/logging/development.json
+++ b/ixmp4/conf/logging/development.json
@@ -1,18 +1,23 @@
 {
   "version": 1,
   "disable_existing_loggers": false,
-  "formatters":{
-    "generic":{ 
+  "formatters": {
+    "generic": {
       "format": "[%(levelname)s] %(asctime)s - %(name)s: %(message)s",
       "datefmt": "%H:%M:%S"
     }
   },
-  "root":{ 
+  "root": {
     "level": "INFO",
     "handlers": ["console"]
   },
-  "handlers":{
-    "console":{
+  "loggers": {
+    "ixmp4": {
+      "level": "NOTSET"
+    }
+  },
+  "handlers": {
+    "console": {
       "class": "logging.StreamHandler",
       "level": "NOTSET",
       "formatter": "generic"

--- a/ixmp4/conf/logging/production.json
+++ b/ixmp4/conf/logging/production.json
@@ -13,8 +13,7 @@
   },
   "loggers": {
     "ixmp4": {
-      "level": "INFO",
-      "handlers": ["console"]
+      "level": "INFO"
     }
   },
   "handlers": {

--- a/ixmp4/conf/settingsmodel.py
+++ b/ixmp4/conf/settingsmodel.py
@@ -57,7 +57,7 @@ class Settings(BaseSettings):
 
         self.setup_directories()
 
-        if _stdout_is_tty or _in_ipython_session:
+        if self.is_in_interactive_mode():
             self.configure_logging(self.mode)
 
         self._credentials: Credentials | None = None
@@ -66,6 +66,9 @@ class Settings(BaseSettings):
         self._manager: ManagerConfig | None = None
 
         logger.debug(f"Settings loaded: {self}")
+
+    def is_in_interactive_mode(self) -> bool:
+        return _stdout_is_tty or _in_ipython_session
 
     @property
     def credentials(self) -> Credentials:

--- a/ixmp4/conf/settingsmodel.py
+++ b/ixmp4/conf/settingsmodel.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import logging.config
+import os
+import sys
 from pathlib import Path
 from typing import Any, Literal
 
@@ -21,6 +23,14 @@ logger = logging.getLogger(__name__)
 
 here = Path(__file__).parent
 root = Path(__root__file__).parent.parent
+
+try:
+    __IPYTHON__  # type: ignore
+    _in_ipython_session = True
+except NameError:
+    _in_ipython_session = False
+
+_stdout_is_tty = os.isatty(sys.stdout.fileno())
 
 
 class Settings(BaseSettings):
@@ -47,12 +57,8 @@ class Settings(BaseSettings):
 
         self.setup_directories()
 
-        ixmp4_logger = logging.getLogger("ixmp4")
-        if ixmp4_logger.level == logging.NOTSET:
-            ixmp4_logger.setLevel(logging.INFO)
-
-        if len(ixmp4_logger.handlers) == 0:
-            ixmp4_logger.addHandler(logging.StreamHandler())
+        if _stdout_is_tty or _in_ipython_session:
+            self.configure_logging(self.mode)
 
         self._credentials: Credentials | None = None
         self._toml: TomlConfig | None = None

--- a/ixmp4/conf/settingsmodel.py
+++ b/ixmp4/conf/settingsmodel.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import logging.config
-import os
 import sys
 from pathlib import Path
 from typing import Any, Literal
@@ -30,7 +29,7 @@ try:
 except NameError:
     _in_ipython_session = False
 
-_stdout_is_tty = os.isatty(sys.stdout.fileno())
+_sys_has_ps1 = hasattr(sys, "ps1")
 
 
 class Settings(BaseSettings):
@@ -68,7 +67,7 @@ class Settings(BaseSettings):
         logger.debug(f"Settings loaded: {self}")
 
     def is_in_interactive_mode(self) -> bool:
-        return _stdout_is_tty or _in_ipython_session
+        return _sys_has_ps1 or _in_ipython_session
 
     @property
     def credentials(self) -> Credentials:

--- a/ixmp4/conf/settingsmodel.py
+++ b/ixmp4/conf/settingsmodel.py
@@ -47,6 +47,13 @@ class Settings(BaseSettings):
 
         self.setup_directories()
 
+        ixmp4_logger = logging.getLogger("ixmp4")
+        if ixmp4_logger.level == logging.NOTSET:
+            ixmp4_logger.setLevel(logging.INFO)
+
+        if len(ixmp4_logger.handlers) == 0:
+            ixmp4_logger.addHandler(logging.StreamHandler())
+
         self._credentials: Credentials | None = None
         self._toml: TomlConfig | None = None
         self._default_auth: ManagerAuth | AnonymousAuth | None = None

--- a/ixmp4/conf/settingsmodel.py
+++ b/ixmp4/conf/settingsmodel.py
@@ -46,7 +46,6 @@ class Settings(BaseSettings):
         super().__init__(*args, **kwargs)
 
         self.setup_directories()
-        self.configure_logging(self.mode)
 
         self._credentials: Credentials | None = None
         self._toml: TomlConfig | None = None


### PR DESCRIPTION
... thus, logging will be configure when using ixmp4 via the cli: `ixmp4 platforms list`, `ixmp4 server start`, but not when used as a library via `import ixmp4`. In the latter case the library user is responsible for setting up the logging configuration... 