### PR TITLE
add tabulate_manager_platforms pyam compatibilty function

### DIFF
--- a/ixmp4/cli/platforms.py
+++ b/ixmp4/cli/platforms.py
@@ -311,3 +311,27 @@ def generate_data(generator: MockDataGenerator) -> None:
         )
         for df in generator.yield_datapoints(runs, variable_names, units, regions):
             progress.advance(task, len(df))
+
+
+def tabulate_manager_platforms(
+    platforms: list[Any],
+) -> None:
+    """Prints manager platforms to the console. Only used for pyam compatibility.
+    TODO: Remove once no longer needed."""
+    manager_url_str = typer.style(Settings().manager_url, fg=typer.colors.CYAN)
+
+    manager_table = Table(
+        Column("Name", max_width=24, no_wrap=True),
+        "Access",
+        Column("Notice", max_width=48, no_wrap=True),
+        box=box.SIMPLE,
+        title="via manager api " + manager_url_str,
+        title_justify="left",
+        caption="Total: " + typer.style(str(len(platforms)), fg=typer.colors.GREEN),
+        caption_justify="left",
+    )
+    for mp in platforms:
+        manager_table.add_row(mp.name, str(mp.accessibility).lower(), mp.notice)
+    console.print()
+    console.print(manager_table)
+    console.print()

--- a/tests/cli/test_platforms.py
+++ b/tests/cli/test_platforms.py
@@ -1,13 +1,18 @@
 import os
+import re
+from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from typing import Generator
 from unittest import mock
 
 import pytest
+from rich.console import Console
 from typer.testing import CliRunner
 
 from ixmp4.cli import app
+from ixmp4.cli.platforms import tabulate_manager_platforms
 from ixmp4.conf.settings import Settings
 
 
@@ -257,3 +262,42 @@ class TestPlatformGenerateCLI:
 
         # We simply test whether the generate command errors
         assert result.exit_code > 0
+
+
+def test_tabulate_manager_platforms(monkeypatch: pytest.MonkeyPatch) -> None:
+    output_buffer = StringIO()
+    console = Console(
+        file=output_buffer, force_terminal=False, color_system=None, width=120
+    )
+    monkeypatch.setattr("ixmp4.cli.platforms.console", console)
+    monkeypatch.setattr(
+        "ixmp4.cli.platforms.Settings",
+        lambda: SimpleNamespace(manager_url="https://manager.example"),
+    )
+
+    tabulate_manager_platforms(
+        [
+            SimpleNamespace(
+                name="alpha",
+                accessibility="PUBLIC",
+                notice="Primary platform",
+            ),
+            SimpleNamespace(
+                name="beta",
+                accessibility="PRIVATE",
+                notice="Restricted",
+            ),
+        ]
+    )
+
+    output = output_buffer.getvalue()
+    normalized_output = " ".join(re.sub(r"\x1b\[[0-9;]*m", "", output).split())
+
+    assert "via manager api https://manager.example" in normalized_output
+    assert "Total: 2" in normalized_output
+    assert "alpha" in normalized_output
+    assert "public" in normalized_output
+    assert "Primary platform" in normalized_output
+    assert "beta" in normalized_output
+    assert "private" in normalized_output
+    assert "Restricted" in normalized_output


### PR DESCRIPTION
Accidentally removed but needed by pyam in this form... 
Tests added so I dont remove it again. 