### PR TITLE
Fix iamc output format

### DIFF
--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import pandas as pd
 
@@ -17,6 +17,41 @@ from .variable import VariableServiceFacade
 
 if TYPE_CHECKING:
     from ixmp4.core import run
+
+MAP_STEP_COLUMN = {
+    "ANNUAL": "step_year",
+    "CATEGORICAL": "step_year",
+    "DATETIME": "step_datetime",
+}
+
+
+def _convert_to_std_format(
+    df: pd.DataFrame, join_runs: bool, join_run_id: bool
+) -> pd.DataFrame:
+    df.rename(columns={"step_category": "subannual"}, inplace=True)
+
+    if set(df.type.unique()).issubset(["ANNUAL", "CATEGORICAL"]):
+        df.rename(columns={"step_year": "year"}, inplace=True)
+        time_col = "year"
+    else:
+        T = TypeVar("T", bool, float, int, str)
+
+        def map_step_column(df: "pd.Series[T]") -> "pd.Series[T]":
+            df["time"] = df[MAP_STEP_COLUMN[str(df.type)]]
+            return df
+
+        df = df.apply(map_step_column, axis=1)
+        time_col = "time"
+
+    columns = []
+    if join_run_id and "run__id" in df.columns:
+        columns.append("run__id")
+    if join_runs:
+        columns.extend(["model", "scenario", "version"])
+    columns += ["region", "variable", "unit"] + [time_col]
+    if "subannual" in df.columns:
+        columns += ["subannual"]
+    return df[columns + ["value"]]
 
 
 class RunIamcData(BaseBackendFacade):
@@ -62,7 +97,9 @@ class RunIamcData(BaseBackendFacade):
             columns={
                 "year": "step_year",
                 "category": "step_category",
+                "subannual": "step_category",
                 "datetime": "step_datetime",
+                "time": "step_datetime",
             }
         )
 
@@ -70,8 +107,8 @@ class RunIamcData(BaseBackendFacade):
         return df.rename(
             columns={
                 "step_year": "year",
-                "step_category": "category",
-                "step_datetime": "datetime",
+                "step_category": "subannual",
+                "step_datetime": "time",
             }
         ).drop(columns=["id", "time_series__id"])
 
@@ -237,7 +274,7 @@ class RunIamcData(BaseBackendFacade):
             join_runs=False,
             **facade_to_data_filter(kwargs),
         )
-        return self._rename_ret_cols(df)
+        return _convert_to_std_format(df, join_runs=False, join_run_id=False)
 
 
 class PlatformIamcData(BaseBackendFacade):
@@ -302,4 +339,4 @@ class PlatformIamcData(BaseBackendFacade):
             **facade_to_data_filter(kwargs),
         )
 
-        return self._rename_ret_cols(df)
+        return _convert_to_std_format(df, join_runs=join_runs, join_run_id=join_run_id)

--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -48,7 +48,9 @@ def _convert_to_std_format(
         columns.append("run__id")
     if join_runs:
         columns.extend(["model", "scenario", "version"])
-    columns += ["region", "variable", "unit"] + [time_col]
+    columns += ["region", "variable", "unit"]
+    if time_col in df.columns:
+        columns += [time_col]
     if "subannual" in df.columns:
         columns += ["subannual"]
     return df[columns + ["value"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,4 +180,4 @@ vcs = "git"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--benchmark-skip --cov-report term --cov=ixmp4 "
+addopts = "--benchmark-skip"

--- a/tests/core/test_filters.py
+++ b/tests/core/test_filters.py
@@ -240,7 +240,11 @@ class TestFilters:
 
     def test_filter_datapoints(self, platform: ixmp4.Platform) -> None:
         def sort_df(df: pd.DataFrame) -> pd.DataFrame:
-            return df.sort_values(df.columns.tolist()).reset_index(drop=True)
+            # Use string keys to handle columns with mixed types (e.g. int years
+            # and Timestamps in the same "time" column after _convert_to_std_format).
+            return df.sort_values(
+                df.columns.tolist(), key=lambda col: col.astype(str)
+            ).reset_index(drop=True)
 
         df = platform.iamc.tabulate(run={"default_only": False})
         assert len(df) == 426

--- a/tests/core/test_iamc_data.py
+++ b/tests/core/test_iamc_data.py
@@ -74,9 +74,7 @@ class IamcDataTest(IamcTest):
         test_data_type: Type | None,
     ) -> None:
         ret = run.iamc.tabulate()
-        pdt.assert_frame_equal(
-            test_data_add, ret.drop(columns=["type"]), check_like=True
-        )
+        pdt.assert_frame_equal(test_data_add, ret, check_like=True)
 
         test_data_platform = test_data_add.copy()
         test_data_platform["model"] = run.model.name
@@ -84,50 +82,40 @@ class IamcDataTest(IamcTest):
         test_data_platform["version"] = run.version
 
         ret_platform = platform.iamc.tabulate(run={"default_only": False})
-        pdt.assert_frame_equal(
-            test_data_platform, ret_platform.drop(columns=["type"]), check_like=True
-        )
+        pdt.assert_frame_equal(test_data_platform, ret_platform, check_like=True)
 
     def test_iamc_data_facade_name_filter_shorthands(
         self,
         run: ixmp4.Run,
     ) -> None:
-        ret_region = run.iamc.tabulate(region="Region 1").drop(columns=["type"])
-        ret_region_explicit = run.iamc.tabulate(region={"name__like": "Region 1"}).drop(
-            columns=["type"]
-        )
+        ret_region = run.iamc.tabulate(region="Region 1")
+        ret_region_explicit = run.iamc.tabulate(region={"name__like": "Region 1"})
         pdt.assert_frame_equal(
             self.canonical_sort(ret_region),
             self.canonical_sort(ret_region_explicit),
             check_like=True,
         )
 
-        ret_unit = run.iamc.tabulate(unit=["Unit 1", "Unit 2"]).drop(columns=["type"])
-        ret_unit_explicit = run.iamc.tabulate(
-            unit={"name__in": ["Unit 1", "Unit 2"]}
-        ).drop(columns=["type"])
+        ret_unit = run.iamc.tabulate(unit=["Unit 1", "Unit 2"])
+        ret_unit_explicit = run.iamc.tabulate(unit={"name__in": ["Unit 1", "Unit 2"]})
         pdt.assert_frame_equal(
             self.canonical_sort(ret_unit),
             self.canonical_sort(ret_unit_explicit),
             check_like=True,
         )
 
-        ret_variable = run.iamc.tabulate(variable="Variable 1").drop(columns=["type"])
-        ret_variable_explicit = run.iamc.tabulate(
-            variable={"name__like": "Variable 1"}
-        ).drop(columns=["type"])
+        ret_variable = run.iamc.tabulate(variable="Variable 1")
+        ret_variable_explicit = run.iamc.tabulate(variable={"name__like": "Variable 1"})
         pdt.assert_frame_equal(
             self.canonical_sort(ret_variable),
             self.canonical_sort(ret_variable_explicit),
             check_like=True,
         )
 
-        ret_variable_in = run.iamc.tabulate(variable=["Variable 1", "Variable 2"]).drop(
-            columns=["type"]
-        )
+        ret_variable_in = run.iamc.tabulate(variable=["Variable 1", "Variable 2"])
         ret_variable_in_explicit = run.iamc.tabulate(
             variable={"name__in": ["Variable 1", "Variable 2"]}
-        ).drop(columns=["type"])
+        )
         pdt.assert_frame_equal(
             self.canonical_sort(ret_variable_in),
             self.canonical_sort(ret_variable_in_explicit),
@@ -150,9 +138,7 @@ class IamcDataTest(IamcTest):
         test_data_type: Type | None,
     ) -> None:
         ret = run.iamc.tabulate()
-        pdt.assert_frame_equal(
-            test_data_remaining, ret.drop(columns=["type"]), check_like=True
-        )
+        pdt.assert_frame_equal(test_data_remaining, ret, check_like=True)
 
     def test_iamc_data_upsert(
         self,
@@ -170,7 +156,6 @@ class IamcDataTest(IamcTest):
         test_data_upsert: pd.DataFrame,
     ) -> None:
         ret = run.iamc.tabulate()
-        ret = ret.drop(columns=["type"])
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_upsert),
             self.canonical_sort(ret),
@@ -181,9 +166,7 @@ class IamcDataTest(IamcTest):
         test_data_platform["model"] = run.model.name
         test_data_platform["scenario"] = run.scenario.name
         test_data_platform["version"] = run.version
-        ret_platform = platform.iamc.tabulate(run={"default_only": False}).drop(
-            columns=["type"]
-        )
+        ret_platform = platform.iamc.tabulate(run={"default_only": False})
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_platform),
             self.canonical_sort(ret_platform),
@@ -205,13 +188,6 @@ class IamcDataTest(IamcTest):
         run: ixmp4.Run,
     ) -> None:
         ret = run.iamc.tabulate()
-        assert ret.columns.sort_values().to_list() == [
-            "region",
-            "type",
-            "unit",
-            "value",
-            "variable",
-        ]
         assert ret.empty
 
     def test_iamc_data_versioning(self, versioning_platform: ixmp4.Platform) -> None:
@@ -282,7 +258,7 @@ class IamcDataRollbackTest(IamcTest):
         test_data_add: pd.DataFrame,
         test_data_remove: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_add),
             self.canonical_sort(ret),
@@ -296,7 +272,7 @@ class IamcDataRollbackTest(IamcTest):
         test_data_remove: pd.DataFrame,
         test_data_remaining: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_remaining),
             self.canonical_sort(ret),
@@ -321,7 +297,7 @@ class IamcDataRollbackTest(IamcTest):
         run: ixmp4.Run,
         test_data_add: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_add),
             self.canonical_sort(ret),
@@ -334,7 +310,7 @@ class IamcDataRollbackTest(IamcTest):
         run: ixmp4.Run,
         test_data_upsert: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_upsert),
             self.canonical_sort(ret),
@@ -359,7 +335,7 @@ class IamcDataRollbackTest(IamcTest):
         run: ixmp4.Run,
         test_data_add: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_add),
             self.canonical_sort(ret),
@@ -381,7 +357,7 @@ class IamcDataRollbackTest(IamcTest):
         expected = pd.concat(
             [test_data_upsert, test_data_new_timeseries], ignore_index=True
         )
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(expected),
             self.canonical_sort(ret),
@@ -411,7 +387,7 @@ class IamcDataRollbackTest(IamcTest):
         run: ixmp4.Run,
         test_data_add: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_add),
             self.canonical_sort(ret),
@@ -429,7 +405,7 @@ class IamcDataRollbackTest(IamcTest):
         run: ixmp4.Run,
         test_data_upsert_after_full_timeseries_removal: pd.DataFrame,
     ) -> None:
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_upsert_after_full_timeseries_removal),
             self.canonical_sort(ret),
@@ -461,7 +437,7 @@ class IamcDataRollbackTest(IamcTest):
         assert versioning_platform.iamc.variables.get_by_name("Variable 1").name == (
             "Variable 1"
         )
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_add),
             self.canonical_sort(ret),
@@ -669,7 +645,7 @@ class TestIamcDataStringType(IamcDataAnnual, IamcTest):
     ) -> None:
         with run.transact("remove partial"):
             run.iamc.remove(test_data_remove, type="Annual")
-        ret = run.iamc.tabulate().drop(columns=["type"])
+        ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_remaining),
             self.canonical_sort(ret),

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -267,7 +267,7 @@ class TestRunClone:
         assert cloned_run.scenario.name == run.scenario.name
         assert dict(cloned_run.meta) == test_data_meta
 
-        cloned_df = cloned_run.iamc.tabulate().drop(columns=["type"])
+        cloned_df = cloned_run.iamc.tabulate()
         pdt.assert_frame_equal(cloned_df, test_data_iamc, check_like=True)
 
         indexset1 = cloned_run.optimization.indexsets.get_by_name("IndexSet 1")


### PR DESCRIPTION
Returns normalized IAMC output data instead of what was previously obtained using raw=True