### PR TITLE
Remove deprecated `tabulate_manager_platforms`

### DIFF
--- a/ixmp4/cli/platforms.py
+++ b/ixmp4/cli/platforms.py
@@ -311,27 +311,3 @@ def generate_data(generator: MockDataGenerator) -> None:
         )
         for df in generator.yield_datapoints(runs, variable_names, units, regions):
             progress.advance(task, len(df))
-
-
-def tabulate_manager_platforms(
-    platforms: list[Any],
-) -> None:
-    """Prints manager platforms to the console. Only used for pyam compatibility.
-    TODO: Remove once no longer needed."""
-    manager_url_str = typer.style(Settings().manager_url, fg=typer.colors.CYAN)
-
-    manager_table = Table(
-        Column("Name", max_width=24, no_wrap=True),
-        "Access",
-        Column("Notice", max_width=48, no_wrap=True),
-        box=box.SIMPLE,
-        title="via manager api " + manager_url_str,
-        title_justify="left",
-        caption="Total: " + typer.style(str(len(platforms)), fg=typer.colors.GREEN),
-        caption_justify="left",
-    )
-    for mp in platforms:
-        manager_table.add_row(mp.slug, str(mp.accessibility).lower(), mp.notice)
-    console.print()
-    console.print(manager_table)
-    console.print()

--- a/tests/cli/test_platforms.py
+++ b/tests/cli/test_platforms.py
@@ -12,7 +12,6 @@ from rich.console import Console
 from typer.testing import CliRunner
 
 from ixmp4.cli import app
-from ixmp4.cli.platforms import tabulate_manager_platforms
 from ixmp4.conf.settings import Settings
 
 
@@ -262,44 +261,3 @@ class TestPlatformGenerateCLI:
 
         # We simply test whether the generate command errors
         assert result.exit_code > 0
-
-
-def test_tabulate_manager_platforms(monkeypatch: pytest.MonkeyPatch) -> None:
-    output_buffer = StringIO()
-    console = Console(
-        file=output_buffer, force_terminal=False, color_system=None, width=120
-    )
-    monkeypatch.setattr("ixmp4.cli.platforms.console", console)
-    monkeypatch.setattr(
-        "ixmp4.cli.platforms.Settings",
-        lambda: SimpleNamespace(manager_url="https://manager.example"),
-    )
-
-    tabulate_manager_platforms(
-        [
-            SimpleNamespace(
-                name="Alpha Name",
-                slug="alpha",
-                accessibility="PUBLIC",
-                notice="Primary platform",
-            ),
-            SimpleNamespace(
-                name="Beta Name",
-                slug="beta",
-                accessibility="PRIVATE",
-                notice="Restricted",
-            ),
-        ]
-    )
-
-    output = output_buffer.getvalue()
-    normalized_output = " ".join(re.sub(r"\x1b\[[0-9;]*m", "", output).split())
-
-    assert "via manager api https://manager.example" in normalized_output
-    assert "Total: 2" in normalized_output
-    assert "alpha" in normalized_output
-    assert "public" in normalized_output
-    assert "Primary platform" in normalized_output
-    assert "beta" in normalized_output
-    assert "private" in normalized_output
-    assert "Restricted" in normalized_output

--- a/tests/cli/test_platforms.py
+++ b/tests/cli/test_platforms.py
@@ -1,14 +1,10 @@
 import os
-import re
-from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import SimpleNamespace
 from typing import Generator
 from unittest import mock
 
 import pytest
-from rich.console import Console
 from typer.testing import CliRunner
 
 from ixmp4.cli import app

--- a/tests/lib/test_pyam.py
+++ b/tests/lib/test_pyam.py
@@ -114,19 +114,6 @@ class TestPyam_3_3_1:
 
         assert ixmp4.Run.Filter is FacadeRunFilter
 
-    def test_tabulate_manager_platforms_importable(self) -> None:
-        from ixmp4.cli.platforms import tabulate_manager_platforms
-
-        assert callable(tabulate_manager_platforms)
-
-    def test_tabulate_manager_platforms_accepts_platforms_argument(self) -> None:
-        import inspect
-
-        from ixmp4.cli.platforms import tabulate_manager_platforms
-
-        params = inspect.signature(tabulate_manager_platforms).parameters
-        assert "platforms" in params
-
     def test_settings_importable(self) -> None:
         from ixmp4.conf.settings import Settings
 


### PR DESCRIPTION
Legacy function `tabulate_manager_platforms()` removed from latest pyam with release v3.3.2, https://github.com/IAMconsortium/pyam/releases/tag/v3.3.2