### PR TITLE
Fix accidental masking of DSN passed to AlembicController

### DIFF
--- a/ixmp4/transport.py
+++ b/ixmp4/transport.py
@@ -223,8 +223,10 @@ class DirectTransport(Transport):
         assert self.session.bind is not None
         engine = self.session.bind.engine
         inspector = sa.inspect(engine)
-        controller = get_alembic_controller(engine.url.render_as_string())
-
+        # hide_password=False so we dont try to connect to a masked dsn
+        controller = get_alembic_controller(
+            engine.url.render_as_string(hide_password=False)
+        )
         if not inspector.has_table("alembic_version"):
             raise ImproperlyConfigured(
                 "Database schema version check failed because the table "

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -338,6 +338,45 @@ def test_direct_transport_check_alembic_version_requires_current_revision(
         DirectTransport(session, check_alembic_version=True)
 
 
+def test_direct_transport_check_alembic_version_uses_unmasked_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    fake_controller = SimpleNamespace(
+        get_database_revision=lambda: "rev1",
+        get_head_revision=lambda: "rev1",
+        list_revisions=lambda: [SimpleNamespace(revision="rev1")],
+    )
+
+    def fake_get_alembic_controller(dsn: str) -> SimpleNamespace:
+        captured["dsn"] = dsn
+        return fake_controller
+
+    monkeypatch.setattr(
+        transport_module,
+        "get_alembic_controller",
+        fake_get_alembic_controller,
+    )
+    monkeypatch.setattr(
+        sa,
+        "inspect",
+        lambda _engine: SimpleNamespace(has_table=lambda _name: True),
+    )
+
+    fake_engine = SimpleNamespace(
+        url=sa.make_url("postgresql+psycopg://user:secret@example.test/db")
+    )
+    fake_bind = SimpleNamespace(engine=fake_engine)
+    fake_session = SimpleNamespace(bind=fake_bind)
+
+    DirectTransport(
+        cast(Any, fake_session), ping_database=False, check_alembic_version=True
+    )
+
+    assert captured["dsn"] == "postgresql+psycopg://user:secret@example.test/db"
+
+
 def test_authorized_transport_string_includes_user_and_platform() -> None:
     session = transport_module.Session(bind=sa.create_engine("sqlite:///:memory:"))
     transport = AuthorizedTransport(


### PR DESCRIPTION
Fixes a bug I noticed in #242 which causes the alembic version check to fail if the database DSN contains a secret.
Adds `hide_password=False` to the render_as_string call so the full unmasked dsn is used.
Also adds a unit test to assert that it works. 