### PR TITLE
Add IAMC DataFrame Input Tests

### DIFF
--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -18,46 +18,16 @@ from .variable import VariableServiceFacade
 if TYPE_CHECKING:
     from ixmp4.core import run
 
-MAP_STEP_COLUMN = {
-    "ANNUAL": "step_year",
-    "CATEGORICAL": "step_year",
-    "DATETIME": "step_datetime",
-}
-
-
-def _convert_to_std_format(
-    df: pd.DataFrame, join_runs: bool, join_run_id: bool
-) -> pd.DataFrame:
-    df.rename(columns={"step_category": "subannual"}, inplace=True)
-
-    if set(df.type.unique()).issubset(["ANNUAL", "CATEGORICAL"]):
-        df.rename(columns={"step_year": "year"}, inplace=True)
-        time_col = "year"
-    else:
-        T = TypeVar("T", bool, float, int, str)
-
-        def map_step_column(df: "pd.Series[T]") -> "pd.Series[T]":
-            df["time"] = df[MAP_STEP_COLUMN[str(df.type)]]
-            return df
-
-        df = df.apply(map_step_column, axis=1)
-        time_col = "time"
-
-    columns = []
-    if join_run_id and "run__id" in df.columns:
-        columns.append("run__id")
-    if join_runs:
-        columns.extend(["model", "scenario", "version"])
-    columns += ["region", "variable", "unit"]
-    if time_col in df.columns:
-        columns += [time_col]
-    if "subannual" in df.columns:
-        columns += ["subannual"]
-    return df[columns + ["value"]]
-
 
 class IamcDataFacade(object):
-    def _rename_arg_cols(self, df: pd.DataFrame) -> pd.DataFrame:
+    _MAP_STEP_COLUMN = {
+        "ANNUAL": "step_year",
+        "CATEGORICAL": "step_year",
+        "DATETIME": "step_datetime",
+    }
+
+    @staticmethod
+    def _rename_arg_cols(df: pd.DataFrame) -> pd.DataFrame:
         return df.rename(
             columns={
                 "year": "step_year",
@@ -67,6 +37,37 @@ class IamcDataFacade(object):
                 "time": "step_datetime",
             }
         )
+
+    @classmethod
+    def _convert_to_std_format(
+        cls, df: pd.DataFrame, join_runs: bool, join_run_id: bool
+    ) -> pd.DataFrame:
+        df.rename(columns={"step_category": "subannual"}, inplace=True)
+
+        if set(df.type.unique()).issubset(["ANNUAL", "CATEGORICAL"]):
+            df.rename(columns={"step_year": "year"}, inplace=True)
+            time_col = "year"
+        else:
+            T = TypeVar("T", bool, float, int, str)
+
+            def map_step_column(df: "pd.Series[T]") -> "pd.Series[T]":
+                df["time"] = df[cls._MAP_STEP_COLUMN[str(df.type)]]
+                return df
+
+            df = df.apply(map_step_column, axis=1)
+            time_col = "time"
+
+        columns = []
+        if join_run_id and "run__id" in df.columns:
+            columns.append("run__id")
+        if join_runs:
+            columns.extend(["model", "scenario", "version"])
+        columns += ["region", "variable", "unit"]
+        if time_col in df.columns:
+            columns += [time_col]
+        if "subannual" in df.columns:
+            columns += ["subannual"]
+        return df[columns + ["value"]]
 
 
 class RunIamcData(BaseBackendFacade, IamcDataFacade):
@@ -269,7 +270,7 @@ class RunIamcData(BaseBackendFacade, IamcDataFacade):
             join_runs=False,
             **facade_to_data_filter(kwargs),
         )
-        return _convert_to_std_format(df, join_runs=False, join_run_id=False)
+        return self._convert_to_std_format(df, join_runs=False, join_run_id=False)
 
 
 class PlatformIamcData(BaseBackendFacade, IamcDataFacade):
@@ -325,4 +326,6 @@ class PlatformIamcData(BaseBackendFacade, IamcDataFacade):
             **facade_to_data_filter(kwargs),
         )
 
-        return _convert_to_std_format(df, join_runs=join_runs, join_run_id=join_run_id)
+        return self._convert_to_std_format(
+            df, join_runs=join_runs, join_run_id=join_run_id
+        )

--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -56,7 +56,20 @@ def _convert_to_std_format(
     return df[columns + ["value"]]
 
 
-class RunIamcData(BaseBackendFacade):
+class IamcDataFacade(object):
+    def _rename_arg_cols(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df.rename(
+            columns={
+                "year": "step_year",
+                "category": "step_category",
+                "subannual": "step_category",
+                "datetime": "step_datetime",
+                "time": "step_datetime",
+            }
+        )
+
+
+class RunIamcData(BaseBackendFacade, IamcDataFacade):
     """IAMC data linked to a :class:`ixmp4.core.run.Run`.
 
     .. code:: python
@@ -93,26 +106,6 @@ class RunIamcData(BaseBackendFacade):
         return pd.merge(
             df, ts_df, how="left", on=id_cols, suffixes=(None, "_y")
         )  # tada, df with 'time_series__id' added from the database.
-
-    def _rename_arg_cols(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df.rename(
-            columns={
-                "year": "step_year",
-                "category": "step_category",
-                "subannual": "step_category",
-                "datetime": "step_datetime",
-                "time": "step_datetime",
-            }
-        )
-
-    def _rename_ret_cols(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df.rename(
-            columns={
-                "step_year": "year",
-                "step_category": "subannual",
-                "step_datetime": "time",
-            }
-        ).drop(columns=["id", "time_series__id"])
 
     def add(self, df: pd.DataFrame, type: Type | str | None = None) -> None:
         """Adds IAMC data from a data frame to a run.
@@ -279,7 +272,7 @@ class RunIamcData(BaseBackendFacade):
         return _convert_to_std_format(df, join_runs=False, join_run_id=False)
 
 
-class PlatformIamcData(BaseBackendFacade):
+class PlatformIamcData(BaseBackendFacade, IamcDataFacade):
     """IAMC data on a platform."""
 
     variables: VariableServiceFacade
@@ -287,15 +280,6 @@ class PlatformIamcData(BaseBackendFacade):
     def __init__(self, backend: Backend) -> None:
         super().__init__(backend)
         self.variables = VariableServiceFacade(backend)
-
-    def _rename_ret_cols(self, df: pd.DataFrame) -> pd.DataFrame:
-        return df.rename(
-            columns={
-                "step_year": "year",
-                "step_category": "category",
-                "step_datetime": "datetime",
-            }
-        ).drop(columns=["id", "time_series__id"])
 
     def tabulate(
         self,

--- a/ixmp4/data/iamc/datapoint/df_schemas.py
+++ b/ixmp4/data/iamc/datapoint/df_schemas.py
@@ -21,7 +21,7 @@ class BaseDataPointFrameSchema(pa.DataFrameModel):
     step_datetime: pat.Series[pa.Timestamp] | None = pa.Field(
         coerce=True, nullable=True
     )
-    step_category: pat.Series[pa.String] | None = pa.Field(nullable=True)
+    step_category: pat.Series[pa.String] | None = pa.Field(nullable=True, coerce=True)
 
     @pa.dataframe_parser
     @classmethod

--- a/ixmp4/data/iamc/timeseries/df_schemas.py
+++ b/ixmp4/data/iamc/timeseries/df_schemas.py
@@ -11,9 +11,9 @@ class UpsertTimeSeriesFrameSchema(pa.DataFrameModel):
     unit__id: pat.Series[pa.Int] | None = pa.Field(coerce=True)
     variable__id: pat.Series[pa.Int] | None = pa.Field(coerce=True)
 
-    region: pat.Series[pa.String] | None = pa.Field()
-    unit: pat.Series[pa.String] | None = pa.Field()
-    variable: pat.Series[pa.String] | None = pa.Field()
+    region: pat.Series[pa.String] | None = pa.Field(coerce=True)
+    unit: pat.Series[pa.String] | None = pa.Field(coerce=True)
+    variable: pat.Series[pa.String] | None = pa.Field(coerce=True)
 
     @pa.dataframe_check
     @classmethod
@@ -42,6 +42,6 @@ class UpsertTimeSeriesFrameSchema(pa.DataFrameModel):
 class TabulateTimeSeriesFrameSchema(pa.DataFrameModel):
     run__id: pat.Series[pa.Int] = pa.Field(coerce=True)
 
-    region: pat.Series[pa.String] = pa.Field()
-    unit: pat.Series[pa.String] = pa.Field()
-    variable: pat.Series[pa.String] = pa.Field()
+    region: pat.Series[pa.String] = pa.Field(coerce=True)
+    unit: pat.Series[pa.String] = pa.Field(coerce=True)
+    variable: pat.Series[pa.String] = pa.Field(coerce=True)

--- a/tests/core/test_iamc_data.py
+++ b/tests/core/test_iamc_data.py
@@ -660,3 +660,125 @@ class TestIamcDataStringType(IamcDataAnnual, IamcTest):
         with pytest.raises(KeyError):
             with run.transact("bad type"):
                 run.iamc.add(test_data_add, type="NOT_A_TYPE")
+
+
+class IamcDataInputTest(IamcTest):
+    @pytest.fixture(autouse=True)
+    def _ensure_regions_and_units(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> None:
+        # Ensure referenced region/unit names exist for fixture-provided input rows.
+        _ = (regions, units)
+
+    @pytest.fixture
+    def expected_data(self) -> pd.DataFrame:
+        raise NotImplementedError
+
+    @pytest.fixture
+    def input_data(self, expected_data: pd.DataFrame) -> pd.DataFrame:
+        return expected_data.copy()
+
+    def test_iamc_data_input(
+        self,
+        run: ixmp4.Run,
+        input_data: pd.DataFrame,
+        expected_data: pd.DataFrame,
+    ) -> None:
+        with run.transact("add iamc input data"):
+            run.iamc.add(input_data)
+
+        ret = run.iamc.tabulate()
+        pdt.assert_frame_equal(
+            self.canonical_sort(expected_data),
+            self.canonical_sort(ret),
+            check_like=True,
+        )
+
+        with run.transact("remove iamc input data"):
+            run.iamc.remove(input_data.drop(columns=["value"]))
+
+        assert run.iamc.tabulate().empty
+
+
+class TestAnnualIamcInputData(IamcDataAnnual, IamcDataInputTest):
+    @pytest.fixture
+    def expected_data(self, test_data_add: pd.DataFrame) -> pd.DataFrame:
+        return test_data_add.copy()
+
+    @pytest.fixture
+    def input_data(self, expected_data: pd.DataFrame) -> pd.DataFrame:
+        input_df = expected_data.copy()
+        input_df["region"] = input_df["region"].astype("category")
+        input_df["unit"] = input_df["unit"].astype("category")
+        input_df["variable"] = input_df["variable"].astype("category")
+        input_df["year"] = input_df["year"].astype("int32")
+        input_df["value"] = input_df["value"].astype("float32")
+        return input_df
+
+
+class TestCategoricalIamcInputData(IamcDataInputTest):
+    @pytest.fixture
+    def expected_data(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "region": ["Region 1", "Region 2"],
+                "variable": ["Variable 1", "Variable 2"],
+                "unit": ["Unit 1", "Unit 2"],
+                "year": pd.Series([2000, 2010], dtype="Int64"),
+                "subannual": ["Summer", "Winter"],
+                "value": [1.1, 2.3],
+            }
+        )
+
+    @pytest.fixture
+    def input_data(self, expected_data: pd.DataFrame) -> pd.DataFrame:
+        input_df = expected_data.copy()
+        input_df["region"] = input_df["region"].astype("category")
+        input_df["unit"] = input_df["unit"].astype("category")
+        input_df["variable"] = input_df["variable"].astype("category")
+        input_df["year"] = input_df["year"].astype("int32")
+        input_df["subannual"] = input_df["subannual"].astype("category")
+        input_df["value"] = input_df["value"].astype("float32")
+        return input_df
+
+
+class TestDatetimeIamcInputData(IamcDataInputTest):
+    @pytest.fixture
+    def expected_data(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "region": ["Region 1", "Region 2"],
+                "variable": ["Variable 1", "Variable 2"],
+                "unit": ["Unit 1", "Unit 2"],
+                "time": pd.to_datetime(["2000-01-01 00:00:00", "2010-06-01 12:34:56"]),
+                "value": [1.1, 2.3],
+            }
+        )
+
+    @pytest.fixture
+    def input_data(self, expected_data: pd.DataFrame) -> pd.DataFrame:
+        input_df = expected_data.copy()
+        input_df["region"] = input_df["region"].astype("category")
+        input_df["unit"] = input_df["unit"].astype("category")
+        input_df["variable"] = input_df["variable"].astype("category")
+        input_df["time"] = (
+            input_df["time"].dt.strftime("%Y-%m-%d %H:%M:%S").astype("string")
+        )
+        input_df["value"] = input_df["value"].astype("float32")
+        return input_df
+
+
+class TestObjectStringsIamcInputData(IamcDataAnnual, IamcDataInputTest):
+    @pytest.fixture
+    def expected_data(self, test_data_add: pd.DataFrame) -> pd.DataFrame:
+        return test_data_add.copy()
+
+    @pytest.fixture
+    def input_data(self, expected_data: pd.DataFrame) -> pd.DataFrame:
+        input_df = expected_data.copy()
+        input_df["region"] = input_df["region"].astype("object")
+        input_df["unit"] = input_df["unit"].astype("object")
+        input_df["variable"] = input_df["variable"].astype("object")
+        return input_df


### PR DESCRIPTION
Opening this as a response to a bug report by @lisahligono. There seemed to be an issue where "object" type string-columns would not be accepted. ~I was not able to reproduce the issue but instead added tests and refactored ixmp4.core.iamc.data a tiny bit.~

**Edit**: Nevermind! Looks like the test runs on this PR uncovered the problem. It has something to do with newer python and pandas versions.

The test that tries to reproduced the specific issue is this one: 
```py


class TestObjectStringsIamcInputData(IamcDataAnnual, IamcDataInputTest):
    @pytest.fixture
    def expected_data(self, test_data_add: pd.DataFrame) -> pd.DataFrame:
        return test_data_add.copy()

    @pytest.fixture
    def input_data(self, expected_data: pd.DataFrame) -> pd.DataFrame:
        input_df = expected_data.copy()
        input_df["region"] = input_df["region"].astype("object")
        input_df["unit"] = input_df["unit"].astype("object")
        input_df["variable"] = input_df["variable"].astype("object")
        return input_df

# -- From superclass
    def test_iamc_data_input(
        self,
        run: ixmp4.Run,
        input_data: pd.DataFrame,
        expected_data: pd.DataFrame,
    ) -> None:
        with run.transact("add iamc input data"):
            run.iamc.add(input_data)

        ret = run.iamc.tabulate()
        pdt.assert_frame_equal(
            self.canonical_sort(expected_data),
            self.canonical_sort(ret),
            check_like=True,
        )

        with run.transact("remove iamc input data"):
            run.iamc.remove(input_data.drop(columns=["value"]))

        assert run.iamc.tabulate().empty
```

The fix was to add coerce=True to all string-like series definitions in the DataFrame schemas.