### PR TITLE
Introduce Library Boundary Tests (With explicit pyam tests)

### DIFF
--- a/ixmp4/__init__.py
+++ b/ixmp4/__init__.py
@@ -1,4 +1,6 @@
 from ixmp4.core.exceptions import InconsistentIamcType as InconsistentIamcType
+from ixmp4.core.exceptions import InvalidCredentials as InvalidCredentials
+from ixmp4.core.exceptions import InvalidToken as InvalidToken
 from ixmp4.core.exceptions import Ixmp4Error as Ixmp4Error
 from ixmp4.core.exceptions import NotFound as NotFound
 from ixmp4.core.exceptions import NotUnique as NotUnique

--- a/ixmp4/base_exceptions.py
+++ b/ixmp4/base_exceptions.py
@@ -5,6 +5,8 @@ from toolkit.exceptions import BadGateway as BaseBadGateway
 from toolkit.exceptions import BadRequest as BaseBadRequest
 from toolkit.exceptions import ConstraintViolated as BaseConstraintViolated
 from toolkit.exceptions import Forbidden as BaseForbidden
+from toolkit.exceptions import InvalidCredentials as InvalidCredentials
+from toolkit.exceptions import InvalidToken as InvalidToken
 from toolkit.exceptions import NotFound as BaseNotFound
 from toolkit.exceptions import NotUnique as BaseNotUnique
 from toolkit.exceptions import PlatformNotFound as BasePlatformNotFound
@@ -13,8 +15,6 @@ from toolkit.exceptions import ServerError as BaseServerError
 from toolkit.exceptions import ServiceException as ServiceException
 from toolkit.exceptions import ServiceUnavailable as BaseServiceUnavailable
 from toolkit.exceptions import Unauthorized as BaseUnauthorized
-from toolkit.exceptions import InvalidToken as InvalidToken
-from toolkit.exceptions import InvalidCredentials as InvalidCredentials
 from toolkit.exceptions.registry import ServiceExceptionRegistry
 from toolkit.exceptions.serviceexception import DataItemType
 
@@ -76,6 +76,7 @@ class NotUnique(BaseNotUnique, Ixmp4Error):
 class ConstraintViolated(BaseConstraintViolated, Ixmp4Error):
     message = "Database constraint violated."
     http_status_code = 400
+
 
 @registry.register()
 class InconsistentIamcType(Ixmp4Error):

--- a/ixmp4/base_exceptions.py
+++ b/ixmp4/base_exceptions.py
@@ -13,12 +13,16 @@ from toolkit.exceptions import ServerError as BaseServerError
 from toolkit.exceptions import ServiceException as ServiceException
 from toolkit.exceptions import ServiceUnavailable as BaseServiceUnavailable
 from toolkit.exceptions import Unauthorized as BaseUnauthorized
+from toolkit.exceptions import InvalidToken as InvalidToken
+from toolkit.exceptions import InvalidCredentials as InvalidCredentials
 from toolkit.exceptions.registry import ServiceExceptionRegistry
 from toolkit.exceptions.serviceexception import DataItemType
 
 registry = ServiceExceptionRegistry()
 
 registry.register()(ServiceException)
+registry.register()(InvalidToken)
+registry.register()(InvalidCredentials)
 
 
 @registry.register()
@@ -72,19 +76,6 @@ class NotUnique(BaseNotUnique, Ixmp4Error):
 class ConstraintViolated(BaseConstraintViolated, Ixmp4Error):
     message = "Database constraint violated."
     http_status_code = 400
-
-
-@registry.register()
-class InvalidToken(Unauthorized):
-    message = "The supplied token is invalid."
-    http_status_code = 401
-
-
-@registry.register()
-class InvalidCredentials(Unauthorized):
-    message = "Authentication credentials rejected."
-    http_status_code = 401
-
 
 @registry.register()
 class InconsistentIamcType(Ixmp4Error):

--- a/ixmp4/conf/auth.py
+++ b/ixmp4/conf/auth.py
@@ -1,3 +1,0 @@
-# this is here for pyam compatibility
-# TODO: remove once pyam is adjusted
-from toolkit.client.auth import ManagerAuth as ManagerAuth

--- a/ixmp4/core/exceptions.py
+++ b/ixmp4/core/exceptions.py
@@ -81,6 +81,9 @@ from ixmp4.base_exceptions import (
     ServerError as ServerError,
 )
 from ixmp4.base_exceptions import (
+    ServiceException as ServiceException,
+)
+from ixmp4.base_exceptions import (
     ServiceUnavailable as ServiceUnavailable,
 )
 from ixmp4.base_exceptions import (

--- a/ixmp4/core/iamc/datapoint.py
+++ b/ixmp4/core/iamc/datapoint.py
@@ -3,11 +3,13 @@ from ixmp4.data.iamc.datapoint.exceptions import (
     DataPointNotFound,
     DataPointNotUnique,
 )
+from ixmp4.data.iamc.datapoint.filter import FacadeDataPointFilter
 from ixmp4.data.iamc.datapoint.type import Type as Type
 
 
 class DataPoint:
     Type = Type
+    Filter = FacadeDataPointFilter
 
     NotFound = DataPointNotFound
     NotUnique = DataPointNotUnique

--- a/ixmp4/core/iamc/variable.py
+++ b/ixmp4/core/iamc/variable.py
@@ -21,6 +21,7 @@ from ixmp4.data.iamc.variable.service import VariableService
 
 
 class Variable(BaseFacadeObject[VariableService, VariableDto]):
+    Filter = FacadeVariableFilter
     NotFound = VariableNotFound
     NotUnique = VariableNotUnique
     DeletionPrevented = VariableDeletionPrevented

--- a/ixmp4/core/model.py
+++ b/ixmp4/core/model.py
@@ -21,6 +21,7 @@ from ixmp4.data.model.service import ModelService
 
 
 class Model(BaseFacadeObject[ModelService, ModelDto]):
+    Filter = FacadeModelFilter
     NotFound = ModelNotFound
     NotUnique = ModelNotUnique
     DeletionPrevented = ModelDeletionPrevented

--- a/ixmp4/core/optimization/equation.py
+++ b/ixmp4/core/optimization/equation.py
@@ -20,6 +20,7 @@ from .base import BaseOptimizationFacadeObject, BaseOptimizationServiceFacade
 
 
 class Equation(BaseOptimizationFacadeObject[EquationService, EquationDto]):
+    Filter = EquationFilter
     NotUnique = EquationNotUnique
     NotFound = EquationNotFound
     DeletionPrevented = EquationDeletionPrevented

--- a/ixmp4/core/optimization/indexset.py
+++ b/ixmp4/core/optimization/indexset.py
@@ -19,6 +19,7 @@ from .base import BaseOptimizationFacadeObject, BaseOptimizationServiceFacade
 
 
 class IndexSet(BaseOptimizationFacadeObject[IndexSetService, IndexSetDto]):
+    Filter = IndexSetFilter
     NotUnique = IndexSetNotUnique
     NotFound = IndexSetNotFound
     DeletionPrevented = IndexSetDeletionPrevented

--- a/ixmp4/core/optimization/parameter.py
+++ b/ixmp4/core/optimization/parameter.py
@@ -20,6 +20,7 @@ from .base import BaseOptimizationFacadeObject, BaseOptimizationServiceFacade
 
 
 class Parameter(BaseOptimizationFacadeObject[ParameterService, ParameterDto]):
+    Filter = ParameterFilter
     NotUnique = ParameterNotUnique
     NotFound = ParameterNotFound
     DeletionPrevented = ParameterDeletionPrevented

--- a/ixmp4/core/optimization/scalar.py
+++ b/ixmp4/core/optimization/scalar.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class Scalar(BaseOptimizationFacadeObject[ScalarService, ScalarDto]):
+    Filter = ScalarFilter
     NotUnique = ScalarNotUnique
     NotFound = ScalarNotFound
     DeletionPrevented = ScalarDeletionPrevented

--- a/ixmp4/core/optimization/table.py
+++ b/ixmp4/core/optimization/table.py
@@ -20,6 +20,7 @@ from .base import BaseOptimizationFacadeObject, BaseOptimizationServiceFacade
 
 
 class Table(BaseOptimizationFacadeObject[TableService, TableDto]):
+    Filter = TableFilter
     NotUnique = TableNotUnique
     NotFound = TableNotFound
     DeletionPrevented = TableDeletionPrevented

--- a/ixmp4/core/optimization/variable.py
+++ b/ixmp4/core/optimization/variable.py
@@ -20,6 +20,7 @@ from .base import BaseOptimizationFacadeObject, BaseOptimizationServiceFacade
 
 
 class Variable(BaseOptimizationFacadeObject[VariableService, VariableDto]):
+    Filter = VariableFilter
     NotUnique = VariableNotUnique
     NotFound = VariableNotFound
     DeletionPrevented = VariableDeletionPrevented

--- a/ixmp4/core/region.py
+++ b/ixmp4/core/region.py
@@ -22,6 +22,7 @@ from .base import BaseDocsServiceFacade, BaseFacadeObject
 
 
 class Region(BaseFacadeObject[RegionService, RegionDto]):
+    Filter = FacadeRegionFilter
     NotFound = RegionNotFound
     NotUnique = RegionNotUnique
     DeletionPrevented = RegionDeletionPrevented

--- a/ixmp4/core/run.py
+++ b/ixmp4/core/run.py
@@ -125,6 +125,7 @@ class Run(BaseFacadeObject[RunService, RunDto]):
 
     """
 
+    Filter = FacadeRunFilter
     NotFound = RunNotFound
     NotUnique = RunNotUnique
     DeletionPrevented = RunDeletionPrevented

--- a/ixmp4/core/scenario.py
+++ b/ixmp4/core/scenario.py
@@ -21,6 +21,7 @@ from ixmp4.data.scenario.service import ScenarioService
 
 
 class Scenario(BaseFacadeObject[ScenarioService, ScenarioDto]):
+    Filter = FacadeScenarioFilter
     NotFound = ScenarioNotFound
     NotUnique = ScenarioNotUnique
     DeletionPrevented = ScenarioDeletionPrevented

--- a/ixmp4/core/unit.py
+++ b/ixmp4/core/unit.py
@@ -20,6 +20,7 @@ from ixmp4.data.unit.service import UnitService
 
 
 class Unit(BaseFacadeObject[UnitService, UnitDto]):
+    Filter = FacadeUnitFilter
     NotUnique = UnitNotUnique
     NotFound = UnitNotFound
     DeletionPrevented = UnitDeletionPrevented

--- a/tests/lib/test_conf.py
+++ b/tests/lib/test_conf.py
@@ -1,0 +1,68 @@
+"""Boundary tests for the ``ixmp4.conf`` package.
+
+Verifies that all public symbols intended for external consumers are
+importable from the canonical sub-module paths and have the expected
+structure.
+"""
+
+
+class TestSettingsImportable:
+    def test_settings(self) -> None:
+        from ixmp4.conf.settings import Settings
+
+        assert isinstance(Settings, type)
+
+    def test_client_settings(self) -> None:
+        from ixmp4.conf.settings import ClientSettings
+
+        assert isinstance(ClientSettings, type)
+
+    def test_server_settings(self) -> None:
+        from ixmp4.conf.settings import ServerSettings
+
+        assert isinstance(ServerSettings, type)
+
+
+class TestCredentialsImportable:
+    def test_credentials(self) -> None:
+        from ixmp4.conf.credentials import Credentials
+
+        assert isinstance(Credentials, type)
+
+    def test_credentials_dict(self) -> None:
+        from ixmp4.conf.credentials import CredentialsDict
+
+        instance: CredentialsDict = {"username": "u", "password": "p"}
+        assert isinstance(instance, dict)
+
+
+class TestPlatformsImportable:
+    def test_platform_connection_info(self) -> None:
+        from ixmp4.conf.platforms import PlatformConnectionInfo
+
+        assert callable(PlatformConnectionInfo)
+
+    def test_platform_connections(self) -> None:
+        from ixmp4.conf.platforms import PlatformConnections
+
+        assert isinstance(PlatformConnections, type)
+
+    def test_toml_platform(self) -> None:
+        from ixmp4.conf.platforms import TomlPlatform
+
+        assert isinstance(TomlPlatform, type)
+
+    def test_toml_platforms(self) -> None:
+        from ixmp4.conf.platforms import TomlPlatforms
+
+        assert isinstance(TomlPlatforms, type)
+
+    def test_manager_platforms(self) -> None:
+        from ixmp4.conf.platforms import ManagerPlatforms
+
+        assert isinstance(ManagerPlatforms, type)
+
+    def test_resolve_dsn_env_tokens(self) -> None:
+        from ixmp4.conf.platforms import resolve_dsn_env_tokens
+
+        assert callable(resolve_dsn_env_tokens)

--- a/tests/lib/test_exceptions.py
+++ b/tests/lib/test_exceptions.py
@@ -1,0 +1,212 @@
+"""Boundary tests for the ixmp4 exceptions public API.
+
+These tests assert that all exceptions intended for external consumers are
+importable from the canonical locations (``ixmp4.core.exceptions`` and the
+top-level ``ixmp4`` namespace) and that they form the expected inheritance
+hierarchy so that callers can rely on catching ``Ixmp4Error`` as the common
+base class.
+"""
+
+import ixmp4.core.exceptions as exc_module
+
+
+class TestCoreExceptionsImportable:
+    """Every public exception must be importable from ixmp4.core.exceptions."""
+
+    def test_service_exception(self) -> None:
+        assert hasattr(exc_module, "ServiceException")
+
+    def test_ixmp4_error(self) -> None:
+        assert hasattr(exc_module, "Ixmp4Error")
+
+    def test_not_found(self) -> None:
+        assert hasattr(exc_module, "NotFound")
+
+    def test_not_unique(self) -> None:
+        assert hasattr(exc_module, "NotUnique")
+
+    def test_constraint_violated(self) -> None:
+        assert hasattr(exc_module, "ConstraintViolated")
+
+    def test_deletion_prevented(self) -> None:
+        assert hasattr(exc_module, "DeletionPrevented")
+
+    def test_forbidden(self) -> None:
+        assert hasattr(exc_module, "Forbidden")
+
+    def test_unauthorized(self) -> None:
+        assert hasattr(exc_module, "Unauthorized")
+
+    def test_bad_request(self) -> None:
+        assert hasattr(exc_module, "BadRequest")
+
+    def test_bad_gateway(self) -> None:
+        assert hasattr(exc_module, "BadGateway")
+
+    def test_invalid_credentials(self) -> None:
+        assert hasattr(exc_module, "InvalidCredentials")
+
+    def test_invalid_token(self) -> None:
+        assert hasattr(exc_module, "InvalidToken")
+
+    def test_server_error(self) -> None:
+        assert hasattr(exc_module, "ServerError")
+
+    def test_service_unavailable(self) -> None:
+        assert hasattr(exc_module, "ServiceUnavailable")
+
+    def test_improperly_configured(self) -> None:
+        assert hasattr(exc_module, "ImproperlyConfigured")
+
+    def test_operation_not_supported(self) -> None:
+        assert hasattr(exc_module, "OperationNotSupported")
+
+    def test_platform_not_found(self) -> None:
+        assert hasattr(exc_module, "PlatformNotFound")
+
+    def test_platform_not_unique(self) -> None:
+        assert hasattr(exc_module, "PlatformNotUnique")
+
+    def test_programming_error(self) -> None:
+        assert hasattr(exc_module, "ProgrammingError")
+
+    def test_schema_error(self) -> None:
+        assert hasattr(exc_module, "SchemaError")
+
+    def test_invalid_arguments(self) -> None:
+        assert hasattr(exc_module, "InvalidArguments")
+
+    def test_invalid_data_frame(self) -> None:
+        assert hasattr(exc_module, "InvalidDataFrame")
+
+    def test_bad_filter_arguments(self) -> None:
+        assert hasattr(exc_module, "BadFilterArguments")
+
+    def test_inconsistent_iamc_type(self) -> None:
+        assert hasattr(exc_module, "InconsistentIamcType")
+
+    def test_unknown_api_error(self) -> None:
+        assert hasattr(exc_module, "UnknownApiError")
+
+    def test_api_encumbered(self) -> None:
+        assert hasattr(exc_module, "ApiEncumbered")
+
+    def test_optimization_data_validation_error(self) -> None:
+        assert hasattr(exc_module, "OptimizationDataValidationError")
+
+    def test_optimization_item_usage_error(self) -> None:
+        assert hasattr(exc_module, "OptimizationItemUsageError")
+
+    def test_invalid_run_meta(self) -> None:
+        assert hasattr(exc_module, "InvalidRunMeta")
+
+    def test_run_meta_entry_not_found(self) -> None:
+        assert hasattr(exc_module, "RunMetaEntryNotFound")
+
+    def test_run_meta_entry_not_unique(self) -> None:
+        assert hasattr(exc_module, "RunMetaEntryNotUnique")
+
+    def test_run_meta_entry_deletion_prevented(self) -> None:
+        assert hasattr(exc_module, "RunMetaEntryDeletionPrevented")
+
+    def test_measurand_not_found(self) -> None:
+        assert hasattr(exc_module, "MeasurandNotFound")
+
+    def test_measurand_not_unique(self) -> None:
+        assert hasattr(exc_module, "MeasurandNotUnique")
+
+    def test_measurand_deletion_prevented(self) -> None:
+        assert hasattr(exc_module, "MeasurandDeletionPrevented")
+
+    def test_time_series_not_found(self) -> None:
+        assert hasattr(exc_module, "TimeSeriesNotFound")
+
+    def test_time_series_not_unique(self) -> None:
+        assert hasattr(exc_module, "TimeSeriesNotUnique")
+
+    def test_time_series_deletion_prevented(self) -> None:
+        assert hasattr(exc_module, "TimeSeriesDeletionPrevented")
+
+    def test_registry(self) -> None:
+        assert hasattr(exc_module, "registry")
+
+
+class TestExceptionHierarchy:
+    """Exceptions must form the expected ``Ixmp4Error`` hierarchy.
+    ``InvalidCredentials`` and ``InvalidToken`` are raised by scse-toolkit
+    and thus toolkit ServiceExceptions."""
+
+    def test_invalid_credentials(self) -> None:
+        assert issubclass(exc_module.InvalidCredentials, exc_module.ServiceException)
+
+    def test_invalid_token(self) -> None:
+        assert issubclass(exc_module.InvalidToken, exc_module.ServiceException)
+
+    def test_not_found_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.NotFound, exc_module.Ixmp4Error)
+
+    def test_not_unique_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.NotUnique, exc_module.Ixmp4Error)
+
+    def test_constraint_violated_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.ConstraintViolated, exc_module.Ixmp4Error)
+
+    def test_deletion_prevented_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.DeletionPrevented, exc_module.Ixmp4Error)
+
+    def test_server_error_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.ServerError, exc_module.Ixmp4Error)
+
+    def test_bad_gateway_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.BadGateway, exc_module.Ixmp4Error)
+
+    def test_service_unavailable_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.ServiceUnavailable, exc_module.Ixmp4Error)
+
+    def test_bad_request_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.BadRequest, exc_module.Ixmp4Error)
+
+    def test_forbidden_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.Forbidden, exc_module.Ixmp4Error)
+
+    def test_unauthorized_is_ixmp4_error(self) -> None:
+        assert issubclass(exc_module.Unauthorized, exc_module.Ixmp4Error)
+
+    def test_platform_not_found_is_not_found(self) -> None:
+        assert issubclass(exc_module.PlatformNotFound, exc_module.NotFound)
+
+    def test_invalid_data_frame_is_bad_request(self) -> None:
+        assert issubclass(exc_module.InvalidDataFrame, exc_module.BadRequest)
+
+    def test_invalid_arguments_is_bad_request(self) -> None:
+        assert issubclass(exc_module.InvalidArguments, exc_module.BadRequest)
+
+    def test_all_exceptions_are_base_exception(self) -> None:
+        for name in (
+            "Ixmp4Error",
+            "NotFound",
+            "NotUnique",
+            "ConstraintViolated",
+            "DeletionPrevented",
+            "ServerError",
+            "BadGateway",
+            "ServiceUnavailable",
+            "BadRequest",
+            "Unauthorized",
+            "Forbidden",
+            "ImproperlyConfigured",
+            "OperationNotSupported",
+            "SchemaError",
+            "InvalidArguments",
+            "InvalidDataFrame",
+            "BadFilterArguments",
+            "InconsistentIamcType",
+            "UnknownApiError",
+            "ApiEncumbered",
+            "OptimizationDataValidationError",
+            "OptimizationItemUsageError",
+        ):
+            cls = getattr(exc_module, name)
+            assert issubclass(cls, BaseException), (
+                f"{name} is not a subclass of BaseException"
+            )

--- a/tests/lib/test_ixmp4_namespace.py
+++ b/tests/lib/test_ixmp4_namespace.py
@@ -1,0 +1,178 @@
+"""Boundary tests for the top-level ``ixmp4`` package namespace.
+
+These tests assert that all public symbols intended for external consumers
+are importable directly from ``import ixmp4`` and that they are the correct
+types so that the package surface stays stable across refactors.
+"""
+
+import ixmp4
+
+
+class TestCoreFacadesExported:
+    """Facade classes must be importable from the top-level namespace."""
+
+    def test_platform(self) -> None:
+        assert hasattr(ixmp4, "Platform")
+
+    def test_run(self) -> None:
+        assert hasattr(ixmp4, "Run")
+
+    def test_model(self) -> None:
+        assert hasattr(ixmp4, "Model")
+
+    def test_scenario(self) -> None:
+        assert hasattr(ixmp4, "Scenario")
+
+    def test_region(self) -> None:
+        assert hasattr(ixmp4, "Region")
+
+    def test_unit(self) -> None:
+        assert hasattr(ixmp4, "Unit")
+
+
+class TestCoreFacadesAreClasses:
+    """Exported facade names must actually be classes."""
+
+    def test_platform_is_class(self) -> None:
+        assert isinstance(ixmp4.Platform, type)
+
+    def test_run_is_class(self) -> None:
+        assert isinstance(ixmp4.Run, type)
+
+    def test_model_is_class(self) -> None:
+        assert isinstance(ixmp4.Model, type)
+
+    def test_scenario_is_class(self) -> None:
+        assert isinstance(ixmp4.Scenario, type)
+
+    def test_region_is_class(self) -> None:
+        assert isinstance(ixmp4.Region, type)
+
+    def test_unit_is_class(self) -> None:
+        assert isinstance(ixmp4.Unit, type)
+
+
+class TestFacadeClasses:
+    """Facade object classes expose class-bound exceptions and filters."""
+
+    def test_platform_exceptions(self) -> None:
+        assert issubclass(ixmp4.Platform.NotFound, BaseException)
+        assert issubclass(ixmp4.Platform.NotUnique, BaseException)
+
+    def test_run_exceptions_and_filter(self) -> None:
+        assert issubclass(ixmp4.Run.NotFound, BaseException)
+        assert issubclass(ixmp4.Run.NotUnique, BaseException)
+        assert issubclass(ixmp4.Run.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.Run.Filter(), dict)
+
+    def test_model_exceptions_and_filter(self) -> None:
+        assert issubclass(ixmp4.Model.NotFound, BaseException)
+        assert issubclass(ixmp4.Model.NotUnique, BaseException)
+        assert issubclass(ixmp4.Model.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.Model.Filter(), dict)
+
+    def test_scenario_exceptions_and_filter(self) -> None:
+        assert issubclass(ixmp4.Scenario.NotFound, BaseException)
+        assert issubclass(ixmp4.Scenario.NotUnique, BaseException)
+        assert issubclass(ixmp4.Scenario.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.Scenario.Filter(), dict)
+
+    def test_region_exceptions_and_filter(self) -> None:
+        assert issubclass(ixmp4.Region.NotFound, BaseException)
+        assert issubclass(ixmp4.Region.NotUnique, BaseException)
+        assert issubclass(ixmp4.Region.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.Region.Filter(), dict)
+
+    def test_unit_exceptions_and_filter(self) -> None:
+        assert issubclass(ixmp4.Unit.NotFound, BaseException)
+        assert issubclass(ixmp4.Unit.NotUnique, BaseException)
+        assert issubclass(ixmp4.Unit.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.Unit.Filter(), dict)
+
+
+class TestSubNamespaces:
+    """Sub-module namespaces must be accessible from the top-level package."""
+
+    def test_iamc_namespace(self) -> None:
+        assert hasattr(ixmp4, "iamc")
+        assert hasattr(ixmp4.iamc, "PlatformIamcData")
+        assert hasattr(ixmp4.iamc, "RunIamcData")
+        assert hasattr(ixmp4.iamc, "DataPoint")
+        assert hasattr(ixmp4.iamc, "Variable")
+
+    def test_iamc_facade_classes(self) -> None:
+        assert issubclass(ixmp4.iamc.DataPoint.NotFound, BaseException)
+        assert issubclass(ixmp4.iamc.DataPoint.NotUnique, BaseException)
+        assert issubclass(ixmp4.iamc.DataPoint.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.iamc.DataPoint.Filter(), dict)
+
+        assert issubclass(ixmp4.iamc.Variable.NotFound, BaseException)
+        assert issubclass(ixmp4.iamc.Variable.NotUnique, BaseException)
+        assert issubclass(ixmp4.iamc.Variable.DeletionPrevented, BaseException)
+        assert isinstance(ixmp4.iamc.Variable.Filter(), dict)
+
+    def test_optimization_namespace(self) -> None:
+        assert hasattr(ixmp4, "optimization")
+        assert hasattr(ixmp4.optimization, "RunOptimizationData")
+        assert hasattr(ixmp4.optimization, "Equation")
+        assert hasattr(ixmp4.optimization, "IndexSet")
+        assert hasattr(ixmp4.optimization, "Parameter")
+        assert hasattr(ixmp4.optimization, "Scalar")
+        assert hasattr(ixmp4.optimization, "Table")
+        assert hasattr(ixmp4.optimization, "Variable")
+
+    def test_optimization_facade_classes(self) -> None:
+        for cls in (
+            ixmp4.optimization.Equation,
+            ixmp4.optimization.IndexSet,
+            ixmp4.optimization.Parameter,
+            ixmp4.optimization.Scalar,
+            ixmp4.optimization.Table,
+            ixmp4.optimization.Variable,
+        ):
+            assert issubclass(cls.NotFound, BaseException)
+            assert issubclass(cls.NotUnique, BaseException)
+            assert issubclass(cls.DeletionPrevented, BaseException)
+            assert isinstance(cls.Filter(), dict)
+
+
+class TestExceptions:
+    """The canonical exceptions must be importable from the top-level package."""
+
+    def test_ixmp4_error(self) -> None:
+        assert hasattr(ixmp4, "Ixmp4Error")
+        assert issubclass(ixmp4.Ixmp4Error, BaseException)
+
+    def test_not_found(self) -> None:
+        assert hasattr(ixmp4, "NotFound")
+        assert issubclass(ixmp4.NotFound, BaseException)
+
+    def test_not_unique(self) -> None:
+        assert hasattr(ixmp4, "NotUnique")
+        assert issubclass(ixmp4.NotUnique, BaseException)
+
+    def test_inconsistent_iamc_type(self) -> None:
+        assert hasattr(ixmp4, "InconsistentIamcType")
+        assert issubclass(ixmp4.InconsistentIamcType, BaseException)
+
+    def test_invalid_token(self) -> None:
+        assert hasattr(ixmp4, "InvalidToken")
+        assert issubclass(ixmp4.InvalidToken, BaseException)
+
+    def test_invalid_credentials(self) -> None:
+        assert hasattr(ixmp4, "InvalidCredentials")
+        assert issubclass(ixmp4.InvalidCredentials, BaseException)
+
+
+class TestVersionMetadata:
+    """Version strings must be accessible from the top-level package."""
+
+    def test_version_string_present(self) -> None:
+        assert hasattr(ixmp4, "__version__")
+        assert isinstance(ixmp4.__version__, str)
+        assert ixmp4.__version__  # non-empty
+
+    def test_version_tuple_present(self) -> None:
+        assert hasattr(ixmp4, "__version_tuple__")
+        assert isinstance(ixmp4.__version_tuple__, tuple)
+        assert len(ixmp4.__version_tuple__) >= 3

--- a/tests/lib/test_pyam.py
+++ b/tests/lib/test_pyam.py
@@ -1,0 +1,146 @@
+"""Boundary tests for ixmp4 -> pyam integration.
+
+These tests verify the ixmp4-side contracts consumed by pyam.
+"""
+
+import ixmp4
+
+
+class TestPyam_3_3_1:
+    def test_platform_accessible(self) -> None:
+        assert hasattr(ixmp4, "Platform")
+        assert isinstance(ixmp4.Platform, type)
+
+    def test_run_accessible(self) -> None:
+        assert hasattr(ixmp4, "Run")
+        assert isinstance(ixmp4.Run, type)
+
+    def test_importable_from_core_iamc(self) -> None:
+        from ixmp4.core.iamc import DataPoint
+
+        assert isinstance(DataPoint, type)
+
+    def test_same_object_as_datapoint_module(self) -> None:
+        from ixmp4.core.iamc import DataPoint
+        from ixmp4.core.iamc.datapoint import DataPoint as DataPointDirect
+
+        assert DataPoint is DataPointDirect
+
+    def test_datapoint_has_type_enum(self) -> None:
+        from ixmp4.core.iamc import DataPoint
+
+        assert hasattr(DataPoint, "Type")
+
+    def test_datapoint_has_not_found(self) -> None:
+        from ixmp4.core.iamc import DataPoint
+
+        assert issubclass(DataPoint.NotFound, BaseException)
+
+    def test_datapoint_has_filter(self) -> None:
+        from ixmp4.core.iamc import DataPoint
+
+        assert isinstance(DataPoint.Filter(), dict)
+
+    def test_region_importable(self) -> None:
+        from ixmp4.core.region import Region
+
+        assert isinstance(Region, type)
+
+    def test_region_same_as_top_level(self) -> None:
+        from ixmp4.core.region import Region
+
+        assert ixmp4.Region is Region
+
+    def test_region_has_not_found(self) -> None:
+        from ixmp4.core.region import Region
+
+        assert issubclass(Region.NotFound, BaseException)
+
+    def test_region_has_filter(self) -> None:
+        from ixmp4.core.region import Region
+
+        assert isinstance(Region.Filter(), dict)
+
+    def test_unit_importable(self) -> None:
+        from ixmp4.core.unit import Unit
+
+        assert isinstance(Unit, type)
+
+    def test_unit_same_as_top_level(self) -> None:
+        from ixmp4.core.unit import Unit
+
+        assert ixmp4.Unit is Unit
+
+    def test_unit_has_not_found(self) -> None:
+        from ixmp4.core.unit import Unit
+
+        assert issubclass(Unit.NotFound, BaseException)
+
+    def test_unit_has_filter(self) -> None:
+        from ixmp4.core.unit import Unit
+
+        assert isinstance(Unit.Filter(), dict)
+
+    def test_facade_datapoint_filter_importable(self) -> None:
+        from ixmp4.data.iamc.datapoint.filter import FacadeDataPointFilter
+
+        assert isinstance(FacadeDataPointFilter(), dict)
+
+    def test_facade_run_filter_importable(self) -> None:
+        from ixmp4.data.run.filter import FacadeRunFilter
+
+        assert isinstance(FacadeRunFilter(), dict)
+
+    def test_facade_run_filter_accepts_default_only(self) -> None:
+        from ixmp4.data.run.filter import FacadeRunFilter
+
+        f = FacadeRunFilter(default_only=True)
+        assert isinstance(f, dict)
+        assert f["default_only"] is True
+
+    def test_facade_run_meta_entry_filter_importable(self) -> None:
+        from ixmp4.data.meta.filter import FacadeRunMetaEntryFilter
+
+        assert isinstance(FacadeRunMetaEntryFilter(), dict)
+
+    def test_facade_datapoint_filter_same_as_datapoint_class_filter(self) -> None:
+        from ixmp4.core.iamc.datapoint import DataPoint
+        from ixmp4.data.iamc.datapoint.filter import FacadeDataPointFilter
+
+        assert DataPoint.Filter is FacadeDataPointFilter
+
+    def test_facade_run_filter_same_as_run_class_filter(self) -> None:
+        from ixmp4.data.run.filter import FacadeRunFilter
+
+        assert ixmp4.Run.Filter is FacadeRunFilter
+
+    def test_tabulate_manager_platforms_importable(self) -> None:
+        from ixmp4.cli.platforms import tabulate_manager_platforms
+
+        assert callable(tabulate_manager_platforms)
+
+    def test_tabulate_manager_platforms_accepts_platforms_argument(self) -> None:
+        import inspect
+
+        from ixmp4.cli.platforms import tabulate_manager_platforms
+
+        params = inspect.signature(tabulate_manager_platforms).parameters
+        assert "platforms" in params
+
+    def test_settings_importable(self) -> None:
+        from ixmp4.conf.settings import Settings
+
+        assert isinstance(Settings, type)
+
+    def test_settings_has_manager_url(self) -> None:
+        from ixmp4.conf.settings import Settings
+
+        s = Settings()
+        assert hasattr(s, "manager_url")
+        assert s.manager_url is not None
+
+    def test_settings_has_get_manager_platforms(self) -> None:
+        """pyam.iiasa calls settings.get_manager_platforms()."""
+        from ixmp4.conf.settings import Settings
+
+        assert callable(getattr(Settings, "get_manager_platforms", None))


### PR DESCRIPTION
Adds another test suite which focuses on testing the export structure that is considered stable.:
- lib/test_conf.py
  conf module export tests (settings) 
- lib/test_exceptions.py 
  exceptions and hierarchy 
- lib/test_ixmp4_namespace.py
  top level namespace   
- lib/test_pyam.py  
  pyam specific tests. 

Also adds class.Filter attributes to all facade classes with associated facade filters for easier use.
