### PR TITLE
Start transaction id at 2

### DIFF
--- a/ixmp4/db/migrations/versions/0b45de1602a6_add_version_tables.py
+++ b/ixmp4/db/migrations/versions/0b45de1602a6_add_version_tables.py
@@ -394,7 +394,12 @@ def upgrade():
 
     op.create_table(
         "transaction",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            sa.Identity(always=False, on_null=True, start=2, increment=1),
+            nullable=False,
+        ),
         sa.Column("remote_addr", sa.String(length=50), nullable=True),
         sa.Column("issued_at", sa.DateTime(), nullable=True),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_transaction")),


### PR DESCRIPTION
Due to a bug, it is necessary to start the transaction id sequence at 2. 
(the initial version migration inserts a transaction with id=1 even if the database is empty)