### PR TITLE
Fall back to HTTP connections if DB connection is theorethically possible (staff, superusers) but fails anyway

### DIFF
--- a/ixmp4/cli/alembic.py
+++ b/ixmp4/cli/alembic.py
@@ -5,7 +5,7 @@ from toolkit.db.alembic import AlembicCli, AlembicController
 from typing_extensions import Annotated
 
 from ixmp4.base_exceptions import PlatformNotFound, ServiceException
-from ixmp4.conf.platforms import PlatformConnectionInfo
+from ixmp4.conf.platforms import PlatformConnectionInfo, resolve_dsn_env_tokens
 from ixmp4.conf.settings import Settings
 from ixmp4.db import __file__ as db_module_dir
 from ixmp4.db.models import get_metadata
@@ -18,6 +18,7 @@ app = AlembicCli(
 
 
 def get_alembic_controller(dsn: str) -> AlembicController:
+    dsn = resolve_dsn_env_tokens(dsn)
     return AlembicController(
         dsn,
         str(migration_script_directory),

--- a/ixmp4/conf/platforms.py
+++ b/ixmp4/conf/platforms.py
@@ -108,17 +108,11 @@ class TomlPlatforms(PlatformConnections):
         toml.dump(obj, f)
 
     def list_platforms(self) -> list[TomlPlatform]:
-        return [
-            platform.model_copy(update={"dsn": resolve_dsn_env_tokens(platform.dsn)})
-            for platform in self.platforms.values()
-        ]
+        return list(self.platforms.values())
 
     def get_platform(self, name: str) -> TomlPlatform:
         try:
-            platform = self.platforms[name]
-            return platform.model_copy(
-                update={"dsn": resolve_dsn_env_tokens(platform.dsn)}
-            )
+            return self.platforms[name]
         except KeyError as e:
             raise PlatformNotFound(f"Platform '{name}' was not found.") from e
 
@@ -146,16 +140,10 @@ class ManagerPlatforms(PlatformConnections):
         self.manager_client = manager_client
 
     def list_platforms(self) -> list[Ixmp4Instance]:
-        return [
-            platform.model_copy(update={"dsn": resolve_dsn_env_tokens(platform.dsn)})
-            for platform in self.manager_client.ixmp4.cached_list()
-        ]
+        return self.manager_client.ixmp4.cached_list()
 
     def get_platform(self, name: str) -> Ixmp4Instance:
         for platform in self.manager_client.ixmp4.cached_list():
             if platform.slug == name:
-                return platform.model_copy(
-                    update={"dsn": resolve_dsn_env_tokens(platform.dsn)}
-                )
-        else:
-            raise PlatformNotFound(f"Platform '{name}' was not found.")
+                return platform
+        raise PlatformNotFound(f"Platform '{name}' was not found.")

--- a/ixmp4/conf/platforms.py
+++ b/ixmp4/conf/platforms.py
@@ -36,7 +36,7 @@ def resolve_dsn_env_tokens(dsn: str) -> str:
 
     resolved = _ENV_TOKEN_PATTERN.sub(replace, dsn)
     if missing:
-        logger.error("Missing DSN environment variable(s): " + str(missing))
+        logger.debug("Missing DSN environment variable(s): " + str(missing))
         raise ImproperlyConfigured(
             "Cannot resolve DSN environment variable placeholder(s)."
         )

--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -1,6 +1,13 @@
 import logging
 
-from ixmp4.base_exceptions import PlatformNotFound, PlatformNotUnique
+import sqlalchemy as sa
+
+from ixmp4.base_exceptions import (
+    Ixmp4Error,
+    PlatformNotFound,
+    PlatformNotUnique,
+    ServiceException,
+)
 from ixmp4.conf.platforms import PlatformConnectionInfo
 from ixmp4.conf.settings import Settings
 from ixmp4.data.backend import Backend
@@ -186,7 +193,12 @@ class Platform(object):
             # Try direct connection first
             try:
                 return DirectTransport.from_dsn(ci.dsn)
-            except Exception as e:
+            except (
+                ServiceException,
+                Ixmp4Error,
+                sa.exc.SQLAlchemyError,
+                ImportError,
+            ) as e:
                 # If direct connection fails and HTTP URL is available,
                 # fall back to HTTP transport.
                 if ci.url is not None:

--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -202,8 +202,11 @@ class Platform(object):
                 # If direct connection fails and HTTP URL is available,
                 # fall back to HTTP transport.
                 if ci.url is not None:
+                    logger.debug(
+                        f"Error while trying to establish direct connection: \n{e}"
+                    )
                     logger.warning(
-                        f"Direct connection failed: {e}. "
+                        f"Direct connection failed with `{e.__class__.__name__}`. "
                         "Falling back to HTTP connection for platform "
                         f"'{ci.name}' at {ci.url}"
                     )

--- a/ixmp4/core/platform.py
+++ b/ixmp4/core/platform.py
@@ -183,7 +183,27 @@ class Platform(object):
                 auth=self.settings.get_client_auth(cred_dict),
             )
         else:
-            return DirectTransport.from_dsn(ci.dsn)
+            # Try direct connection first
+            try:
+                return DirectTransport.from_dsn(ci.dsn)
+            except Exception as e:
+                # If direct connection fails and HTTP URL is available,
+                # fall back to HTTP transport.
+                if ci.url is not None:
+                    logger.warning(
+                        f"Direct connection failed: {e}. "
+                        "Falling back to HTTP connection for platform "
+                        f"'{ci.name}' at {ci.url}"
+                    )
+                    cred_dict = self.settings.get_credentials().get(http_credentials)
+                    return HttpxTransport.from_url(
+                        str(ci.url),
+                        settings=self.settings.client,
+                        auth=self.settings.get_client_auth(cred_dict),
+                    )
+                else:
+                    # No HTTP URL available, re-raise the original error
+                    raise
 
     def get_toml_platform_ci(self, name: str) -> PlatformConnectionInfo | None:
         toml = self.settings.get_toml_platforms()

--- a/ixmp4/db/migrations/env.py
+++ b/ixmp4/db/migrations/env.py
@@ -19,6 +19,7 @@ from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import configure_mappers
 from sqlalchemy.schema import SchemaItem
 
+from ixmp4.conf.platforms import resolve_dsn_env_tokens
 from ixmp4.core.exceptions import ProgrammingError
 from ixmp4.db.models import BaseModel
 
@@ -33,7 +34,9 @@ if maybe_dsn is None:
         "which is needed to run migrations."
     )
 
-dsn = maybe_dsn.replace("postgresql://", "postgresql+psycopg://")
+dsn = resolve_dsn_env_tokens(maybe_dsn).replace(
+    "postgresql://", "postgresql+psycopg://"
+)
 
 configure_mappers()
 

--- a/ixmp4/server/v1/__init__.py
+++ b/ixmp4/server/v1/__init__.py
@@ -23,6 +23,7 @@ from toolkit.manager.client import ManagerClient
 from ixmp4.conf.platforms import (
     ManagerPlatforms,
     PlatformConnectionInfo,
+    resolve_dsn_env_tokens,
 )
 from ixmp4.conf.settings import ServerSettings
 from ixmp4.core.exceptions import (
@@ -118,7 +119,8 @@ async def get_transport(
     platform: PlatformConnectionInfo,
     request: Request[User | None, AuthorizationContext | None, Any],
 ) -> AsyncGenerator[DirectTransport, None]:
-    async with yield_session(platform.dsn) as session:
+    dsn = resolve_dsn_env_tokens(platform.dsn)
+    async with yield_session(dsn) as session:
         if request.auth is not None:
             yield AuthorizedTransport(session, request.auth, platform)
         else:

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 @lru_cache()
 def cached_create_engine(dsn: str, **kwargs: Any) -> sa.Engine:
     # max_identifier_length=63 to avoid exceeding postgres' default maximum
-    dsn = resolve_dsn_env_tokens(dsn)
     return sa.create_engine(
         dsn, poolclass=sa.NullPool, max_identifier_length=63, **kwargs
     )

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -51,8 +51,10 @@ Session = orm.sessionmaker(autocommit=False, autoflush=False)
 class DirectTransport(Transport):
     session: orm.Session
 
-    def __init__(self, session: orm.Session):
+    def __init__(self, session: orm.Session, ping_database: bool = True):
         self.session = session
+        if ping_database:
+            self.session.execute(sa.text("SELECT 1"))
 
         if (url := self.get_database_url()) is not None:
             logger.debug(f"Connected to IXMP4 database at '{url.render_as_string()}'.")
@@ -137,10 +139,9 @@ class AuthorizedTransport(DirectTransport):
         session: orm.Session,
         auth_ctx: AuthorizationContext,
         platform: PlatformProtocol,
+        ping_database: bool = True,
     ):
-        super().__init__(
-            session,
-        )
+        super().__init__(session, ping_database=ping_database)
         self.auth_ctx = auth_ctx
         self.platform = platform
         self.unauthorized_transport = DirectTransport(session)

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -143,7 +143,7 @@ class AuthorizedTransport(DirectTransport):
         super().__init__(session, ping_database=ping_database)
         self.auth_ctx = auth_ctx
         self.platform = platform
-        self.unauthorized_transport = DirectTransport(session)
+        self.unauthorized_transport = DirectTransport(session, ping_database=False)
 
     def __str__(self) -> str:
         return (

--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -17,6 +17,7 @@ from toolkit.client.auth import Auth, ManagerAuth, SelfSignedAuth
 from toolkit.client.base import ServiceClient
 
 from ixmp4.base_exceptions import ImproperlyConfigured
+from ixmp4.conf.platforms import resolve_dsn_env_tokens
 from ixmp4.conf.settings import ClientSettings, Settings
 from ixmp4.core.exceptions import OperationNotSupported, ProgrammingError
 from ixmp4.core.exceptions import registry as exception_registry
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 @lru_cache()
 def cached_create_engine(dsn: str, **kwargs: Any) -> sa.Engine:
     # max_identifier_length=63 to avoid exceeding postgres' default maximum
+    dsn = resolve_dsn_env_tokens(dsn)
     return sa.create_engine(
         dsn, poolclass=sa.NullPool, max_identifier_length=63, **kwargs
     )
@@ -66,6 +68,8 @@ class DirectTransport(Transport):
 
     @classmethod
     def from_dsn(cls, dsn: str, *args: Any, **kwargs: Any) -> "DirectTransport":
+        # Resolve environment variable placeholders in DSN
+        dsn = resolve_dsn_env_tokens(dsn)
         dsn = cls.check_dsn(dsn)
         if dsn.startswith("sqlite"):
             engine = cls.create_sqlite_engine(dsn)

--- a/tests/cli/test_alembic.py
+++ b/tests/cli/test_alembic.py
@@ -8,8 +8,9 @@ from toolkit.manager.mock import MockManagerClient
 from typer.testing import CliRunner
 
 from ixmp4.cli import app
-from ixmp4.cli.alembic import collect_platforms
+from ixmp4.cli.alembic import collect_platforms, get_alembic_controller
 from ixmp4.conf.settings import Settings
+from ixmp4.core.exceptions import ImproperlyConfigured
 
 
 @pytest.fixture(scope="function")
@@ -81,3 +82,46 @@ class TestAlembicTargets:
         assert result.exit_code == 0
         assert "databases/test-1.sqlite3" in result.output
         assert "databases/test-2.sqlite3" in result.output
+
+    def test_collect_platforms_manager_does_not_require_env_tokens(
+        self,
+        temporary_settings: Settings,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("IXMP4_DIR", raising=False)
+
+        manager_platforms = collect_platforms(
+            temporary_settings, platform=[], toml=False, manager=True
+        )
+        assert len(manager_platforms) == 3
+        assert manager_platforms[0].slug == "dev-public"
+        assert "{env:IXMP4_DIR}" in manager_platforms[0].dsn
+
+
+def test_get_alembic_controller_resolves_dsn_env_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_dsn: str | None = None
+
+    class FakeAlembicController:
+        def __init__(self, dsn: str, *_args: object, **_kwargs: object) -> None:
+            nonlocal captured_dsn
+            captured_dsn = dsn
+
+    monkeypatch.setattr("ixmp4.cli.alembic.AlembicController", FakeAlembicController)
+    monkeypatch.setenv("IXMP4_DB_PASSWORD", "pw")
+
+    get_alembic_controller("postgresql://u:{env:IXMP4_DB_PASSWORD}@db/test")
+    assert captured_dsn == "postgresql://u:pw@db/test"
+
+
+def test_get_alembic_controller_raises_for_missing_dsn_env_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("IXMP4_DB_PASSWORD", raising=False)
+
+    with pytest.raises(
+        ImproperlyConfigured,
+        match=r"Cannot resolve DSN environment variable placeholder\(s\).",
+    ):
+        get_alembic_controller("postgresql://u:{env:IXMP4_DB_PASSWORD}@db/test")

--- a/tests/conf/test_manager.py
+++ b/tests/conf/test_manager.py
@@ -5,6 +5,7 @@ from ixmp4.conf.platforms import ManagerPlatforms
 from ixmp4.core.exceptions import (
     ImproperlyConfigured,
 )
+from ixmp4.transport import DirectTransport
 from tests.fixtures import get_manager_fixtures
 
 
@@ -14,27 +15,37 @@ def mock_manager_client() -> MockManagerClient:
 
 
 class TestManagerPlatforms:
-    def test_get_platform_substitutes_dsn_env_tokens(
+    def test_get_platform_returns_dsn_with_placeholders(
         self, monkeypatch: pytest.MonkeyPatch, mock_manager_client: MockManagerClient
     ) -> None:
         monkeypatch.setenv("IXMP4_DIR", "/tmp/ixmp4")
         manager_platforms = ManagerPlatforms(mock_manager_client)
 
+        # get_platform returns DSN with placeholders (not resolved)
         platform = manager_platforms.get_platform("dev-public")
-        assert platform.dsn == "sqlite:////tmp/ixmp4/databases/dev-public.sqlite3"
+        assert platform.dsn == "sqlite:///{env:IXMP4_DIR}/databases/dev-public.sqlite3"
 
-        # Ensure substitution happens on returned copies only.
+        # Original cached platform still has placeholders
         cached_platform = mock_manager_client.ixmp4.cached_list()[0]
         assert "{env:IXMP4_DIR}" in cached_platform.dsn
 
-    def test_get_platform_raises_for_missing_dsn_env_tokens(
+        # Env var substitution happens when creating the engine
+        transport = DirectTransport.from_dsn(platform.dsn)
+        assert transport is not None
+
+    def test_get_platform_returns_unresolved_dsn_for_missing_env_tokens(
         self, monkeypatch: pytest.MonkeyPatch, mock_manager_client: MockManagerClient
     ) -> None:
         monkeypatch.delenv("IXMP4_DIR", raising=False)
         manager_platforms = ManagerPlatforms(mock_manager_client)
 
+        # get_platform should NOT raise - it returns the raw DSN with placeholders
+        platform = manager_platforms.get_platform("dev-public")
+        assert platform.dsn == "sqlite:///{env:IXMP4_DIR}/databases/dev-public.sqlite3"
+
+        # Error is raised when trying to create the engine
         with pytest.raises(
             ImproperlyConfigured,
             match=r"Cannot resolve DSN environment variable placeholder\(s\).",
         ):
-            manager_platforms.get_platform("dev-public")
+            DirectTransport.from_dsn(platform.dsn)

--- a/tests/conf/test_manager.py
+++ b/tests/conf/test_manager.py
@@ -30,7 +30,7 @@ class TestManagerPlatforms:
         assert "{env:IXMP4_DIR}" in cached_platform.dsn
 
         # Env var substitution happens when creating the engine
-        transport = DirectTransport.from_dsn(platform.dsn)
+        transport = DirectTransport.from_dsn(platform.dsn, ping_database=False)
         assert transport is not None
 
     def test_get_platform_returns_unresolved_dsn_for_missing_env_tokens(

--- a/tests/conf/test_toml.py
+++ b/tests/conf/test_toml.py
@@ -94,7 +94,7 @@ class TestTomlPlatforms(TomlTest):
         assert "{env:IXMP4_TEST_PASSWORD}" in platforms_toml.read_text()
 
         # Env var substitution happens when creating the engine
-        transport = DirectTransport.from_dsn(platform.dsn)
+        transport = DirectTransport.from_dsn(platform.dsn, ping_database=False)
         assert transport is not None
 
     def test_get_platform_returns_unresolved_dsn_for_missing_env_tokens(

--- a/tests/conf/test_toml.py
+++ b/tests/conf/test_toml.py
@@ -12,6 +12,7 @@ from ixmp4.core.exceptions import (
     PlatformNotFound,
     PlatformNotUnique,
 )
+from ixmp4.transport import DirectTransport
 
 
 @pytest.fixture(scope="class")
@@ -73,9 +74,10 @@ class TestTomlPlatforms(TomlTest):
         with pytest.raises(PlatformNotFound):
             toml_platforms.remove_platform("test")
 
-    def test_get_platform_substitutes_dsn_env_tokens(
+    def test_get_platform_returns_dsn_with_placeholders(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # When env var is present, get_platform returns the raw DSN with placeholders
         platforms_toml = tmp_path / "platforms.toml"
         platforms_toml.write_text(
             '[test]\ndsn = "postgresql://user:{env:IXMP4_TEST_PASSWORD}@foo.bar/db"\n'
@@ -83,16 +85,22 @@ class TestTomlPlatforms(TomlTest):
         monkeypatch.setenv("IXMP4_TEST_PASSWORD", "s3cr3t")
 
         platforms = TomlPlatforms(platforms_toml)
-        assert (
-            platforms.get_platform("test").dsn == "postgresql://user:s3cr3t@foo.bar/db"
-        )
+        platform = platforms.get_platform("test")
+
+        # get_platform returns DSN with placeholders (not resolved)
+        assert platform.dsn == "postgresql://user:{env:IXMP4_TEST_PASSWORD}@foo.bar/db"
 
         # Placeholder syntax must remain on disk and never be persisted with secrets.
         assert "{env:IXMP4_TEST_PASSWORD}" in platforms_toml.read_text()
 
-    def test_get_platform_raises_for_missing_dsn_env_tokens(
+        # Env var substitution happens when creating the engine
+        transport = DirectTransport.from_dsn(platform.dsn)
+        assert transport is not None
+
+    def test_get_platform_returns_unresolved_dsn_for_missing_env_tokens(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # When env var is missing, get_platform still returns the DSN with placeholders
         platforms_toml = tmp_path / "platforms.toml"
         platforms_toml.write_text(
             '[test]\ndsn = "postgresql://user:{env:IXMP4_MISSING_PASSWORD}@foo.bar/db"\n'
@@ -100,11 +108,18 @@ class TestTomlPlatforms(TomlTest):
         monkeypatch.delenv("IXMP4_MISSING_PASSWORD", raising=False)
 
         platforms = TomlPlatforms(platforms_toml)
+        # get_platform should NOT raise - it returns the raw DSN
+        platform = platforms.get_platform("test")
+        assert (
+            platform.dsn == "postgresql://user:{env:IXMP4_MISSING_PASSWORD}@foo.bar/db"
+        )
+
+        # Error is raised when trying to create the engine
         with pytest.raises(
             ImproperlyConfigured,
             match=r"Cannot resolve DSN environment variable placeholder\(s\).",
         ):
-            platforms.get_platform("test")
+            DirectTransport.from_dsn(platform.dsn)
 
 
 @pytest.fixture(scope="class")

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
+import sqlalchemy as sa
 
 from ixmp4.base_exceptions import ImproperlyConfigured
 from ixmp4.conf.platforms import PlatformConnectionInfo
@@ -51,3 +52,46 @@ def test_get_transport_falls_back_to_http_on_direct_error(
         cast(PlatformConnectionInfo, _PlatformConnectionInfo())
     )
     assert transport is expected_transport
+
+
+def test_get_transport_falls_back_to_http_on_sqlalchemy_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = Platform.__new__(Platform)
+    platform.settings = cast(Settings, _SettingsStub())
+
+    def _raise_direct_error(dsn: str) -> object:
+        raise sa.exc.OperationalError("SELECT 1", {}, Exception("boom"))
+
+    expected_transport = object()
+
+    def _http_from_url(url: str, settings: object, auth: object) -> object:
+        assert url == "https://example.test"
+        return expected_transport
+
+    monkeypatch.setattr(
+        "ixmp4.core.platform.DirectTransport.from_dsn", _raise_direct_error
+    )
+    monkeypatch.setattr("ixmp4.core.platform.HttpxTransport.from_url", _http_from_url)
+
+    transport = platform.get_transport(
+        cast(PlatformConnectionInfo, _PlatformConnectionInfo())
+    )
+    assert transport is expected_transport
+
+
+def test_get_transport_does_not_fallback_on_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = Platform.__new__(Platform)
+    platform.settings = cast(Settings, _SettingsStub())
+
+    def _raise_direct_error(dsn: str) -> object:
+        raise ValueError("Unrelated incident.")
+
+    monkeypatch.setattr(
+        "ixmp4.core.platform.DirectTransport.from_dsn", _raise_direct_error
+    )
+
+    with pytest.raises(ValueError):
+        platform.get_transport(cast(PlatformConnectionInfo, _PlatformConnectionInfo()))

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from ixmp4.base_exceptions import ImproperlyConfigured
+from ixmp4.conf.platforms import PlatformConnectionInfo
+from ixmp4.conf.settings import Settings
+from ixmp4.core.platform import Platform
+
+
+class _PlatformConnectionInfo:
+    name = "dev"
+    dsn = "postgresql://user:{env:MISSING}@db/test"
+    url = "https://example.test"
+
+
+class _SettingsStub:
+    client = SimpleNamespace()
+
+    def get_credentials(self) -> dict[str, dict[str, str]]:
+        return {"default": {"username": "u", "password": "p"}}
+
+    def get_client_auth(self, cred_dict: dict[str, str]) -> object:
+        return object()
+
+
+def test_get_transport_falls_back_to_http_on_direct_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = Platform.__new__(Platform)
+    platform.settings = cast(Settings, _SettingsStub())
+
+    def _raise_direct_error(dsn: str) -> object:
+        raise ImproperlyConfigured(
+            "Cannot resolve DSN environment variable placeholder(s)."
+        )
+
+    expected_transport = object()
+
+    def _http_from_url(url: str, settings: object, auth: object) -> object:
+        assert url == "https://example.test"
+        return expected_transport
+
+    monkeypatch.setattr(
+        "ixmp4.core.platform.DirectTransport.from_dsn", _raise_direct_error
+    )
+    monkeypatch.setattr("ixmp4.core.platform.HttpxTransport.from_url", _http_from_url)
+
+    transport = platform.get_transport(
+        cast(PlatformConnectionInfo, _PlatformConnectionInfo())
+    )
+    assert transport is expected_transport

--- a/tests/unit/test_procedure.py
+++ b/tests/unit/test_procedure.py
@@ -579,37 +579,37 @@ class TestProcedurePagination:
 
 
 class TestProcedureRouteHandler:
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def demo_transport(self) -> Generator[DirectTransport, None, None]:
         t = DirectTransport.from_dsn("sqlite:///:memory:")
         yield t
         t.close()
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def demo_service(self, demo_transport: DirectTransport) -> DemoService:
         return DemoService(demo_transport)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def paginated_service(
         self, demo_transport: DirectTransport
     ) -> PaginatedDemoService:
         return PaginatedDemoService(demo_transport)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def compute_handler(self) -> ProcedureRouteHandler[Any, Any, Any]:
         return cast(
             ProcedureRouteHandler[Any, Any, Any],
             DemoService.compute.procedure.handlers[DemoService],
         )
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def rename_handler(self) -> ProcedureRouteHandler[Any, Any, Any]:
         return cast(
             ProcedureRouteHandler[Any, Any, Any],
             DemoService.rename.procedure.handlers[DemoService],
         )
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture(scope="class")
     def list_handler(self) -> ProcedureRouteHandler[Any, Any, Any]:
         return cast(
             ProcedureRouteHandler[Any, Any, Any],

--- a/tests/unit/test_server_v1.py
+++ b/tests/unit/test_server_v1.py
@@ -42,6 +42,18 @@ class TestYieldSession:
 
         asyncio.run(_run())
 
+    def test_yield_session_resolves_dsn_env_tokens(self) -> None:
+        """Server-side session creation resolves {env:...} placeholders."""
+        from ixmp4.server.v1 import yield_session
+
+        async def _run() -> None:
+            async with yield_session("sqlite:///{env:IXMP4_SERVER_DB}") as session:
+                assert session is not None
+                session.execute(sa.text("SELECT 1"))
+
+        with mock.patch.dict("os.environ", {"IXMP4_SERVER_DB": ":memory:"}):
+            asyncio.run(_run())
+
 
 class TestGetTransport:
     def test_get_transport_yields_direct_transport_when_unauthenticated(self) -> None:

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -53,7 +53,7 @@ def test_cached_create_engine_uses_cache() -> None:
 
 
 def test_direct_transport_handles_bound_and_unbound_sessions() -> None:
-    unbound = DirectTransport(transport_module.Session())
+    unbound = DirectTransport(transport_module.Session(), ping_database=False)
     assert unbound.get_database_url() is None
     assert unbound.get_engine_info() == ""
     assert str(unbound) == "<DirectTransport >"


### PR DESCRIPTION
Previous ixmp4 versions would never try to connect to the database directly so this was never a problem, now a fallback is needed here. Also refactors all the resolve_dsn_env_tokens calls to where they are immediately needed so leaking dsns with secrets is less likely. DirectTransport now sends a simple ping query upon instantiation to catch any connection errors (can be disabled with ping_database=False).