### PR TITLE
Add Migration Version Check for the `DirectTransport` class

### DIFF
--- a/ixmp4/cli/alembic.py
+++ b/ixmp4/cli/alembic.py
@@ -1,29 +1,15 @@
-from pathlib import Path
-
 import typer
-from toolkit.db.alembic import AlembicCli, AlembicController
+from toolkit.db.alembic import AlembicCli
 from typing_extensions import Annotated
 
 from ixmp4.base_exceptions import PlatformNotFound, ServiceException
 from ixmp4.conf.platforms import PlatformConnectionInfo, resolve_dsn_env_tokens
 from ixmp4.conf.settings import Settings
-from ixmp4.db import __file__ as db_module_dir
-from ixmp4.db.models import get_metadata
-
-migration_script_directory = (Path(db_module_dir).parent / "migrations").absolute()
+from ixmp4.db import get_alembic_controller
 
 app = AlembicCli(
     help="Manages alembic migrations on selected platforms via subcommands."
 )
-
-
-def get_alembic_controller(dsn: str) -> AlembicController:
-    dsn = resolve_dsn_env_tokens(dsn)
-    return AlembicController(
-        dsn,
-        str(migration_script_directory),
-        f"{get_metadata.__module__}:{get_metadata.__name__}",
-    )
 
 
 def get_connection_info(settings: Settings, name: str) -> PlatformConnectionInfo:
@@ -123,6 +109,7 @@ def alembic(
             "'--platform/-p', '--toml', '--manager'?"
         )
 
-    controllers = [get_alembic_controller(platform.dsn) for platform in platforms]
+    dsns = [resolve_dsn_env_tokens(platform.dsn) for platform in platforms]
+    controllers = [get_alembic_controller(dsn) for dsn in dsns]
     ctx.ensure_object(dict)
     ctx.obj["controllers"] = controllers

--- a/ixmp4/cli/platforms.py
+++ b/ixmp4/cli/platforms.py
@@ -17,12 +17,7 @@ from ixmp4.conf.settings import Settings
 from ixmp4.core.exceptions import PlatformNotFound
 from ixmp4.core.platform import Platform
 from ixmp4.data.generator import MockDataGenerator
-from ixmp4.db import __file__ as db_module_dir
-
-from .alembic import get_alembic_controller
-
-migration_script_directory = (Path(db_module_dir).parent / "migrations").absolute()
-
+from ixmp4.db import get_alembic_controller
 
 app = typer.Typer(help="Manages platforms via subcommands.")
 console = Console()

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -73,6 +73,7 @@ class Settings(BaseSettings):
     )
     storage_directory: Path = Path("~/.local/share/ixmp4/")
     manager_url: HttpUrl = HttpUrl("https://api.manager.ece.iiasa.ac.at/v1")
+    check_alembic_version: bool = True
 
     server: ServerSettings = ServerSettings()
     client: ClientSettings = ClientSettings()

--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -183,7 +183,10 @@ class Platform(object):
                 auth=self.settings.get_client_auth(cred_dict),
             )
         else:
-            return DirectTransport.from_dsn(ci.dsn)
+            return DirectTransport.from_dsn(
+                ci.dsn,
+                check_alembic_version=self.settings.check_alembic_version,
+            )
 
     def get_toml_platform_ci(self, name: str) -> PlatformConnectionInfo | None:
         toml = self.settings.get_toml_platforms()

--- a/ixmp4/db/__init__.py
+++ b/ixmp4/db/__init__.py
@@ -61,3 +61,22 @@ test.sqlite3' to revision 'head'.
 Refer to the :doc:`cli documentation </usage/cli>` for all alembic cli commands.
 
 """
+
+from pathlib import Path
+
+from toolkit.db.alembic import AlembicController
+
+from .models import get_metadata
+
+migration_script_directory = (Path(__file__).parent / "migrations").absolute()
+
+
+def get_alembic_controller(dsn: str) -> AlembicController:
+    """Returns a :class:`~toolkit.db.alembic.AlembicController` configured
+    with ixmp4's script directory and model metadata.
+    """
+    return AlembicController(
+        dsn,
+        str(migration_script_directory),
+        f"{get_metadata.__module__}:{get_metadata.__name__}",
+    )

--- a/ixmp4/server/v1/__init__.py
+++ b/ixmp4/server/v1/__init__.py
@@ -122,9 +122,19 @@ async def get_transport(
     dsn = resolve_dsn_env_tokens(platform.dsn)
     async with yield_session(dsn) as session:
         if request.auth is not None:
-            yield AuthorizedTransport(session, request.auth, platform)
+            yield AuthorizedTransport(
+                session,
+                request.auth,
+                platform,
+                check_alembic_version=False,
+                ping_database=False,
+            )
         else:
-            yield DirectTransport(session)
+            yield DirectTransport(
+                session,
+                check_alembic_version=False,
+                ping_database=False,
+            )
 
 
 async def get_backend(transport: DirectTransport) -> AsyncGenerator[Backend, None]:

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from email.utils import parsedate_to_datetime
 from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -15,11 +16,14 @@ from sqlalchemy import orm
 from toolkit.auth.context import AuthorizationContext, PlatformProtocol
 from toolkit.client.auth import Auth, ManagerAuth, SelfSignedAuth
 from toolkit.client.base import ServiceClient
+from toolkit.db.alembic import AlembicController
 
 from ixmp4.base_exceptions import ImproperlyConfigured
 from ixmp4.conf.settings import ClientSettings, Settings
 from ixmp4.core.exceptions import OperationNotSupported, ProgrammingError
 from ixmp4.core.exceptions import registry as exception_registry
+from ixmp4.db import __file__ as db_module_dir
+from ixmp4.db.models import get_metadata
 
 from ._version import __version__
 
@@ -49,8 +53,15 @@ Session = orm.sessionmaker(autocommit=False, autoflush=False)
 class DirectTransport(Transport):
     session: orm.Session
 
-    def __init__(self, session: orm.Session):
+    def __init__(
+        self,
+        session: orm.Session,
+        check_alembic_version: bool = False,
+    ):
         self.session = session
+
+        if check_alembic_version:
+            self.check_alembic_version()
 
         if (url := self.get_database_url()) is not None:
             logger.debug(f"Connected to IXMP4 database at '{url.render_as_string()}'.")
@@ -112,6 +123,81 @@ class DirectTransport(Transport):
         assert self.session.bind is not None
         self.session.bind.engine.dispose()
 
+    def get_alembic_controller(self, dsn: str) -> AlembicController:
+        migration_script_directory = (
+            Path(db_module_dir).parent / "migrations"
+        ).absolute()
+
+        return AlembicController(
+            dsn,
+            str(migration_script_directory),
+            f"{get_metadata.__module__}:{get_metadata.__name__}",
+        )
+
+    def check_alembic_version(self) -> None:
+        assert self.session.bind is not None
+        engine = self.session.bind.engine
+        inspector = sa.inspect(engine)
+        controller = self.get_alembic_controller(engine.url.render_as_string())
+
+        if not inspector.has_table("alembic_version"):
+            raise ImproperlyConfigured(
+                "Database schema version check failed because the table "
+                "'alembic_version' does not exist. Run migrations or disable the "
+                "check via check_alembic_version=False/"
+                "IXMP4_CHECK_ALEMBIC_VERSION=false."
+            )
+
+        current_revision = controller.get_database_revision()
+        head_revision = controller.get_head_revision()
+        if head_revision is None:
+            raise ImproperlyConfigured(
+                "Could not determine the expected alembic "
+                "revision from migration scripts."
+            )
+
+        if isinstance(head_revision, tuple):
+            if len(head_revision) == 1:
+                head_revision = head_revision[0]
+            raise ImproperlyConfigured(
+                "Could not determine a unique expected alembic revision because "
+                f"multiple heads were found: {head_revision}."
+            )
+
+        if current_revision is None:
+            raise ImproperlyConfigured(
+                "Database schema version check failed because no alembic revision "
+                "entry was found in 'alembic_version'. Run migrations or disable "
+                "the check via check_alembic_version=False/"
+                "IXMP4_CHECK_ALEMBIC_VERSION=false."
+            )
+
+        if current_revision != head_revision:
+            revision_order = [script.revision for script in controller.list_revisions()]
+            is_previous_migration = (
+                current_revision in revision_order
+                and head_revision in revision_order
+                and revision_order.index(current_revision)
+                > revision_order.index(head_revision)
+            )
+
+            if is_previous_migration:
+                raise ImproperlyConfigured(
+                    "Database schema version mismatch. "
+                    f"Expected revision '{head_revision}' but found older "
+                    f"revision '{current_revision}'. Upgrade the database to the "
+                    "current ixmp4 migration head, or downgrade ixmp4 to a version "
+                    "compatible with this database revision."
+                )
+
+            raise ImproperlyConfigured(
+                "Database schema version mismatch. "
+                f"Expected revision '{head_revision}' but found "
+                f"'{current_revision}'. Upgrade your ixmp4 installation or disable the "
+                "check via check_alembic_version=False/"
+                "IXMP4_CHECK_ALEMBIC_VERSION=false."
+            )
+
     def check_versioning_compatiblity(self) -> None:
         assert self.session.bind is not None
         if self.session.bind.engine.dialect.name != "postgresql":
@@ -133,9 +219,11 @@ class AuthorizedTransport(DirectTransport):
         session: orm.Session,
         auth_ctx: AuthorizationContext,
         platform: PlatformProtocol,
+        check_alembic_version: bool = False,
     ):
         super().__init__(
             session,
+            check_alembic_version=check_alembic_version,
         )
         self.auth_ctx = auth_ctx
         self.platform = platform

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -5,7 +5,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from email.utils import parsedate_to_datetime
 from functools import lru_cache
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -16,15 +15,13 @@ from sqlalchemy import orm
 from toolkit.auth.context import AuthorizationContext, PlatformProtocol
 from toolkit.client.auth import Auth, ManagerAuth, SelfSignedAuth
 from toolkit.client.base import ServiceClient
-from toolkit.db.alembic import AlembicController
 
 from ixmp4.base_exceptions import ImproperlyConfigured
 from ixmp4.conf.platforms import resolve_dsn_env_tokens
 from ixmp4.conf.settings import ClientSettings, Settings
 from ixmp4.core.exceptions import OperationNotSupported, ProgrammingError
 from ixmp4.core.exceptions import registry as exception_registry
-from ixmp4.db import __file__ as db_module_dir
-from ixmp4.db.models import get_metadata
+from ixmp4.db import get_alembic_controller
 
 from ._version import __version__
 
@@ -129,22 +126,11 @@ class DirectTransport(Transport):
         assert self.session.bind is not None
         self.session.bind.engine.dispose()
 
-    def get_alembic_controller(self, dsn: str) -> AlembicController:
-        migration_script_directory = (
-            Path(db_module_dir).parent / "migrations"
-        ).absolute()
-
-        return AlembicController(
-            dsn,
-            str(migration_script_directory),
-            f"{get_metadata.__module__}:{get_metadata.__name__}",
-        )
-
     def check_alembic_version(self) -> None:
         assert self.session.bind is not None
         engine = self.session.bind.engine
         inspector = sa.inspect(engine)
-        controller = self.get_alembic_controller(engine.url.render_as_string())
+        controller = get_alembic_controller(engine.url.render_as_string())
 
         if not inspector.has_table("alembic_version"):
             raise ImproperlyConfigured(

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -58,7 +58,7 @@ class DirectTransport(Transport):
         self,
         session: orm.Session,
         ping_database: bool = True,
-        check_alembic_version: bool = False,
+        check_alembic_version: bool = True,
     ):
         self.session = session
         if ping_database:
@@ -226,7 +226,7 @@ class AuthorizedTransport(DirectTransport):
         auth_ctx: AuthorizationContext,
         platform: PlatformProtocol,
         ping_database: bool = True,
-        check_alembic_version: bool = False,
+        check_alembic_version: bool = True,
     ):
         super().__init__(
             session,
@@ -235,7 +235,10 @@ class AuthorizedTransport(DirectTransport):
         )
         self.auth_ctx = auth_ctx
         self.platform = platform
-        self.unauthorized_transport = DirectTransport(session, ping_database=False)
+        # turn off extra checks so they are not run twice
+        self.unauthorized_transport = DirectTransport(
+            session, ping_database=False, check_alembic_version=False
+        )
 
     def __str__(self) -> str:
         return (

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -124,7 +124,7 @@ def get_direct_transport(
     platform_info: PlatformProtocol | None,
 ) -> DirectTransport:
     if auth_ctx is None:
-        return DirectTransport.from_dsn(dsn)
+        return DirectTransport.from_dsn(dsn, check_alembic_version=False)
     else:
         if platform_info is None:
             raise ValueError(

--- a/tests/backends.py
+++ b/tests/backends.py
@@ -131,7 +131,7 @@ def get_direct_transport(
                 "Provide the `platform_info` fixture to test authorized transports."
             )
         return AuthorizedTransport.from_dsn(
-            dsn, auth_ctx=auth_ctx, platform=platform_info
+            dsn, auth_ctx=auth_ctx, platform=platform_info, check_alembic_version=False
         )
 
 

--- a/tests/cli/test_alembic.py
+++ b/tests/cli/test_alembic.py
@@ -8,9 +8,8 @@ from toolkit.manager.mock import MockManagerClient
 from typer.testing import CliRunner
 
 from ixmp4.cli import app
-from ixmp4.cli.alembic import collect_platforms, get_alembic_controller
+from ixmp4.cli.alembic import collect_platforms
 from ixmp4.conf.settings import Settings
-from ixmp4.core.exceptions import ImproperlyConfigured
 
 
 @pytest.fixture(scope="function")
@@ -96,32 +95,3 @@ class TestAlembicTargets:
         assert len(manager_platforms) == 3
         assert manager_platforms[0].slug == "dev-public"
         assert "{env:IXMP4_DIR}" in manager_platforms[0].dsn
-
-
-def test_get_alembic_controller_resolves_dsn_env_tokens(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured_dsn: str | None = None
-
-    class FakeAlembicController:
-        def __init__(self, dsn: str, *_args: object, **_kwargs: object) -> None:
-            nonlocal captured_dsn
-            captured_dsn = dsn
-
-    monkeypatch.setattr("ixmp4.cli.alembic.AlembicController", FakeAlembicController)
-    monkeypatch.setenv("IXMP4_DB_PASSWORD", "pw")
-
-    get_alembic_controller("postgresql://u:{env:IXMP4_DB_PASSWORD}@db/test")
-    assert captured_dsn == "postgresql://u:pw@db/test"
-
-
-def test_get_alembic_controller_raises_for_missing_dsn_env_tokens(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("IXMP4_DB_PASSWORD", raising=False)
-
-    with pytest.raises(
-        ImproperlyConfigured,
-        match=r"Cannot resolve DSN environment variable placeholder\(s\).",
-    ):
-        get_alembic_controller("postgresql://u:{env:IXMP4_DB_PASSWORD}@db/test")

--- a/tests/conf/test_manager.py
+++ b/tests/conf/test_manager.py
@@ -30,7 +30,9 @@ class TestManagerPlatforms:
         assert "{env:IXMP4_DIR}" in cached_platform.dsn
 
         # Env var substitution happens when creating the engine
-        transport = DirectTransport.from_dsn(platform.dsn, ping_database=False)
+        transport = DirectTransport.from_dsn(
+            platform.dsn, ping_database=False, check_alembic_version=False
+        )
         assert transport is not None
 
     def test_get_platform_returns_unresolved_dsn_for_missing_env_tokens(

--- a/tests/conf/test_settings.py
+++ b/tests/conf/test_settings.py
@@ -66,6 +66,7 @@ class TestSettings:
 
         expected_database_path = expected_database_dir / "test.sqlite3"
         assert settings.get_database_path("test") == expected_database_path
+        assert settings.check_alembic_version is True
 
         manager_platforms = settings.get_manager_platforms()
         assert manager_platforms.manager_client.auth is None

--- a/tests/conf/test_toml.py
+++ b/tests/conf/test_toml.py
@@ -94,7 +94,9 @@ class TestTomlPlatforms(TomlTest):
         assert "{env:IXMP4_TEST_PASSWORD}" in platforms_toml.read_text()
 
         # Env var substitution happens when creating the engine
-        transport = DirectTransport.from_dsn(platform.dsn, ping_database=False)
+        transport = DirectTransport.from_dsn(
+            platform.dsn, ping_database=False, check_alembic_version=False
+        )
         assert transport is not None
 
     def test_get_platform_returns_unresolved_dsn_for_missing_env_tokens(

--- a/tests/db/test_version_check.py
+++ b/tests/db/test_version_check.py
@@ -1,0 +1,195 @@
+"""Integration tests for DirectTransport.check_alembic_version()."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+from ixmp4.base_exceptions import ImproperlyConfigured
+from ixmp4.db import get_alembic_controller
+from ixmp4.transport import DirectTransport
+
+
+@pytest.fixture
+def engine(tmp_path: Path) -> sa.Engine:
+    """File-based SQLite engine backed by a per-test temp directory."""
+    return sa.create_engine(
+        f"sqlite:///{tmp_path / 'test.sqlite3'}",
+        poolclass=sa.StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+
+@pytest.fixture
+def transport(engine: sa.Engine) -> DirectTransport:
+    """DirectTransport wrapping *engine* with all start-up checks disabled."""
+    session = orm.sessionmaker(autocommit=False, autoflush=False)(bind=engine)
+    return DirectTransport(session, ping_database=False, check_alembic_version=False)
+
+
+@pytest.fixture
+def version_table(engine: sa.Engine) -> None:
+    """Create the bare ``alembic_version`` table without running any migration."""
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE alembic_version "
+                "(version_num VARCHAR(32) NOT NULL, PRIMARY KEY (version_num))"
+            )
+        )
+        conn.commit()
+
+
+@pytest.fixture(scope="module")
+def head_revision() -> str:
+    """Current head revision hash from the real migration scripts."""
+    ctrl = get_alembic_controller("sqlite:///:memory:")
+    head = ctrl.get_head_revision()
+    assert isinstance(head, str), "Expected a single head revision"
+    return head
+
+
+@pytest.fixture(scope="module")
+def oldest_revision() -> str:
+    """Oldest known revision hash from the real migration scripts."""
+    ctrl = get_alembic_controller("sqlite:///:memory:")
+    # walk_revisions yields newest-first; last entry is the oldest
+    revisions = [s.revision for s in ctrl.list_revisions()]
+    return revisions[-1]
+
+
+def _insert_revision(engine: sa.Engine, revision: str) -> None:
+    """Insert *revision* into an existing ``alembic_version`` table."""
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text("INSERT INTO alembic_version VALUES (:rev)"),
+            {"rev": revision},
+        )
+        conn.commit()
+
+
+class TestCheckAlembicVersion:
+    def test_missing_alembic_version_table(self, transport: DirectTransport) -> None:
+        """Raises when the ``alembic_version`` table does not exist at all."""
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="'alembic_version' does not exist",
+        ):
+            transport.check_alembic_version()
+
+    def test_head_revision_is_none(
+        self, transport: DirectTransport, engine: sa.Engine, version_table: None
+    ) -> None:
+        """Raises when ``get_head_revision`` returns ``None``."""
+        _insert_revision(engine, "abc123abc123")
+
+        mock_ctrl = mock.Mock()
+        mock_ctrl.get_database_revision.return_value = "abc123abc123"
+        mock_ctrl.get_head_revision.return_value = None
+
+        with mock.patch(
+            "ixmp4.transport.get_alembic_controller", return_value=mock_ctrl
+        ):
+            with pytest.raises(
+                ImproperlyConfigured,
+                match="Could not determine the expected alembic revision",
+            ):
+                transport.check_alembic_version()
+
+    def test_head_revision_multiple_heads(
+        self, transport: DirectTransport, engine: sa.Engine, version_table: None
+    ) -> None:
+        """Raises when ``get_head_revision`` returns a tuple with more than one entry."""
+        _insert_revision(engine, "abc123abc123")
+
+        mock_ctrl = mock.Mock()
+        mock_ctrl.get_database_revision.return_value = "abc123abc123"
+        mock_ctrl.get_head_revision.return_value = ("head_a1b2c3d4", "head_e5f6a7b8")
+
+        with mock.patch(
+            "ixmp4.transport.get_alembic_controller", return_value=mock_ctrl
+        ):
+            with pytest.raises(
+                ImproperlyConfigured,
+                match="multiple heads were found",
+            ):
+                transport.check_alembic_version()
+
+    def test_head_revision_single_element_tuple(
+        self, transport: DirectTransport, engine: sa.Engine, version_table: None
+    ) -> None:
+        """Raises even when ``get_head_revision`` returns a one-element tuple.
+
+        A one-element tuple is still treated as an error; the single revision is
+        unpacked into the error message but the exception is still raised.
+        """
+        _insert_revision(engine, "abc123abc123")
+
+        mock_ctrl = mock.Mock()
+        mock_ctrl.get_database_revision.return_value = "abc123abc123"
+        mock_ctrl.get_head_revision.return_value = ("head_a1b2c3d4",)
+
+        with mock.patch(
+            "ixmp4.transport.get_alembic_controller", return_value=mock_ctrl
+        ):
+            with pytest.raises(
+                ImproperlyConfigured,
+                match="multiple heads were found",
+            ):
+                transport.check_alembic_version()
+
+    def test_empty_alembic_version_table(
+        self, transport: DirectTransport, version_table: None
+    ) -> None:
+        """Raises when the ``alembic_version`` table exists but contains no rows."""
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="no alembic revision entry was found",
+        ):
+            transport.check_alembic_version()
+
+    def test_outdated_known_revision(
+        self,
+        transport: DirectTransport,
+        engine: sa.Engine,
+        version_table: None,
+        oldest_revision: str,
+    ) -> None:
+        """Raises with an 'older revision' message when the DB lags behind head."""
+        _insert_revision(engine, oldest_revision)
+
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="found older revision",
+        ):
+            transport.check_alembic_version()
+
+    def test_unknown_revision(
+        self, transport: DirectTransport, engine: sa.Engine, version_table: None
+    ) -> None:
+        """Raises a generic mismatch message for a completely unknown revision.
+
+        This covers the case where the database was created by a *newer* ixmp4
+        version and the current installation does not know that revision.
+        """
+        _insert_revision(engine, "deadbeefcafe1234")
+
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="Upgrade your ixmp4 installation",
+        ):
+            transport.check_alembic_version()
+
+    def test_valid_head_revision_passes(
+        self,
+        transport: DirectTransport,
+        engine: sa.Engine,
+        version_table: None,
+        head_revision: str,
+    ) -> None:
+        """No exception is raised when the DB revision matches head."""
+        _insert_revision(engine, head_revision)
+
+        transport.check_alembic_version()  # must not raise

--- a/tests/db/test_version_check.py
+++ b/tests/db/test_version_check.py
@@ -118,29 +118,6 @@ class TestCheckAlembicVersion:
             ):
                 transport.check_alembic_version()
 
-    def test_head_revision_single_element_tuple(
-        self, transport: DirectTransport, engine: sa.Engine, version_table: None
-    ) -> None:
-        """Raises even when ``get_head_revision`` returns a one-element tuple.
-
-        A one-element tuple is still treated as an error; the single revision is
-        unpacked into the error message but the exception is still raised.
-        """
-        _insert_revision(engine, "abc123abc123")
-
-        mock_ctrl = mock.Mock()
-        mock_ctrl.get_database_revision.return_value = "abc123abc123"
-        mock_ctrl.get_head_revision.return_value = ("head_a1b2c3d4",)
-
-        with mock.patch(
-            "ixmp4.transport.get_alembic_controller", return_value=mock_ctrl
-        ):
-            with pytest.raises(
-                ImproperlyConfigured,
-                match="multiple heads were found",
-            ):
-                transport.check_alembic_version()
-
     def test_empty_alembic_version_table(
         self, transport: DirectTransport, version_table: None
     ) -> None:

--- a/tests/db/test_version_check.py
+++ b/tests/db/test_version_check.py
@@ -101,7 +101,8 @@ class TestCheckAlembicVersion:
     def test_head_revision_multiple_heads(
         self, transport: DirectTransport, engine: sa.Engine, version_table: None
     ) -> None:
-        """Raises when ``get_head_revision`` returns a tuple with more than one entry."""
+        """Raises when ``get_head_revision`` returns a tuple with more than one
+        entry."""
         _insert_revision(engine, "abc123abc123")
 
         mock_ctrl = mock.Mock()

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,0 +1,258 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+import pytest
+
+import ixmp4.core.platform as platform_module
+from ixmp4.base_exceptions import PlatformNotFound
+from ixmp4.conf.settings import Settings
+from ixmp4.core.platform import Platform
+from ixmp4.transport import Transport
+
+
+class DummyTransport(Transport):
+    def check_versioning_compatiblity(self) -> None:
+        return None
+
+
+def patch_platform_dependencies(monkeypatch: pytest.MonkeyPatch) -> type:
+    class FakeBackend:
+        def __init__(self, transport: object):
+            self.transport = transport
+
+    monkeypatch.setattr(platform_module, "Backend", FakeBackend)
+
+    for attr in (
+        "RunServiceFacade",
+        "PlatformIamcData",
+        "ModelServiceFacade",
+        "RegionServiceFacade",
+        "ScenarioServiceFacade",
+        "UnitServiceFacade",
+        "PlatformRunMetaFacade",
+    ):
+        monkeypatch.setattr(
+            platform_module,
+            attr,
+            lambda backend, attr=attr: SimpleNamespace(name=attr, backend=backend),
+        )
+
+    return FakeBackend
+
+
+def test_platform_init_with_name_uses_init_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    backend = FakeBackend(mock.sentinel.transport)
+
+    monkeypatch.setattr(
+        Platform,
+        "init_backend",
+        lambda self, name: backend,
+    )
+
+    platform = Platform("demo", settings=settings)
+
+    assert platform.backend is backend
+    assert platform.settings is settings
+
+
+def test_platform_init_with_transport_wraps_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    transport = DummyTransport()
+
+    platform = Platform(transport, settings=settings)
+
+    assert isinstance(platform.backend, FakeBackend)
+    assert platform.backend.transport is transport
+
+
+def test_platform_init_with_backend_uses_backend_as_is(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    backend = FakeBackend(mock.sentinel.transport)
+
+    platform = Platform(backend, settings=settings)
+
+    assert platform.backend is backend
+
+
+def test_platform_init_with_invalid_input_raises_type_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+
+    with pytest.raises(TypeError, match="missing required argument 'name'"):
+        Platform(123, settings=settings)  # type: ignore[arg-type]
+
+
+def test_platform_init_backend_prefers_toml_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    platform = Platform(FakeBackend(mock.sentinel.transport), settings=settings)
+
+    ci_toml = SimpleNamespace(dsn="sqlite:///:memory:")
+    monkeypatch.setattr(platform, "get_toml_platform_ci", lambda name: ci_toml)
+
+    def manager_should_not_be_called(name: str) -> None:
+        raise AssertionError("manager lookup should not be called")
+
+    monkeypatch.setattr(
+        platform,
+        "get_manager_platform_ci",
+        manager_should_not_be_called,
+    )
+    monkeypatch.setattr(
+        platform,
+        "get_transport",
+        lambda ci: mock.sentinel.transport,
+    )
+
+    backend = platform.init_backend("demo")
+
+    assert isinstance(backend, FakeBackend)
+    assert backend.transport is mock.sentinel.transport
+
+
+def test_platform_init_backend_falls_back_to_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    platform = Platform(FakeBackend(mock.sentinel.transport), settings=settings)
+
+    ci_manager = SimpleNamespace(dsn="sqlite:///:memory:")
+    monkeypatch.setattr(platform, "get_toml_platform_ci", lambda name: None)
+    monkeypatch.setattr(platform, "get_manager_platform_ci", lambda name: ci_manager)
+    monkeypatch.setattr(
+        platform,
+        "get_transport",
+        lambda ci: mock.sentinel.transport,
+    )
+
+    backend = platform.init_backend("demo")
+
+    assert isinstance(backend, FakeBackend)
+    assert backend.transport is mock.sentinel.transport
+
+
+def test_platform_init_backend_raises_when_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    platform = Platform(FakeBackend(mock.sentinel.transport), settings=settings)
+
+    monkeypatch.setattr(platform, "get_toml_platform_ci", lambda name: None)
+    monkeypatch.setattr(platform, "get_manager_platform_ci", lambda name: None)
+
+    with pytest.raises(PlatformNotFound, match="Platform 'demo' was not found"):
+        platform.init_backend("demo")
+
+
+def test_platform_get_transport_uses_httpx_for_http_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    platform = Platform(FakeBackend(mock.sentinel.transport), settings=settings)
+
+    credentials = SimpleNamespace()
+    platform.settings = cast(
+        Settings,
+        SimpleNamespace(
+            client=mock.sentinel.client,
+            check_alembic_version=True,
+            get_credentials=lambda: SimpleNamespace(get=lambda key: credentials),
+            get_client_auth=lambda cred: mock.sentinel.auth,
+        ),
+    )
+
+    calls: list[dict[str, object]] = []
+
+    def fake_from_url(
+        url: str,
+        settings: object,
+        auth: object,
+    ) -> object:
+        calls.append({"url": url, "settings": settings, "auth": auth})
+        return mock.sentinel.transport
+
+    monkeypatch.setattr("ixmp4.core.platform.HttpxTransport.from_url", fake_from_url)
+
+    result = platform.get_transport(
+        SimpleNamespace(dsn="https://platform.example/v1"),
+        http_credentials="demo",
+    )
+
+    assert result is mock.sentinel.transport
+    assert calls == [
+        {
+            "url": "https://platform.example/v1",
+            "settings": mock.sentinel.client,
+            "auth": mock.sentinel.auth,
+        }
+    ]
+
+
+def test_platform_get_transport_uses_direct_transport_for_database_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    FakeBackend = patch_platform_dependencies(monkeypatch)
+    settings = Settings(storage_directory=tmp_path)
+    platform = Platform(FakeBackend(mock.sentinel.transport), settings=settings)
+
+    platform.settings = cast(
+        Settings,
+        SimpleNamespace(
+            check_alembic_version=True,
+        ),
+    )
+
+    calls: list[dict[str, object]] = []
+
+    def fake_from_dsn(
+        cls: type,
+        /,
+        dsn: str,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        calls.append({"dsn": dsn, "kwargs": kwargs})
+        return mock.sentinel.transport
+
+    monkeypatch.setattr(
+        "ixmp4.core.platform.DirectTransport.from_dsn",
+        classmethod(fake_from_dsn),
+    )
+
+    result = platform.get_transport(SimpleNamespace(dsn="sqlite:///:memory:"))
+
+    assert result is mock.sentinel.transport
+    assert calls == [
+        {
+            "dsn": "sqlite:///:memory:",
+            "kwargs": {"check_alembic_version": True},
+        }
+    ]

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest import mock
 
 import pytest
@@ -22,6 +22,7 @@ class _PlatformConnectionInfo:
 
 class _SettingsStub:
     client = SimpleNamespace()
+    check_alembic_version = True
 
     def get_credentials(self) -> dict[str, dict[str, str]]:
         return {"default": {"username": "u", "password": "p"}}
@@ -282,7 +283,7 @@ def test_get_transport_falls_back_to_http_on_direct_error(
     platform = Platform.__new__(Platform)
     platform.settings = cast(Settings, _SettingsStub())
 
-    def _raise_direct_error(dsn: str) -> object:
+    def _raise_direct_error(dsn: str, **kw: Any) -> object:
         raise ImproperlyConfigured(
             "Cannot resolve DSN environment variable placeholder(s)."
         )
@@ -310,7 +311,7 @@ def test_get_transport_falls_back_to_http_on_sqlalchemy_error(
     platform = Platform.__new__(Platform)
     platform.settings = cast(Settings, _SettingsStub())
 
-    def _raise_direct_error(dsn: str) -> object:
+    def _raise_direct_error(dsn: str, **kw: Any) -> object:
         raise sa.exc.OperationalError("SELECT 1", {}, Exception("boom"))
 
     expected_transport = object()
@@ -336,7 +337,7 @@ def test_get_transport_does_not_fallback_on_value_error(
     platform = Platform.__new__(Platform)
     platform.settings = cast(Settings, _SettingsStub())
 
-    def _raise_direct_error(dsn: str) -> object:
+    def _raise_direct_error(dsn: str, **kw: Any) -> object:
         raise ValueError("Unrelated incident.")
 
     monkeypatch.setattr(

--- a/tests/unit/test_procedure.py
+++ b/tests/unit/test_procedure.py
@@ -321,7 +321,9 @@ class TestProcedureCallableWrappers:
         self,
     ) -> None:
         """AuthorizedTransport triggers auth_check.prepend_auth_check."""
-        transport = DirectTransport.from_dsn("sqlite:///:memory:")
+        transport = DirectTransport.from_dsn(
+            "sqlite:///:memory:", check_alembic_version=False
+        )
         session = transport.session
 
         auth_called: list[bool] = []
@@ -351,6 +353,7 @@ class TestProcedureCallableWrappers:
             session=session,
             auth_ctx=cast(AuthorizationContext, SimpleNamespace(user="alice")),
             platform=cast(PlatformProtocol, SimpleNamespace(id="demo")),
+            check_alembic_version=False,
         )
         svc = AuthDemoService(auth_transport)
         bound_func = mock.Mock(return_value=42)
@@ -581,7 +584,7 @@ class TestProcedurePagination:
 class TestProcedureRouteHandler:
     @pytest.fixture(scope="class")
     def demo_transport(self) -> Generator[DirectTransport, None, None]:
-        t = DirectTransport.from_dsn("sqlite:///:memory:")
+        t = DirectTransport.from_dsn("sqlite:///:memory:", check_alembic_version=False)
         yield t
         t.close()
 
@@ -745,7 +748,9 @@ class TestProcedureClient:
         from ixmp4.data.services.procedure.client import ProcedureClient
 
         svc = object.__new__(DemoService)
-        svc.transport = DirectTransport.from_dsn("sqlite:///:memory:")
+        svc.transport = DirectTransport.from_dsn(
+            "sqlite:///:memory:", check_alembic_version=False
+        )
 
         handler = cast(
             ProcedureRouteHandler[Any, Any, Any],

--- a/tests/unit/test_server_v1.py
+++ b/tests/unit/test_server_v1.py
@@ -42,18 +42,6 @@ class TestYieldSession:
 
         asyncio.run(_run())
 
-    def test_yield_session_resolves_dsn_env_tokens(self) -> None:
-        """Server-side session creation resolves {env:...} placeholders."""
-        from ixmp4.server.v1 import yield_session
-
-        async def _run() -> None:
-            async with yield_session("sqlite:///{env:IXMP4_SERVER_DB}") as session:
-                assert session is not None
-                session.execute(sa.text("SELECT 1"))
-
-        with mock.patch.dict("os.environ", {"IXMP4_SERVER_DB": ":memory:"}):
-            asyncio.run(_run())
-
 
 class TestGetTransport:
     def test_get_transport_yields_direct_transport_when_unauthenticated(self) -> None:

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -53,12 +53,14 @@ def test_cached_create_engine_uses_cache() -> None:
 
 
 def test_direct_transport_handles_bound_and_unbound_sessions() -> None:
-    unbound = DirectTransport(transport_module.Session(), ping_database=False)
+    unbound = DirectTransport(
+        transport_module.Session(), ping_database=False, check_alembic_version=False
+    )
     assert unbound.get_database_url() is None
     assert unbound.get_engine_info() == ""
     assert str(unbound) == "<DirectTransport >"
 
-    bound = DirectTransport.from_dsn("sqlite:///:memory:")
+    bound = DirectTransport.from_dsn("sqlite:///:memory:", check_alembic_version=False)
     assert str(bound.get_database_url()) == "sqlite:///:memory:"
     assert "dialect=sqlite" in bound.get_engine_info()
     assert str(bound).startswith("<DirectTransport dialect=sqlite")
@@ -73,7 +75,7 @@ def test_direct_transport_check_dsn_and_invalid_dsn() -> None:
     assert DirectTransport.check_dsn("sqlite:///:memory:") == "sqlite:///:memory:"
 
     with pytest.raises(ProgrammingError, match="Unsupported database dialect"):
-        DirectTransport.from_dsn("mysql://example.test/db")
+        DirectTransport.from_dsn("mysql://example.test/db", check_alembic_version=False)
 
 
 def test_direct_transport_from_dsn_uses_postgresql_engine(
@@ -94,7 +96,9 @@ def test_direct_transport_from_dsn_uses_postgresql_engine(
         classmethod(fake_create_postgresql_engine),
     )
 
-    transport = DirectTransport.from_dsn("postgresql://user:pass@example.test/db")
+    transport = DirectTransport.from_dsn(
+        "postgresql://user:pass@example.test/db", check_alembic_version=False
+    )
 
     assert calls == ["postgresql+psycopg://user:pass@example.test/db"]
     assert transport.session.bind is fake_engine
@@ -102,7 +106,9 @@ def test_direct_transport_from_dsn_uses_postgresql_engine(
 
 
 def test_direct_transport_versioning_requires_postgresql() -> None:
-    transport = DirectTransport.from_dsn("sqlite:///:memory:")
+    transport = DirectTransport.from_dsn(
+        "sqlite:///:memory:", check_alembic_version=False
+    )
 
     with pytest.raises(OperationNotSupported, match="Versioning is only enabled"):
         transport.check_versioning_compatiblity()
@@ -323,6 +329,7 @@ def test_authorized_transport_string_includes_user_and_platform() -> None:
         session=session,
         auth_ctx=cast(AuthorizationContext, SimpleNamespace(user="alice")),
         platform=cast(PlatformProtocol, SimpleNamespace(id="demo-platform")),
+        check_alembic_version=False,
     )
 
     assert transport.unauthorized_transport.session is session
@@ -400,7 +407,7 @@ def test_httpx_transport_from_asgi_sets_direct_transport(
 
     monkeypatch.setattr(transport_module, "TestClient", fake_test_client)
 
-    direct = DirectTransport.from_dsn("sqlite:///:memory:")
+    direct = DirectTransport.from_dsn("sqlite:///:memory:", check_alembic_version=False)
     transport = HttpxTransport.from_asgi(
         asgi=mock.sentinel.asgi,
         settings=ClientSettings(),

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -233,6 +233,90 @@ def test_direct_transport_check_alembic_version_older_db_revision_guidance(
         DirectTransport(session, check_alembic_version=True)
 
 
+def test_direct_transport_check_alembic_version_requires_head_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "rev1",
+        get_head_revision=lambda: None,
+        list_revisions=lambda: [SimpleNamespace(revision="rev1")],
+    )
+    monkeypatch.setattr(
+        transport_module.DirectTransport,
+        "get_alembic_controller",
+        lambda self, dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        conn.execute(
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('rev1')")
+        )
+
+    session = transport_module.Session(bind=engine)
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="Could not determine the expected alembic revision",
+    ):
+        DirectTransport(session, check_alembic_version=True)
+
+
+def test_direct_transport_check_alembic_version_rejects_non_unique_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "rev1",
+        get_head_revision=lambda: ("head-1",),
+        list_revisions=lambda: [SimpleNamespace(revision="rev1")],
+    )
+    monkeypatch.setattr(
+        transport_module.DirectTransport,
+        "get_alembic_controller",
+        lambda self, dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        conn.execute(
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('rev1')")
+        )
+
+    session = transport_module.Session(bind=engine)
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="Could not determine a unique expected alembic revision",
+    ):
+        DirectTransport(session, check_alembic_version=True)
+
+
+def test_direct_transport_check_alembic_version_requires_current_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: None,
+        get_head_revision=lambda: "rev1",
+        list_revisions=lambda: [SimpleNamespace(revision="rev1")],
+    )
+    monkeypatch.setattr(
+        transport_module.DirectTransport,
+        "get_alembic_controller",
+        lambda self, dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+
+    session = transport_module.Session(bind=engine)
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="no alembic revision entry was found in 'alembic_version'",
+    ):
+        DirectTransport(session, check_alembic_version=True)
+
+
 def test_authorized_transport_string_includes_user_and_platform() -> None:
     session = transport_module.Session(bind=sa.create_engine("sqlite:///:memory:"))
     transport = AuthorizedTransport(

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -110,6 +110,129 @@ def test_direct_transport_versioning_requires_postgresql() -> None:
     transport.close()
 
 
+def test_direct_transport_check_alembic_version_succeeds_when_matching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "rev1",
+        get_head_revision=lambda: "rev1",
+        list_revisions=lambda: [SimpleNamespace(revision="rev1")],
+    )
+    monkeypatch.setattr(
+        transport_module,
+        "get_alembic_controller",
+        lambda dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        conn.execute(
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('rev1')")
+        )
+
+    session = transport_module.Session(bind=engine)
+    transport = DirectTransport(session, check_alembic_version=True)
+    transport.close()
+
+
+def test_direct_transport_check_alembic_version_raises_on_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "different",
+        get_head_revision=lambda: "expected",
+        list_revisions=lambda: [
+            SimpleNamespace(revision="expected"),
+            SimpleNamespace(revision="base"),
+        ],
+    )
+    monkeypatch.setattr(
+        transport_module,
+        "get_alembic_controller",
+        lambda dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        conn.execute(
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('different')")
+        )
+
+    session = transport_module.Session(bind=engine)
+    with pytest.raises(ImproperlyConfigured, match="Database schema version mismatch"):
+        DirectTransport(session, check_alembic_version=True)
+
+
+def test_direct_transport_check_alembic_version_can_be_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "different",
+        get_head_revision=lambda: "expected",
+        list_revisions=lambda: [SimpleNamespace(revision="expected")],
+    )
+    monkeypatch.setattr(
+        transport_module,
+        "get_alembic_controller",
+        lambda dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        conn.execute(
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('different')")
+        )
+
+    session = transport_module.Session(bind=engine)
+    transport = DirectTransport(session, check_alembic_version=False)
+    transport.close()
+
+
+def test_direct_transport_check_alembic_version_requires_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    session = transport_module.Session(bind=engine)
+
+    with pytest.raises(ImproperlyConfigured, match="alembic_version"):
+        DirectTransport(session, check_alembic_version=True)
+
+
+def test_direct_transport_check_alembic_version_older_db_revision_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "old-rev",
+        get_head_revision=lambda: "new-rev",
+        list_revisions=lambda: [
+            SimpleNamespace(revision="new-rev"),
+            SimpleNamespace(revision="old-rev"),
+        ],
+    )
+    monkeypatch.setattr(
+        transport_module,
+        "get_alembic_controller",
+        lambda dsn: fake_controller,
+    )
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
+        conn.execute(
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('old-rev')")
+        )
+
+    session = transport_module.Session(bind=engine)
+    with pytest.raises(
+        ImproperlyConfigured,
+        match="Upgrade the database.*or downgrade ixmp4",
+    ):
+        DirectTransport(session, check_alembic_version=True)
+
+
 def test_authorized_transport_string_includes_user_and_platform() -> None:
     session = transport_module.Session(bind=sa.create_engine("sqlite:///:memory:"))
     transport = AuthorizedTransport(

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -119,9 +119,9 @@ def test_direct_transport_check_alembic_version_succeeds_when_matching(
         list_revisions=lambda: [SimpleNamespace(revision="rev1")],
     )
     monkeypatch.setattr(
-        transport_module,
+        transport_module.DirectTransport,
         "get_alembic_controller",
-        lambda dsn: fake_controller,
+        lambda self, dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -148,9 +148,9 @@ def test_direct_transport_check_alembic_version_raises_on_mismatch(
         ],
     )
     monkeypatch.setattr(
-        transport_module,
+        transport_module.DirectTransport,
         "get_alembic_controller",
-        lambda dsn: fake_controller,
+        lambda self, dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -174,9 +174,9 @@ def test_direct_transport_check_alembic_version_can_be_skipped(
         list_revisions=lambda: [SimpleNamespace(revision="expected")],
     )
     monkeypatch.setattr(
-        transport_module,
+        transport_module.DirectTransport,
         "get_alembic_controller",
-        lambda dsn: fake_controller,
+        lambda self, dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -213,9 +213,9 @@ def test_direct_transport_check_alembic_version_older_db_revision_guidance(
         ],
     )
     monkeypatch.setattr(
-        transport_module,
+        transport_module.DirectTransport,
         "get_alembic_controller",
-        lambda dsn: fake_controller,
+        lambda self, dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -134,9 +134,8 @@ def test_direct_transport_check_alembic_version_succeeds_when_matching(
     with engine.begin() as conn:
         conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32))"))
         conn.execute(
-            sa.text("INSERT INTO alembic_version (version_num) VALUES ('rev1')")
+            sa.text("INSERT INTO alembic_version (version_num) VALUES ('different')")
         )
-
     session = transport_module.Session(bind=engine)
     transport = DirectTransport(session, check_alembic_version=True)
     transport.close()
@@ -174,6 +173,15 @@ def test_direct_transport_check_alembic_version_raises_on_mismatch(
 def test_direct_transport_check_alembic_version_can_be_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    session = transport_module.Session(bind=engine)
+    transport = DirectTransport(session, check_alembic_version=False)
+    transport.close()
+
+
+def test_direct_transport_check_alembic_version_runs_via_from_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     fake_controller = SimpleNamespace(
         get_database_revision=lambda: "different",
         get_head_revision=lambda: "expected",
@@ -192,9 +200,16 @@ def test_direct_transport_check_alembic_version_can_be_skipped(
             sa.text("INSERT INTO alembic_version (version_num) VALUES ('different')")
         )
 
-    session = transport_module.Session(bind=engine)
-    transport = DirectTransport(session, check_alembic_version=False)
-    transport.close()
+    def fake_create_engine(cls: type[DirectTransport], dsn: str) -> sa.Engine:
+        return engine
+
+    monkeypatch.setattr(
+        DirectTransport,
+        "create_sqlite_engine",
+        classmethod(fake_create_engine),
+    )
+    with pytest.raises(ImproperlyConfigured, match="Database schema version mismatch"):
+        DirectTransport.from_dsn("sqlite:///:memory:", check_alembic_version=True)
 
 
 def test_direct_transport_check_alembic_version_requires_table(

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -125,9 +125,9 @@ def test_direct_transport_check_alembic_version_succeeds_when_matching(
         list_revisions=lambda: [SimpleNamespace(revision="rev1")],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -154,9 +154,9 @@ def test_direct_transport_check_alembic_version_raises_on_mismatch(
         ],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -180,9 +180,9 @@ def test_direct_transport_check_alembic_version_can_be_skipped(
         list_revisions=lambda: [SimpleNamespace(revision="expected")],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -219,9 +219,9 @@ def test_direct_transport_check_alembic_version_older_db_revision_guidance(
         ],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -248,9 +248,9 @@ def test_direct_transport_check_alembic_version_requires_head_revision(
         list_revisions=lambda: [SimpleNamespace(revision="rev1")],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -277,9 +277,9 @@ def test_direct_transport_check_alembic_version_rejects_non_unique_head(
         list_revisions=lambda: [SimpleNamespace(revision="rev1")],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")
@@ -306,9 +306,9 @@ def test_direct_transport_check_alembic_version_requires_current_revision(
         list_revisions=lambda: [SimpleNamespace(revision="rev1")],
     )
     monkeypatch.setattr(
-        transport_module.DirectTransport,
+        transport_module,
         "get_alembic_controller",
-        lambda self, dsn: fake_controller,
+        lambda dsn: fake_controller,
     )
 
     engine = sa.create_engine("sqlite:///:memory:")


### PR DESCRIPTION
When `DirectTransport` (or `AuthorizedTransport`) are instantiated with check_alembic_version=True, it will 
check if the migration version in the database is the same as in the current code base.
For the transport classes the argument is ~`False`~ `True` per default but if instantiated through a platform the value from Settings.check_alembic_version (or the corresponding env var) will be used. Which is also True by default.

Closes #222 

@khaeru Fridolin mentioned this is a request from you so feel free to add you two cents
@danielhuppmann fyi

### Failure Modes

**alembic_version table does not exist:**
```py
raise ImproperlyConfigured(
    "Database schema version check failed because the table "
    "'alembic_version' does not exist. Run migrations or disable the "
    "check via check_alembic_version=False/"
    "IXMP4_CHECK_ALEMBIC_VERSION=false."
)
```
**alembic returns no head revision:**
```py
raise ImproperlyConfigured(
    "Could not determine the expected alembic "
    "revision from migration scripts."
)
```
**alembic returns multiple head revisions**
```py
raise ImproperlyConfigured(
    "Could not determine a unique expected alembic revision because "
    f"multiple heads were found: {head_revision}."
)
```
**alembic_version table has no entries**
```py
raise ImproperlyConfigured(
    "Database schema version check failed because no alembic revision "
    "entry was found in 'alembic_version'. Run migrations or disable "
    "the check via check_alembic_version=False/"
    "IXMP4_CHECK_ALEMBIC_VERSION=false."
)
```
**alembic_version entry is previous revision**
```py
raise ImproperlyConfigured(
    "Database schema version mismatch. "
    f"Expected revision '{head_revision}' but found older "
    f"revision '{current_revision}'. Upgrade the database to the "
    "current ixmp4 migration head, or downgrade ixmp4 to a version "
    "compatible with this database revision."
)
```
**alembic_version entry is unknown revision**
```py
raise ImproperlyConfigured(
    "Database schema version mismatch. "
    f"Expected revision '{head_revision}' but found "
    f"'{current_revision}'. Upgrade your ixmp4 installation or disable the "
    "check via check_alembic_version=False/"
    "IXMP4_CHECK_ALEMBIC_VERSION=false."
)
```
