### PR TITLE
Fix tabulate_manager_platforms printing platform names instead of slugs

### DIFF
--- a/ixmp4/cli/platforms.py
+++ b/ixmp4/cli/platforms.py
@@ -331,7 +331,7 @@ def tabulate_manager_platforms(
         caption_justify="left",
     )
     for mp in platforms:
-        manager_table.add_row(mp.name, str(mp.accessibility).lower(), mp.notice)
+        manager_table.add_row(mp.slug, str(mp.accessibility).lower(), mp.notice)
     console.print()
     console.print(manager_table)
     console.print()

--- a/tests/cli/test_platforms.py
+++ b/tests/cli/test_platforms.py
@@ -278,12 +278,14 @@ def test_tabulate_manager_platforms(monkeypatch: pytest.MonkeyPatch) -> None:
     tabulate_manager_platforms(
         [
             SimpleNamespace(
-                name="alpha",
+                name="Alpha Name",
+                slug="alpha",
                 accessibility="PUBLIC",
                 notice="Primary platform",
             ),
             SimpleNamespace(
-                name="beta",
+                name="Beta Name",
+                slug="beta",
                 accessibility="PRIVATE",
                 notice="Restricted",
             ),


### PR DESCRIPTION
For the **pyam** workflow we need `tabulate_manager_platforms` to print platform slugs not names. 
Fixes a bug introduced by switching to scse-toolkit (which changes the name and slug attributes).