### PR TITLE
Support filtering by meta indicators 

### DIFF
--- a/ixmp4/data/filters/__init__.py
+++ b/ixmp4/data/filters/__init__.py
@@ -48,7 +48,34 @@ class DtypeFilter(TypedDict, total=False):
     dtype__in: list[str]
 
 
-class RunMetaEntryFilter(IdFilter, KeyFilter, RunIdFilter, DtypeFilter, total=False):
+class ValueFilter(TypedDict, total=False):
+    value_float: float
+    value_float__lte: float
+    value_float__lt: float
+    value_float__gte: float
+    value_float__gt: float
+    value_float__in: list[float]
+
+    value_int: int
+    value_int__lte: int
+    value_int__lt: int
+    value_int__gte: int
+    value_int__gt: int
+    value_int__in: list[int]
+
+    value_str: str
+    value_str__in: list[str]
+    value_str__like: str
+    value_str__ilike: str
+    value_str__notlike: str
+    value_str__notilike: str
+
+    value_bool: bool
+
+
+class RunMetaEntryFilter(
+    IdFilter, KeyFilter, RunIdFilter, DtypeFilter, ValueFilter, total=False
+):
     pass
 
 

--- a/ixmp4/data/iamc/datapoint/filter.py
+++ b/ixmp4/data/iamc/datapoint/filter.py
@@ -69,7 +69,7 @@ class FacadeDataPointFilter(
     variable: iamc.VariableFilter | str | Iterable[str]
     model: base.ModelFilter | str | Iterable[str]
     scenario: base.ScenarioFilter | str | Iterable[str]
-    meta: base.RunMetaEntryFilter
+    meta: base.RunMetaEntryFilter | str | Iterable[str]
     run: FacadeRunFilter
 
 
@@ -92,6 +92,10 @@ FACADE_FILTER_TRANSFORMERS: dict[str, Sequence[FilterValueTransformer]] = {
     "variable": NAME_FILTER_TRANSFORMERS,
     "model": NAME_FILTER_TRANSFORMERS,
     "scenario": NAME_FILTER_TRANSFORMERS,
+    "meta": (
+        make_str_like_transformer("key"),
+        make_iterable_str_in_transformer("key"),
+    ),
     "run": (make_mapping_transformer(run_facade_to_data_filter),),
 }
 

--- a/ixmp4/data/iamc/datapoint/filter.py
+++ b/ixmp4/data/iamc/datapoint/filter.py
@@ -27,6 +27,10 @@ class DataPointFilter(iamc.DataPointFilter, total=False):
         iamc.VariableFilter, (DataPoint.timeseries, TimeSeries.variable)
     ]
     unit: Annotated[base.UnitFilter, (DataPoint.timeseries, TimeSeries.unit)]
+    meta: Annotated[
+        base.RunMetaEntryFilter,
+        (DataPoint.timeseries, TimeSeries.run, Run.meta),
+    ]
     run: Annotated[base.RunFilter, (DataPoint.timeseries, TimeSeries.run)]
     model: Annotated[
         base.ModelFilter, (DataPoint.timeseries, TimeSeries.run, Run.model)
@@ -65,6 +69,7 @@ class FacadeDataPointFilter(
     variable: iamc.VariableFilter | str | Iterable[str]
     model: base.ModelFilter | str | Iterable[str]
     scenario: base.ScenarioFilter | str | Iterable[str]
+    meta: base.RunMetaEntryFilter
     run: FacadeRunFilter
 
 

--- a/ixmp4/data/meta/db.py
+++ b/ixmp4/data/meta/db.py
@@ -40,7 +40,7 @@ class RunMetaEntry(BaseModel):
     )
     run: Mapped["Run"] = orm.relationship(
         "Run",
-        backref="meta",
+        back_populates="meta",
         foreign_keys=[run__id],
     )
 

--- a/ixmp4/data/run/db.py
+++ b/ixmp4/data/run/db.py
@@ -11,6 +11,7 @@ from ixmp4.data.scenario.db import Scenario
 
 if TYPE_CHECKING:
     from ixmp4.data.iamc.timeseries.db import TimeSeries
+    from ixmp4.data.meta.db import RunMetaEntry
 
 
 class Run(BaseModel, HasUpdateInfo):
@@ -31,6 +32,12 @@ class Run(BaseModel, HasUpdateInfo):
         "Scenario", backref="run", foreign_keys=[scenario__id], lazy="joined"
     )
     timeseries: Mapped[list["TimeSeries"]] = orm.relationship(viewonly=True)
+    meta: Mapped[list["RunMetaEntry"]] = orm.relationship(
+        "RunMetaEntry",
+        back_populates="run",
+        foreign_keys="RunMetaEntry.run__id",
+        viewonly=True,
+    )
 
     # equations: Mapped[list["Equation"]] = orm.relationship()
     # indexsets: Mapped[list["IndexSet"]] = orm.relationship()

--- a/ixmp4/data/run/filter.py
+++ b/ixmp4/data/run/filter.py
@@ -56,7 +56,7 @@ class RunFilter(base.RunFilter, total=False):
 class FacadeRunFilter(base.RunFilter, total=False):
     model: base.ModelFilter | str | Iterable[str]
     scenario: base.ScenarioFilter | str | Iterable[str]
-    meta: base.RunMetaEntryFilter
+    meta: base.RunMetaEntryFilter | str | Iterable[str]
     iamc: IamcRunFilter | bool | None
 
 
@@ -69,6 +69,10 @@ NAME_FILTER_TRANSFORMERS: tuple[FilterValueTransformer, ...] = (
 FACADE_FILTER_TRANSFORMERS: dict[str, Sequence[FilterValueTransformer]] = {
     "model": NAME_FILTER_TRANSFORMERS,
     "scenario": NAME_FILTER_TRANSFORMERS,
+    "meta": (
+        make_str_like_transformer("key"),
+        make_iterable_str_in_transformer("key"),
+    ),
 }
 
 

--- a/ixmp4/data/run/filter.py
+++ b/ixmp4/data/run/filter.py
@@ -49,12 +49,14 @@ def filter_by_iamc(
 class RunFilter(base.RunFilter, total=False):
     model: Annotated[base.ModelFilter, Run.model]
     scenario: Annotated[base.ScenarioFilter, Run.scenario]
+    meta: Annotated[base.RunMetaEntryFilter, Run.meta]
     iamc: Annotated[IamcRunFilter | bool | None, filter_by_iamc]
 
 
 class FacadeRunFilter(base.RunFilter, total=False):
     model: base.ModelFilter | str | Iterable[str]
     scenario: base.ScenarioFilter | str | Iterable[str]
+    meta: base.RunMetaEntryFilter
     iamc: IamcRunFilter | bool | None
 
 

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -1,8 +1,10 @@
 import httpx
 import pytest
 
+from ixmp4.data.meta.service import RunMetaEntryService
 from ixmp4.data.run.dto import Run
 from ixmp4.data.run.service import RunService
+from ixmp4.transport import DirectTransport
 from tests.api.base import (
     ApiServiceTest,
     api_transport,
@@ -133,3 +135,32 @@ class TestRunState(RunApiTest):
         ).json()
         assert unlocked["id"] == run.id
         assert unlocked["lock_transaction"] is None
+
+
+class TestRunQueryByMeta(RunApiTest):
+    @pytest.fixture(scope="class")
+    def runs(self, direct_transport: DirectTransport) -> tuple[Run, Run]:
+        runs = RunService(direct_transport)
+        meta = RunMetaEntryService(direct_transport)
+
+        run_with_meta = runs.create("Model A", "Scenario A")
+        run_without_meta = runs.create("Model B", "Scenario B")
+
+        meta.create(run_with_meta.id, "indicator", "keep")
+        return run_with_meta, run_without_meta
+
+    def test_run_list_by_meta(
+        self, client: httpx.Client, runs: tuple[Run, Run]
+    ) -> None:
+        run_with_meta, run_without_meta = runs
+
+        listed = self.request(
+            client,
+            "PATCH",
+            "/runs/list",
+            json={"default_only": False, "meta": {"key": "indicator"}},
+        ).json()
+
+        assert_paginated_list(listed, expected_count=1)
+        assert listed["results"][0]["id"] == run_with_meta.id
+        assert listed["results"][0]["id"] != run_without_meta.id

--- a/tests/core/test_filters.py
+++ b/tests/core/test_filters.py
@@ -392,6 +392,22 @@ class TestFilters:
         assert not by_meta_like.empty
         assert by_meta_like["model"].eq("Model 1").all()
 
+        by_meta_shorthand = platform.runs.tabulate(
+            default_only=False,
+            meta="indicator_model_2",
+        )
+
+        assert not by_meta_shorthand.empty
+        assert by_meta_shorthand["model"].eq("Model 2").all()
+
+        by_meta_in_shorthand = platform.runs.tabulate(
+            default_only=False,
+            meta=["indicator_model_1"],
+        )
+
+        assert not by_meta_in_shorthand.empty
+        assert by_meta_in_shorthand["model"].eq("Model 1").all()
+
     def test_filter_datapoints_by_meta(self, platform: ixmp4.Platform) -> None:
         by_meta = platform.iamc.tabulate(
             run={"default_only": False},
@@ -407,6 +423,22 @@ class TestFilters:
 
         assert not by_meta_like.empty
         assert by_meta_like["model"].eq("Model 1").all()
+
+        by_meta_shorthand = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta="indicator_model_2",
+        )
+
+        assert not by_meta_shorthand.empty
+        assert by_meta_shorthand["model"].eq("Model 2").all()
+
+        by_meta_in_shorthand = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta=["indicator_model_1"],
+        )
+
+        assert not by_meta_in_shorthand.empty
+        assert by_meta_in_shorthand["model"].eq("Model 1").all()
 
     def test_invalid_filters_raise(self, platform: ixmp4.Platform) -> None:
         with pytest.raises(InvalidArguments):

--- a/tests/core/test_filters.py
+++ b/tests/core/test_filters.py
@@ -56,6 +56,11 @@ class TestFilters:
             if is_default:
                 run.set_as_default()
 
+            if model in {"Model 1", "Model 2"}:
+                meta_key = f"indicator_{model.lower().replace(' ', '_')}"
+                with run.transact("Add run meta indicator"):
+                    run.meta[meta_key] = True
+
         for run_tuple, rows in datapoints.groupby(
             ["model", "scenario", "version"], group_keys=False
         ):
@@ -369,6 +374,39 @@ class TestFilters:
             year__in=[2000, 2010], run={"default_only": False}
         )
         pdt.assert_frame_equal(sort_df(df_year_in), sort_df(df_year_in_shorthand))
+
+    def test_filter_runs_by_meta(self, platform: ixmp4.Platform) -> None:
+        by_meta = platform.runs.tabulate(
+            default_only=False,
+            meta={"key": "indicator_model_2"},
+        )
+
+        assert not by_meta.empty
+        assert by_meta["model"].eq("Model 2").all()
+
+        by_meta_like = platform.runs.tabulate(
+            default_only=False,
+            meta={"key__like": "*_model_1"},
+        )
+
+        assert not by_meta_like.empty
+        assert by_meta_like["model"].eq("Model 1").all()
+
+    def test_filter_datapoints_by_meta(self, platform: ixmp4.Platform) -> None:
+        by_meta = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta={"key": "indicator_model_2"},
+        )
+        assert not by_meta.empty
+        assert by_meta["model"].eq("Model 2").all()
+
+        by_meta_like = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta={"key__like": "*_model_1"},
+        )
+
+        assert not by_meta_like.empty
+        assert by_meta_like["model"].eq("Model 1").all()
 
     def test_invalid_filters_raise(self, platform: ixmp4.Platform) -> None:
         with pytest.raises(InvalidArguments):

--- a/tests/core/test_filters.py
+++ b/tests/core/test_filters.py
@@ -60,6 +60,12 @@ class TestFilters:
                 meta_key = f"indicator_{model.lower().replace(' ', '_')}"
                 with run.transact("Add run meta indicator"):
                     run.meta[meta_key] = True
+                    run.meta["filter_value_bool"] = model == "Model 2"
+                    run.meta["filter_value_int"] = 2 if model == "Model 2" else 1
+                    run.meta["filter_value_float"] = 2.5 if model == "Model 2" else 1.5
+                    run.meta["filter_value_str"] = (
+                        "model_2" if model == "Model 2" else "model_1"
+                    )
 
         for run_tuple, rows in datapoints.groupby(
             ["model", "scenario", "version"], group_keys=False
@@ -408,6 +414,34 @@ class TestFilters:
         assert not by_meta_in_shorthand.empty
         assert by_meta_in_shorthand["model"].eq("Model 1").all()
 
+        by_meta_bool = platform.runs.tabulate(
+            default_only=False,
+            meta={"key": "filter_value_bool", "value_bool": True},
+        )
+        assert not by_meta_bool.empty
+        assert by_meta_bool["model"].eq("Model 2").all()
+
+        by_meta_int = platform.runs.tabulate(
+            default_only=False,
+            meta={"key": "filter_value_int", "value_int": 2},
+        )
+        assert not by_meta_int.empty
+        assert by_meta_int["model"].eq("Model 2").all()
+
+        by_meta_float = platform.runs.tabulate(
+            default_only=False,
+            meta={"key": "filter_value_float", "value_float": 2.5},
+        )
+        assert not by_meta_float.empty
+        assert by_meta_float["model"].eq("Model 2").all()
+
+        by_meta_str = platform.runs.tabulate(
+            default_only=False,
+            meta={"key": "filter_value_str", "value_str": "model_2"},
+        )
+        assert not by_meta_str.empty
+        assert by_meta_str["model"].eq("Model 2").all()
+
     def test_filter_datapoints_by_meta(self, platform: ixmp4.Platform) -> None:
         by_meta = platform.iamc.tabulate(
             run={"default_only": False},
@@ -439,6 +473,34 @@ class TestFilters:
 
         assert not by_meta_in_shorthand.empty
         assert by_meta_in_shorthand["model"].eq("Model 1").all()
+
+        by_meta_bool = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta={"key": "filter_value_bool", "value_bool": True},
+        )
+        assert not by_meta_bool.empty
+        assert by_meta_bool["model"].eq("Model 2").all()
+
+        by_meta_int = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta={"key": "filter_value_int", "value_int": 2},
+        )
+        assert not by_meta_int.empty
+        assert by_meta_int["model"].eq("Model 2").all()
+
+        by_meta_float = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta={"key": "filter_value_float", "value_float": 2.5},
+        )
+        assert not by_meta_float.empty
+        assert by_meta_float["model"].eq("Model 2").all()
+
+        by_meta_str = platform.iamc.tabulate(
+            run={"default_only": False},
+            meta={"key": "filter_value_str", "value_str": "model_2"},
+        )
+        assert not by_meta_str.empty
+        assert by_meta_str["model"].eq("Model 2").all()
 
     def test_invalid_filters_raise(self, platform: ixmp4.Platform) -> None:
         with pytest.raises(InvalidArguments):


### PR DESCRIPTION
Adds related filters to run and iamc datapoint filters which allow filtering by meta indicators. 
The data layer and api each accept the full meta filter under the "meta" key:

```json
{
  "meta": {
      "key": str,
      "key__in": list[str],
      "key__like": str,
      "key__ilike": str,
      "key__notlike": str,
      "key__notilike": str,
      "dtype": str,
      "dtype__in": list[str],
      // ...  }
}
```

And the facade layer adds shorthand filters: 
```py
mp.runs.tabulate(meta="Emissions Diagnostics|*")
mp.runs.tabulate(meta=[
		"Emissions Diagnostics|Cumulative CCS [2020-2100, Gt CO2]",
		"Climate Assessment|Peak Warming|Median [MAGICCv7.5.3]",
		"Climate Assessment|Year of Peak Warming|Median [MAGICCv7.5.3]"
])
```

Closes #225

@danielhuppmann 