### PR TITLE
ENABLE/DISABLE TRIGGER -ALL +USER

### DIFF
--- a/ixmp4/db/migrations/utils.py
+++ b/ixmp4/db/migrations/utils.py
@@ -26,7 +26,7 @@ def pause_foreign_key_checks() -> Generator[None, None, None]:
             )
         ]
         for table in tables:
-            op.execute(f'ALTER TABLE "{table}" DISABLE TRIGGER ALL;')
+            op.execute(f'ALTER TABLE "{table}" DISABLE TRIGGER USER;')
     else:
         raise NotImplementedError(
             "Foreign key checks cannot be paused for dialect "
@@ -46,4 +46,4 @@ def pause_foreign_key_checks() -> Generator[None, None, None]:
                 )
             ]
             for table in tables:
-                op.execute(f'ALTER TABLE "{table}" ENABLE TRIGGER ALL;')
+                op.execute(f'ALTER TABLE "{table}" ENABLE TRIGGER USER;')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -36,7 +36,7 @@ def backends(request: pytest.FixtureRequest) -> Backends:
 
 @pytest.fixture()
 def alembic(
-    request: pytest.FixtureRequest, backends: Backends
+    request: pytest.FixtureRequest, backends: Backends, alembic_config: dict[str, Any]
 ) -> Generator[MigrationContext, Any, None]:
     bctx: (
         _GeneratorContextManager[PostgresTestBackend, None, None]
@@ -50,7 +50,7 @@ def alembic(
     elif request.param == "sqlite":
         bctx = backends.sqlite()
 
-    config = Config.from_raw_config(None)
+    config = Config.from_raw_config(alembic_config)
     with bctx as backend:
         backend.teardown()
         with backend.engine.connect() as conn:
@@ -86,3 +86,4 @@ def test_up_down_consistency(alembic: MigrationContext) -> None:
 def test_upgrade(alembic: MigrationContext) -> None:
     """Test that the upgrade migrations work."""
     upgrade(alembic)
+    pass


### PR DESCRIPTION
Tries to fix a common error when creating databases where the `ixmp4 platforms upgrade` command will fail with a message like: "permission denied 'xyz' is a system trigger". By disabling "USER" triggers instead of "ALL" triggers we might fix this... 
Lets see if the test run through... 