### PR TITLE
Adjust HTTP Endpoints

### DIFF
--- a/ixmp4/data/iamc/variable/service.py
+++ b/ixmp4/data/iamc/variable/service.py
@@ -98,7 +98,9 @@ class VariableService(DocsService, GetByIdService):
     ) -> None:
         auth_ctx.has_management_permission(platform, raise_exc=Forbidden)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get_by_name(self, name: str) -> Variable:
         """Retrieves a variable by its name.
 

--- a/ixmp4/data/meta/service.py
+++ b/ixmp4/data/meta/service.py
@@ -84,7 +84,9 @@ class RunMetaEntryService(Service):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, key: str) -> RunMetaEntry:
         """Retrieves a metadata entry by the run id and key.
 

--- a/ixmp4/data/model/service.py
+++ b/ixmp4/data/model/service.py
@@ -91,7 +91,9 @@ class ModelService(DocsService, GetByIdService):
     ) -> None:
         auth_ctx.has_management_permission(platform, raise_exc=Forbidden)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get_by_name(self, name: str) -> Model:
         """Retrieves a model by its name.
 

--- a/ixmp4/data/optimization/equation/service.py
+++ b/ixmp4/data/optimization/equation/service.py
@@ -140,7 +140,9 @@ class EquationService(DocsService, IndexSetAssociatedService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, name: str) -> Equation:
         """Retrieves a equation by its name and run_id.
 

--- a/ixmp4/data/optimization/indexset/service.py
+++ b/ixmp4/data/optimization/indexset/service.py
@@ -119,7 +119,9 @@ class IndexSetService(DocsService, GetByIdService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, name: str) -> IndexSet:
         """Retrieves an indexset by its name and run_id.
 

--- a/ixmp4/data/optimization/parameter/service.py
+++ b/ixmp4/data/optimization/parameter/service.py
@@ -141,7 +141,9 @@ class ParameterService(DocsService, IndexSetAssociatedService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, name: str) -> Parameter:
         """Retrieves a parameter by its name and run_id.
 

--- a/ixmp4/data/optimization/scalar/service.py
+++ b/ixmp4/data/optimization/scalar/service.py
@@ -103,7 +103,9 @@ class ScalarService(DocsService, GetByIdService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, name: str) -> Scalar:
         """Retrieves a scalar by its name and run_id.
 

--- a/ixmp4/data/optimization/table/service.py
+++ b/ixmp4/data/optimization/table/service.py
@@ -146,7 +146,9 @@ class TableService(DocsService, IndexSetAssociatedService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, name: str) -> Table:
         """Retrieves a table by its name and run_id.
 

--- a/ixmp4/data/optimization/variable/service.py
+++ b/ixmp4/data/optimization/variable/service.py
@@ -124,7 +124,9 @@ class VariableService(DocsService, IndexSetAssociatedService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, run_id: int, name: str) -> Variable:
         """Retrieves a table by its name and run_id.
 

--- a/ixmp4/data/region/service.py
+++ b/ixmp4/data/region/service.py
@@ -102,7 +102,9 @@ class RegionService(DocsService, GetByIdService):
     ) -> None:
         auth_ctx.has_management_permission(platform, raise_exc=Forbidden)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get_by_name(self, name: str) -> Region:
         """Retrieves a region by its name.
 

--- a/ixmp4/data/run/service.py
+++ b/ixmp4/data/run/service.py
@@ -140,7 +140,9 @@ class RunService(GetByIdService):
     ) -> None:
         auth_ctx.has_management_permission(platform, raise_exc=Forbidden)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get(self, model_name: str, scenario_name: str, version: int) -> Run:
         """Retrieves a run.
 
@@ -205,7 +207,9 @@ class RunService(GetByIdService):
         except NoDefaultRunVersion:
             return self.create(model_name, scenario_name)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get_default_version(self, model_name: str, scenario_name: str) -> Run:
         """Retrieves a run's default version.
 
@@ -423,7 +427,7 @@ class RunService(GetByIdService):
             pagination=pagination,
         )
 
-    @procedure(Http(methods=("POST",)))
+    @procedure(Http(path="/{id:int}/set-as-default", methods=("POST",)))
     def set_as_default_version(self, id: int) -> None:
         """Sets a run as the default version for a (model, scenario) combination.
 
@@ -449,7 +453,7 @@ class RunService(GetByIdService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    @procedure(Http(path="/{id:int}/unset-as-default", methods=("POST",)))
     def unset_as_default_version(self, id: int) -> None:
         """Unsets a run as the default version leaving no
         default version for a (model, scenario) combination.
@@ -476,7 +480,7 @@ class RunService(GetByIdService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    @procedure(Http(path="/{id:int}/revert", methods=("POST",)))
     def revert(
         self, id: int, transaction__id: int, revert_platform: bool = False
     ) -> None:
@@ -517,7 +521,7 @@ class RunService(GetByIdService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    @procedure(Http(path="/{id:int}/lock", methods=("POST",)))
     def lock(self, id: int) -> Run:
         """Locks a run at the current transaction (via `transaction__id`).
 
@@ -552,7 +556,7 @@ class RunService(GetByIdService):
             platform, models=[run.model.name], raise_exc=Forbidden
         )
 
-    @procedure(Http(methods=("POST",)))
+    @procedure(Http(path="/{id:int}/unlock", methods=("POST",)))
     def unlock(self, id: int) -> Run:
         """Locks a run at the current transaction (via `transaction__id`).
 

--- a/ixmp4/data/scenario/service.py
+++ b/ixmp4/data/scenario/service.py
@@ -94,7 +94,9 @@ class ScenarioService(DocsService, GetByIdService):
     ) -> None:
         auth_ctx.has_management_permission(platform, raise_exc=Forbidden)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get_by_name(self, name: str) -> Scenario:
         """Retrieves a scenario by its name.
 

--- a/ixmp4/data/services/procedure/endpoint.py
+++ b/ixmp4/data/services/procedure/endpoint.py
@@ -96,8 +96,7 @@ class ProcedureRouteHandler(HTTPRouteHandler, Generic[ServiceT, Params, ReturnT]
         self.name = ".".join(
             [service_class.__module__, service_class.__name__, procedure.func.__name__]
         )
-        self.operation_id = self.name
-
+        self.operation_id = self.get_operation_id
         self.path_fields = self.get_path_fields(path)
         self.supports_body = not ("GET" in methods or "HEAD" in methods)
 
@@ -119,6 +118,17 @@ class ProcedureRouteHandler(HTTPRouteHandler, Generic[ServiceT, Params, ReturnT]
 
     def get_path_fields(self, path: str) -> list[str]:
         return [name for (_, name, *_) in Formatter().parse(path) if name is not None]
+
+    def get_operation_id(
+        self,
+        _route_handler: HTTPRouteHandler,
+        http_method: Method,
+        _path_components: list[Any],
+    ) -> str:
+        if len(self.http_methods) == 1:
+            return str(self.name)
+        method_name = str(http_method).split(".")[-1].lower()
+        return f"{self.name}:{method_name}"
 
     def build_payload_model(self, path_fields: list[str]) -> type[pyd.BaseModel]:
         def callback(index: int, name: str, param: Any) -> Literal["skip"] | None:

--- a/ixmp4/data/unit/service.py
+++ b/ixmp4/data/unit/service.py
@@ -93,7 +93,9 @@ class UnitService(DocsService, GetByIdService):
     ) -> None:
         auth_ctx.has_management_permission(platform, raise_exc=Forbidden)
 
-    @procedure(Http(methods=("POST",)))
+    # NOTE: Moving to PATCH or GET for all read-only endpoints
+    # TODO: Remove before 1.0.0
+    @procedure(Http(methods=("PATCH", "POST")))
     def get_by_name(self, name: str) -> Unit:
         """Retrieves a unit by its name.
 

--- a/tests/api/test_iamc_variable_api.py
+++ b/tests/api/test_iamc_variable_api.py
@@ -60,12 +60,13 @@ class TestIamcVariableLookup(IamcVariableApiTest):
         assert got["id"] == variable.id
         assert got["name"] == variable.name
 
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
     def test_iamc_variable_get_by_name(
-        self, client: httpx.Client, variable: Variable
+        self, client: httpx.Client, variable: Variable, method: str
     ) -> None:
         got = self.request(
             client,
-            "POST",
+            method,
             "/iamc/variables/get-by-name",
             json={"name": variable.name},
         ).json()

--- a/tests/api/test_model_api.py
+++ b/tests/api/test_model_api.py
@@ -36,9 +36,12 @@ class TestModelLookup(ModelApiTest):
         assert got["id"] == model.id
         assert got["name"] == model.name
 
-    def test_model_get_by_name(self, client: httpx.Client, model: Model) -> None:
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    def test_model_get_by_name(
+        self, client: httpx.Client, model: Model, method: str
+    ) -> None:
         got = self.request(
-            client, "POST", "/models/get-by-name", json={"name": model.name}
+            client, method, "/models/get-by-name", json={"name": model.name}
         ).json()
 
         assert got["id"] == model.id

--- a/tests/api/test_openapi_api.py
+++ b/tests/api/test_openapi_api.py
@@ -71,7 +71,6 @@ def collect_service_endpoints() -> list[CollectedEndpoint]:
                 if methods == ["OPTIONS"]:
                     continue
 
-                method = methods[0]
                 route_path = next(iter(handler.paths))
                 relative_path = _normalize_openapi_path(
                     "/" + _join_relative_path(service_class.router_prefix, route_path)
@@ -82,18 +81,30 @@ def collect_service_endpoints() -> list[CollectedEndpoint]:
                 summary = getattr(handler, "summary", "") or ""
                 signature = _get_service_signature(service_class, summary)
                 source = "compatibility" if summary == "query" else "service"
+                operation_id = getattr(handler, "operation_id", None)
 
-                endpoints.append(
-                    CollectedEndpoint(
-                        source=source,
-                        method=method.lower(),
-                        schema_path=schema_path,
-                        relative_path=relative_path,
-                        summary=summary,
-                        operation_id=getattr(handler, "operation_id", None),
-                        signature=signature,
+                for method in methods:
+                    expected_operation_id: str | None
+                    if callable(operation_id):
+                        expected_operation_id = operation_id(
+                            handler, method, route.path_components
+                        )
+                    elif isinstance(operation_id, str):
+                        expected_operation_id = operation_id
+                    else:
+                        expected_operation_id = None
+
+                    endpoints.append(
+                        CollectedEndpoint(
+                            source=source,
+                            method=method.lower(),
+                            schema_path=schema_path,
+                            relative_path=relative_path,
+                            summary=summary,
+                            operation_id=expected_operation_id,
+                            signature=signature,
+                        )
                     )
-                )
 
     return endpoints
 

--- a/tests/api/test_optimization_equation_api.py
+++ b/tests/api/test_optimization_equation_api.py
@@ -25,7 +25,7 @@ class TestEquationCreate(EquationApiTest):
     def indexset(self, direct_transport: DirectTransport, run: Run) -> IndexSet:
         return IndexSetService(direct_transport).create(run.id, "IndexSet")
 
-    def test_equation_create_and_tabulate(
+    def test_equation_create_get_and_tabulate(
         self, client: httpx.Client, run: Run, indexset: IndexSet
     ) -> None:
         created = self.request(
@@ -42,6 +42,15 @@ class TestEquationCreate(EquationApiTest):
 
         assert created["id"] == 1
         assert created["name"] == "Equation"
+
+        for method in ["POST", "PATCH"]:
+            got = self.request(
+                client,
+                method,
+                "/optimization/equations/get",
+                json={"run_id": run.id, "name": "Equation"},
+            ).json()
+            assert got["id"] == created["id"]
 
         tabulated = self.request(
             client, "PATCH", "/optimization/equations/tabulate", json={}

--- a/tests/api/test_optimization_indexset_api.py
+++ b/tests/api/test_optimization_indexset_api.py
@@ -47,9 +47,18 @@ class TestIndexSetDataAndDocs(IndexSetApiTest):
         run = RunService(direct_transport).create("Model", "Scenario")
         return direct_service.create(run.id, "IndexSet")
 
-    def test_indexset_add_and_get_data(
+    def test_indexset_add_get_and_get_data(
         self, client: httpx.Client, indexset: IndexSet
     ) -> None:
+        for method in ["POST", "PATCH"]:
+            got = self.request(
+                client,
+                method,
+                "/optimization/indexsets/get",
+                json={"run_id": indexset.run__id, "name": indexset.name},
+            ).json()
+            assert got["id"] == indexset.id
+
         self.request(
             client,
             "POST",

--- a/tests/api/test_optimization_parameter_api.py
+++ b/tests/api/test_optimization_parameter_api.py
@@ -25,7 +25,7 @@ class TestParameterCreate(ParameterApiTest):
     def indexset(self, direct_transport: DirectTransport, run: Run) -> IndexSet:
         return IndexSetService(direct_transport).create(run.id, "IndexSet")
 
-    def test_parameter_create_and_tabulate(
+    def test_parameter_create_get_and_tabulate(
         self, client: httpx.Client, run: Run, indexset: IndexSet
     ) -> None:
         created = self.request(
@@ -41,6 +41,15 @@ class TestParameterCreate(ParameterApiTest):
 
         assert created["id"] == 1
         assert created["name"] == "Parameter"
+
+        for method in ["POST", "PATCH"]:
+            got = self.request(
+                client,
+                method,
+                "/optimization/parameters/get",
+                json={"run_id": run.id, "name": "Parameter"},
+            ).json()
+            assert got["id"] == created["id"]
 
         tabulated = self.request(
             client, "PATCH", "/optimization/parameters/tabulate", json={}

--- a/tests/api/test_optimization_scalar_api.py
+++ b/tests/api/test_optimization_scalar_api.py
@@ -25,7 +25,7 @@ class TestScalarCreateAndUpdate(ScalarApiTest):
     def unit(self, direct_transport: DirectTransport) -> Unit:
         return UnitService(direct_transport).create("Unit")
 
-    def test_scalar_create_update_and_tabulate(
+    def test_scalar_create_get_update_and_tabulate(
         self, client: httpx.Client, run: Run, unit: Unit
     ) -> None:
         created = self.request(
@@ -42,6 +42,15 @@ class TestScalarCreateAndUpdate(ScalarApiTest):
 
         assert created["id"] == 1
         assert created["name"] == "Scalar"
+
+        for method in ["POST", "PATCH"]:
+            got = self.request(
+                client,
+                method,
+                "/optimization/scalars/get",
+                json={"run_id": run.id, "name": "Scalar"},
+            ).json()
+            assert got["id"] == created["id"]
 
         updated = self.request(
             client,

--- a/tests/api/test_optimization_table_api.py
+++ b/tests/api/test_optimization_table_api.py
@@ -25,7 +25,7 @@ class TestTableCreate(TableApiTest):
     def indexset(self, direct_transport: DirectTransport, run: Run) -> IndexSet:
         return IndexSetService(direct_transport).create(run.id, "IndexSet")
 
-    def test_table_create_and_tabulate(
+    def test_table_create_get_and_tabulate(
         self, client: httpx.Client, run: Run, indexset: IndexSet
     ) -> None:
         created = self.request(
@@ -42,6 +42,15 @@ class TestTableCreate(TableApiTest):
 
         assert created["id"] == 1
         assert created["name"] == "Table"
+
+        for method in ["POST", "PATCH"]:
+            got = self.request(
+                client,
+                method,
+                "/optimization/tables/get",
+                json={"run_id": run.id, "name": "Table"},
+            ).json()
+            assert got["id"] == created["id"]
 
         tabulated = self.request(
             client, "PATCH", "/optimization/tables/tabulate", json={}

--- a/tests/api/test_optimization_variable_api.py
+++ b/tests/api/test_optimization_variable_api.py
@@ -25,7 +25,7 @@ class TestOptimizationVariableCreate(OptimizationVariableApiTest):
     def indexset(self, direct_transport: DirectTransport, run: Run) -> IndexSet:
         return IndexSetService(direct_transport).create(run.id, "IndexSet")
 
-    def test_optimization_variable_create_and_tabulate(
+    def test_optimization_variable_create_get_and_tabulate(
         self, client: httpx.Client, run: Run, indexset: IndexSet
     ) -> None:
         created = self.request(
@@ -42,6 +42,15 @@ class TestOptimizationVariableCreate(OptimizationVariableApiTest):
 
         assert created["id"] == 1
         assert created["name"] == "Variable"
+
+        for method in ["POST", "PATCH"]:
+            got = self.request(
+                client,
+                method,
+                "/optimization/variables/get",
+                json={"run_id": run.id, "name": "Variable"},
+            ).json()
+            assert got["id"] == created["id"]
 
         tabulated = self.request(
             client, "PATCH", "/optimization/variables/tabulate", json={}

--- a/tests/api/test_region_api.py
+++ b/tests/api/test_region_api.py
@@ -43,9 +43,12 @@ class TestRegionLookup(RegionApiTest):
         assert got["name"] == region.name
         assert got["hierarchy"] == region.hierarchy
 
-    def test_region_get_by_name(self, client: httpx.Client, region: Region) -> None:
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    def test_region_get_by_name(
+        self, client: httpx.Client, region: Region, method: str
+    ) -> None:
         got = self.request(
-            client, "POST", "/regions/get-by-name", json={"name": region.name}
+            client, method, "/regions/get-by-name", json={"name": region.name}
         ).json()
 
         assert got["id"] == region.id

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -37,10 +37,11 @@ class TestRunLookup(RunApiTest):
     def run(self, direct_service: RunService) -> Run:
         return direct_service.create("Model", "Scenario")
 
-    def test_run_get(self, client: httpx.Client, run: Run) -> None:
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    def test_run_get(self, client: httpx.Client, run: Run, method: str) -> None:
         got = self.request(
             client,
-            "POST",
+            method,
             "/runs/get",
             json={"model_name": "Model", "scenario_name": "Scenario", "version": 1},
         ).json()
@@ -125,32 +126,27 @@ class TestRunState(RunApiTest):
         return direct_service.create("Model", "Scenario")
 
     def test_run_default_version(self, client: httpx.Client, run: Run) -> None:
-        self.request(
-            client, "POST", "/runs/set-as-default-version", json={"id": run.id}
-        )
-        default_run = self.request(
-            client,
-            "POST",
-            "/runs/get-default-version",
-            json={"model_name": "Model", "scenario_name": "Scenario"},
-        ).json()
+        self.request(client, "POST", f"/runs/{run.id}/set-as-default")
+        for method in ["POST", "PATCH"]:
+            default_run = self.request(
+                client,
+                method,
+                "/runs/get-default-version",
+                json={"model_name": "Model", "scenario_name": "Scenario"},
+            ).json()
 
-        assert default_run["id"] == run.id
-        assert default_run["is_default"] is True
+            assert default_run["id"] == run.id
+            assert default_run["is_default"] is True
 
-        self.request(
-            client, "POST", "/runs/unset-as-default-version", json={"id": run.id}
-        )
+        self.request(client, "POST", f"/runs/{run.id}/unset-as-default")
         unset = self.request(client, "GET", f"/runs/{run.id}").json()
         assert unset["is_default"] is False
 
     def test_run_lock_and_unlock(self, client: httpx.Client, run: Run) -> None:
-        locked = self.request(client, "POST", "/runs/lock", json={"id": run.id}).json()
+        locked = self.request(client, "POST", f"/runs/{run.id}/lock").json()
         assert locked["id"] == run.id
         assert locked["lock_transaction"] is not None
 
-        unlocked = self.request(
-            client, "POST", "/runs/unlock", json={"id": run.id}
-        ).json()
+        unlocked = self.request(client, "POST", f"/runs/{run.id}/unlock").json()
         assert unlocked["id"] == run.id
         assert unlocked["lock_transaction"] is None

--- a/tests/api/test_run_meta_api.py
+++ b/tests/api/test_run_meta_api.py
@@ -56,12 +56,17 @@ class TestRunMetaLookupAndQuery(RunMetaApiTest):
     def meta_entry(self, direct_service: RunMetaEntryService, run: Run) -> RunMetaEntry:
         return direct_service.create(run.id, "category", "demo")
 
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
     def test_run_meta_get(
-        self, client: httpx.Client, meta_entry: RunMetaEntry, run: Run
+        self,
+        client: httpx.Client,
+        meta_entry: RunMetaEntry,
+        run: Run,
+        method: str,
     ) -> None:
         got = self.request(
             client,
-            "POST",
+            method,
             "/meta/get",
             json={"run_id": run.id, "key": meta_entry.key},
         ).json()

--- a/tests/api/test_scenario_api.py
+++ b/tests/api/test_scenario_api.py
@@ -38,11 +38,15 @@ class TestScenarioLookup(ScenarioApiTest):
         assert got["id"] == scenario.id
         assert got["name"] == scenario.name
 
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
     def test_scenario_get_by_name(
-        self, client: httpx.Client, scenario: Scenario
+        self, client: httpx.Client, scenario: Scenario, method: str
     ) -> None:
         got = self.request(
-            client, "POST", "/scenarios/get-by-name", json={"name": scenario.name}
+            client,
+            method,
+            "/scenarios/get-by-name",
+            json={"name": scenario.name},
         ).json()
 
         assert got["id"] == scenario.id

--- a/tests/api/test_unit_api.py
+++ b/tests/api/test_unit_api.py
@@ -36,9 +36,12 @@ class TestUnitLookup(UnitApiTest):
         assert got["id"] == unit.id
         assert got["name"] == unit.name
 
-    def test_unit_get_by_name(self, client: httpx.Client, unit: Unit) -> None:
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    def test_unit_get_by_name(
+        self, client: httpx.Client, unit: Unit, method: str
+    ) -> None:
         got = self.request(
-            client, "POST", "/units/get-by-name", json={"name": unit.name}
+            client, method, "/units/get-by-name", json={"name": unit.name}
         ).json()
 
         assert got["id"] == unit.id


### PR DESCRIPTION
… so read-only procedures only use PATCH or GET verbs and procedures with "id" as the first argument have it in the endpoint path. 
This has the advantage that putting the ixmp4 http api in read-only mode is as simple as only allowing those two verbs on the web server.

| procedure | endpoint  |
|---|---|
| UnitService.get_by_name | /units/get-by-name [POST] -> /units/get-by-name [PATCH, POST] |
| ScenarioService.get_by_name | /scenarios/get-by-name [POST] -> /scenarios/get-by-name [PATCH, POST] |
| RegionService.get_by_name | /regions/get-by-name [POST] -> /regions/get-by-name [PATCH, POST] |
| ModelService.get_by_name | /models/get-by-name [POST] -> /models/get-by-name [PATCH, POST] |
| RunMetaEntryService.get | /meta/get [POST] -> /meta/get [PATCH, POST] |
| RunService.get | /runs/get [POST] -> /runs/get [PATCH, POST] |
| RunService.get_default_version | /runs/get-default-version [POST] -> /runs/get-default-version [PATCH, POST] |
| VariableService.get_by_name (IAMC) | /iamc/variables/get-by-name [POST] -> /iamc/variables/get-by-name [PATCH, POST] |
| EquationService.get | /optimization/equations/get [POST] -> /optimization/equations/get [PATCH, POST] |
| IndexSetService.get | /optimization/indexsets/get [POST] -> /optimization/indexsets/get [PATCH, POST] |
| ParameterService.get | /optimization/parameters/get [POST] -> /optimization/parameters/get [PATCH, POST] |
| ScalarService.get | /optimization/scalars/get [POST] -> /optimization/scalars/get [PATCH, POST] |
| TableService.get | /optimization/tables/get [POST] -> /optimization/tables/get [PATCH, POST] |
| VariableService.get (Optimization) | /optimization/variables/get [POST] -> /optimization/variables/get [PATCH, POST] |
| RunService.set_as_default_version | /runs/set-as-default-version [POST] -> /runs/{id:int}/set-as-default [POST] |
| RunService.unset_as_default_version | /runs/unset-as-default-version [POST] -> /runs/{id:int}/unset-as-default [POST] |
| RunService.revert | /runs/revert [POST] -> /runs/{id:int}/revert [POST] |
| RunService.lock | /runs/lock [POST] -> /runs/{id:int}/lock [POST] |
| RunService.unlock | /runs/unlock [POST] -> /runs/{id:int}/unlock [POST] |
