### PR TITLE
Fix Exception Logging Behaviour

### DIFF
--- a/ixmp4/conf/__init__.py
+++ b/ixmp4/conf/__init__.py
@@ -33,6 +33,7 @@ For the convenience, a local `.env` file can be used to configure the settings o
     IXMP4_SERVER__SECRET_HS256=changeme
     IXMP4_SERVER__MAX_PAGE_SIZE=10000
     IXMP4_SERVER__DEFAULT_PAGE_SIZE=5000
+    IXMP4_SERVER__LOG_EXCEPTIONS=always
 
     # Client Settings
     IXMP4_CLIENT__DEFAULT_UPLOAD_CHUNK_SIZE=10000

--- a/ixmp4/conf/settings.py
+++ b/ixmp4/conf/settings.py
@@ -41,6 +41,7 @@ class ServerSettings(BaseSettings):
 
     max_page_size: int = 10_000
     default_page_size: int = 5_000
+    log_exceptions: Literal["never", "always", "debug"] = "always"
 
     @model_validator(mode="after")
     def setup(self) -> "ServerSettings":

--- a/ixmp4/server/__init__.py
+++ b/ixmp4/server/__init__.py
@@ -19,6 +19,7 @@ import pydantic as pyd
 from litestar import Controller, Litestar, get
 from litestar.config.cors import CORSConfig
 from litestar.datastructures import State
+from litestar.logging import LoggingConfig
 from litestar.openapi import OpenAPIConfig
 from litestar.openapi.plugins import ScalarRenderPlugin
 from litestar.openapi.spec.components import Components
@@ -85,6 +86,11 @@ class Ixmp4Server(object):
             render_plugins=[ScalarRenderPlugin(path="/")],
             components=Components(security_schemes={"default": bearer_scheme}),
         )
+        logging_config = LoggingConfig(
+            log_exceptions=settings.log_exceptions,
+            # expected client exceptions
+            disable_stack_trace={422, 409, 404, 403, 401, 400},
+        )
 
         if settings.secret_hs256 is None:
             logger.warning(
@@ -101,6 +107,7 @@ class Ixmp4Server(object):
             route_handlers=[ServerContoller, self.v1.router],
             openapi_config=openapi_config,
             on_startup=[self.v1.on_startup],
+            logging_config=logging_config,
         )
 
     def simulate_startup(self) -> None:


### PR DESCRIPTION
Currently the server is only able to log exceptions in debug mode. 
This adds a configuration variable `ServerSettings.log_exceptions`/`IXMP4_SERVER__LOG_EXCEPTIONS` which controls the litestar logging config. It can be "always" (default) "never" or "debug". [litestar docs](https://docs.litestar.dev/2/reference/logging/config.html#litestar.logging.config.LoggingConfig.log_exceptions)
Some status codes are never logged as they are expected client exceptions: 422, 409, 404, 403, 401, 400