### PR TITLE
Add `describe()` Methods

### DIFF
--- a/doc/source/data/iamc.rst
+++ b/doc/source/data/iamc.rst
@@ -27,6 +27,13 @@ Filters
     :undoc-members:
     :show-inheritance:
 
+Aggregations DTO
+^^^^^^^^^^^^^^^^
+.. autoclass:: ixmp4.data.iamc.datapoint.dto.DataPointAggregations
+    :members:   
+    :undoc-members:
+    :show-inheritance:
+    
 
 Measurands (ixmp4.data.iamc.measurand)
 --------------------------------------

--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -7,6 +7,7 @@ import pandas as pd
 from typing_extensions import Unpack
 
 from ixmp4.data.backend import Backend
+from ixmp4.data.iamc.datapoint.dto import DataPointAggregations
 from ixmp4.data.iamc.datapoint.filter import (
     FacadeDataPointFilter,
     facade_to_data_filter,
@@ -181,7 +182,7 @@ class RunIamcData(BaseBackendFacade, IamcDataFacade):
 
         self._run.require_lock()
         if "time" in df.columns:
-            df = self._split_time_col(df)
+            df = self._split_time_col(df.copy())
         df = self._rename_arg_cols(df)
         df["run__id"] = self._run.id
         df = self._get_or_create_ts(df)
@@ -242,7 +243,7 @@ class RunIamcData(BaseBackendFacade, IamcDataFacade):
         """
         self._run.require_lock()
         if "time" in df.columns:
-            df = self._split_time_col(df)
+            df = self._split_time_col(df.copy())
         df = self._rename_arg_cols(df)
         df["run__id"] = self._run.id
         # NOTE: This creates ts and deletes them right after
@@ -292,6 +293,27 @@ class RunIamcData(BaseBackendFacade, IamcDataFacade):
             **facade_to_data_filter(kwargs),
         )
         return self._convert_to_std_format(df, join_runs=False, join_run_id=False)
+
+    def describe(
+        self,
+        raw: bool = False,
+        **kwargs: Unpack[FacadeDataPointFilter],
+    ) -> DataPointAggregations:
+        r"""Describes datapoints by specified criteria.
+
+        Parameters
+        ----------
+        \*\*kwargs: any
+            Filter parameters as specified in :class:`FacadeDataPointFilter`.
+
+        Returns
+        -------
+        :class:`ixmp4.data.iamc.datapoint.dto.DataPointDescribe`
+            Aggregate statistics for matching datapoints.
+        """
+
+        kwargs["run"] = {"id": self._run.id, "default_only": False}
+        return self._backend.iamc.datapoints.describe(**facade_to_data_filter(kwargs))
 
 
 class PlatformIamcData(BaseBackendFacade, IamcDataFacade):
@@ -350,3 +372,24 @@ class PlatformIamcData(BaseBackendFacade, IamcDataFacade):
         return self._convert_to_std_format(
             df, join_runs=join_runs, join_run_id=join_run_id
         )
+
+    def describe(
+        self,
+        *,
+        raw: bool = False,
+        **kwargs: Unpack[FacadeDataPointFilter],
+    ) -> DataPointAggregations:
+        r"""Describes datapoints by specified criteria.
+
+        Parameters
+        ----------
+        \*\*kwargs: any
+            Filter parameters as specified in :class:`FacadeDataPointFilter`.
+
+        Returns
+        -------
+        :class:`ixmp4.data.iamc.datapoint.dto.DataPointDescribe`
+            Aggregate statistics for matching datapoints.
+        """
+
+        return self._backend.iamc.datapoints.describe(**facade_to_data_filter(kwargs))

--- a/ixmp4/core/iamc/data.py
+++ b/ixmp4/core/iamc/data.py
@@ -308,7 +308,7 @@ class RunIamcData(BaseBackendFacade, IamcDataFacade):
 
         Returns
         -------
-        :class:`ixmp4.data.iamc.datapoint.dto.DataPointDescribe`
+        :class:`ixmp4.data.iamc.datapoint.dto.DataPointAggregations`
             Aggregate statistics for matching datapoints.
         """
 
@@ -388,7 +388,7 @@ class PlatformIamcData(BaseBackendFacade, IamcDataFacade):
 
         Returns
         -------
-        :class:`ixmp4.data.iamc.datapoint.dto.DataPointDescribe`
+        :class:`ixmp4.data.iamc.datapoint.dto.DataPointAggregations`
             Aggregate statistics for matching datapoints.
         """
 

--- a/ixmp4/data/iamc/datapoint/db.py
+++ b/ixmp4/data/iamc/datapoint/db.py
@@ -28,7 +28,7 @@ class DataPoint(BaseModel):
     )
     timeseries: Mapped["TimeSeries"] = orm.relationship(viewonly=True)
 
-    value: Float = orm.mapped_column()
+    value: Float = orm.mapped_column(nullable=False)
 
     type: String = orm.mapped_column(sa.String(255), nullable=False, index=True)
 

--- a/ixmp4/data/iamc/datapoint/dto.py
+++ b/ixmp4/data/iamc/datapoint/dto.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+import pydantic as pyd
+
+
+class DataPointAggregations(pyd.BaseModel):
+    count: int
+    min: float | None
+    p25: float | None
+    median: float | None
+    p75: float | None
+    max: float | None
+    first_year: int | None
+    last_year: int | None
+    first_datetime: datetime | None
+    last_datetime: datetime | None
+    categories: list[str]
+    types: list[str]
+
+    model_config = pyd.ConfigDict(extra="ignore")

--- a/ixmp4/data/iamc/datapoint/repositories.py
+++ b/ixmp4/data/iamc/datapoint/repositories.py
@@ -8,6 +8,7 @@ from toolkit.db.repositories import PandasRepository as BasePandasRepository
 from toolkit.db.repositories.base import Values
 from toolkit.db.target import ExtendedTarget, ModelTarget
 
+from ixmp4.base_exceptions import ProgrammingError
 from ixmp4.data.base.repository import AuthRepository
 from ixmp4.data.iamc.measurand.db import Measurand
 from ixmp4.data.iamc.timeseries.db import TimeSeries
@@ -21,6 +22,7 @@ from ixmp4.data.unit.db import Unit
 from .db import DataPoint, DataPointVersion
 from .exceptions import DataPointNotFound, DataPointNotUnique
 from .filter import DataPointFilter, DataPointVersionFilter
+from .type import Type
 
 
 class DataPointAuthRepository(AuthRepository[DataPointVersion | DataPoint]):
@@ -80,6 +82,140 @@ class PandasRepository(DataPointAuthRepository, BasePandasRepository):
             col for col in cols_to_check if col in df.columns and df[col].isna().all()
         ]
         return df.drop(columns=cols_to_drop)
+
+    def describe(self, values: Values | None = None) -> dict[str, Any]:
+        delimiter = "\x1f"
+        dialect = self.executor.engine.dialect.name
+
+        filtered = (
+            self.select_for_values(
+                values=values,
+                columns=(
+                    "id",
+                    "type",
+                    "step_year",
+                    "step_datetime",
+                    "step_category",
+                    "value",
+                ),
+            )
+            .distinct()
+            .cte("filtered_datapoints")
+        )
+
+        ordered_values = sa.select(
+            filtered.c.value,
+            (
+                sa.func.row_number().over(order_by=filtered.c.value) - sa.literal(1)
+            ).label("idx"),
+        ).cte("ordered_values")
+
+        count = sa.select(
+            sa.select(sa.func.count())
+            .select_from(filtered)
+            .scalar_subquery()
+            .label("count"),
+        ).cte("count")
+
+        def percentile_expr(p: float) -> sa.ColumnElement[float | None]:
+            rank = (sa.cast(count.c.count, sa.Float) - sa.literal(1.0)) * sa.literal(p)
+            lower_idx = sa.cast(sa.func.floor(rank), sa.Integer)
+            upper_idx = sa.cast(sa.func.ceil(rank), sa.Integer)
+            fraction = rank - sa.cast(lower_idx, sa.Float)
+
+            lower_val = (
+                sa.select(ordered_values.c.value)
+                .where(ordered_values.c.idx == lower_idx)
+                .scalar_subquery()
+            )
+            upper_val = (
+                sa.select(ordered_values.c.value)
+                .where(ordered_values.c.idx == upper_idx)
+                .scalar_subquery()
+            )
+
+            interp = sa.cast(lower_val, sa.Float) + fraction * (
+                sa.cast(upper_val, sa.Float) - sa.cast(lower_val, sa.Float)
+            )
+
+            return sa.case(
+                (count.c.count == 0, sa.null()),
+                (lower_idx == upper_idx, sa.cast(lower_val, sa.Float)),
+                else_=interp,
+            )
+
+        categories_sorted = (
+            sa.select(filtered.c.step_category.label("item"))
+            .where(filtered.c.type == Type.CATEGORICAL)
+            .where(filtered.c.step_category.is_not(None))
+            .distinct()
+            .order_by(filtered.c.step_category)
+            .cte("categories_sorted")
+        )
+        types_sorted = (
+            sa.select(sa.cast(filtered.c.type, sa.String).label("item"))
+            .where(filtered.c.type.is_not(None))
+            .distinct()
+            .order_by(sa.cast(filtered.c.type, sa.String))
+            .cte("types_sorted")
+        )
+
+        if dialect == "sqlite":
+            categories_joined = sa.select(
+                sa.func.coalesce(
+                    sa.func.group_concat(categories_sorted.c.item, delimiter), ""
+                )
+            ).scalar_subquery()
+            types_joined = sa.select(
+                sa.func.coalesce(
+                    sa.func.group_concat(types_sorted.c.item, delimiter), ""
+                )
+            ).scalar_subquery()
+        elif dialect == "postgresql":
+            categories_joined = sa.select(
+                sa.func.coalesce(
+                    sa.func.string_agg(categories_sorted.c.item, delimiter), ""
+                )
+            ).scalar_subquery()
+            types_joined = sa.select(
+                sa.func.coalesce(sa.func.string_agg(types_sorted.c.item, delimiter), "")
+            ).scalar_subquery()
+        else:
+            raise ProgrammingError("Unsupported database dialect: " + dialect)
+
+        describe_exc = sa.select(
+            count.c.count,
+            sa.select(sa.func.min(filtered.c.value)).scalar_subquery().label("min"),
+            percentile_expr(0.25).label("p25"),
+            percentile_expr(0.5).label("median"),
+            percentile_expr(0.75).label("p75"),
+            sa.select(sa.func.max(filtered.c.value)).scalar_subquery().label("max"),
+            sa.select(sa.func.min(filtered.c.step_year))
+            .scalar_subquery()
+            .label("first_year"),
+            sa.select(sa.func.max(filtered.c.step_year))
+            .scalar_subquery()
+            .label("last_year"),
+            sa.select(sa.func.min(filtered.c.step_datetime))
+            .scalar_subquery()
+            .label("first_datetime"),
+            sa.select(sa.func.max(filtered.c.step_datetime))
+            .scalar_subquery()
+            .label("last_datetime"),
+            categories_joined.label("categories"),
+            types_joined.label("types"),
+        ).select_from(count)
+
+        with self.executor.select(describe_exc) as result:
+            row = result.mappings().one()
+
+        aggregations = dict(row)
+        raw_types = [item for item in str(row["types"]).split(delimiter) if item]
+        aggregations["types"] = [type_ for type_ in Type if type_.value in raw_types]
+        aggregations["categories"] = [
+            item for item in str(row["categories"]).split(delimiter) if item
+        ]
+        return aggregations
 
 
 class VersionRepository(PandasRepository):

--- a/ixmp4/data/iamc/datapoint/service.py
+++ b/ixmp4/data/iamc/datapoint/service.py
@@ -13,6 +13,7 @@ from ixmp4.data.services import Http, Service, procedure
 from ixmp4.transport import DirectTransport
 
 from .df_schemas import DeleteDataPointFrameSchema, UpsertDataPointFrameSchema
+from .dto import DataPointAggregations
 from .filter import DataPointFilter
 from .repositories import PandasRepository, VersionRepository
 
@@ -152,6 +153,30 @@ class DataPointService(Service):
             total=self.pandas.count(values=self.apply_filter_defaults(kwargs)),
             pagination=pagination,
         )
+
+    @procedure(Http(methods=("PATCH",)))
+    def describe(self, **kwargs: Unpack[DataPointFilter]) -> DataPointAggregations:
+        r"""Describes datapoints by specified criteria.
+
+        Parameters
+        ----------
+        \*\*kwargs: any
+            Filter parameters as specified in :class:`DataPointFilter`.
+
+        Returns
+        -------
+        :class:`ixmp4.data.iamc.datapoint.dto.DataPointDescribe`
+            Aggregate statistics for matching datapoints.
+        """
+
+        result = self.pandas.describe(values=self.apply_filter_defaults(kwargs))
+        return DataPointAggregations.model_validate(result)
+
+    @describe.auth_check()
+    def describe_auth_check(
+        self, auth_ctx: AuthorizationContext, platform: PlatformProtocol
+    ) -> None:
+        auth_ctx.has_view_permission(platform, raise_exc=Forbidden)
 
     @procedure(Http(methods=("POST",)))
     def bulk_upsert(self, df: SerializableDataFrame) -> None:

--- a/tests/core/test_iamc_data.py
+++ b/tests/core/test_iamc_data.py
@@ -34,7 +34,7 @@ class IamcTest(DataFrameTest, PlatformTest):
         self,
         platform: ixmp4.Platform,
     ) -> list[ixmp4.Unit]:
-        return [platform.units.create("Unit 1"), platform.units.create("Unit 2")]
+        return [platform.units.create("U 1"), platform.units.create("U 2")]
 
     @pytest.fixture(scope="class")
     def regions(
@@ -42,12 +42,31 @@ class IamcTest(DataFrameTest, PlatformTest):
         platform: ixmp4.Platform,
     ) -> list[ixmp4.Region]:
         return [
-            platform.regions.create("Region 1", "default"),
-            platform.regions.create("Region 2", "default"),
+            platform.regions.create("R 1", "default"),
+            platform.regions.create("R 2", "default"),
         ]
 
 
 class IamcDataTest(IamcTest):
+    @classmethod
+    def canonical_sort(cls, df: pd.DataFrame) -> pd.DataFrame:
+        sorted_cols = df.columns.sort_values().to_list()
+        sort_df = df.copy()
+        for col in sorted_cols:
+            series = sort_df[col]
+            if isinstance(series.dtype, pd.CategoricalDtype):
+                sort_df[col] = series.astype("string")
+                continue
+            if pd.api.types.is_object_dtype(series):
+                try:
+                    series.sort_values()
+                except TypeError:
+                    sort_df[col] = series.map(
+                        lambda v: "" if pd.isna(v) else f"{type(v).__name__}:{v}"
+                    )
+        order = sort_df.sort_values(by=sorted_cols).index
+        return df.loc[order].reset_index(drop=True)
+
     @pytest.fixture(scope="class")
     def test_data_upsert(
         self,
@@ -64,7 +83,7 @@ class IamcDataTest(IamcTest):
         test_data_type: Type | None,
     ) -> None:
         with run.transact("Full Addition"):
-            run.iamc.add(test_data_add, type=test_data_type)
+            run.iamc.add(test_data_add.copy(), type=test_data_type)
 
     def test_iamc_data_tabulate_after_add(
         self,
@@ -84,37 +103,98 @@ class IamcDataTest(IamcTest):
         ret_platform = platform.iamc.tabulate(run={"default_only": False})
         pdt.assert_frame_equal(test_data_platform, ret_platform, check_like=True)
 
+    def test_iamc_data_describe_after_add(
+        self,
+        platform: ixmp4.Platform,
+        run: ixmp4.Run,
+        test_data_add: pd.DataFrame,
+    ) -> None:
+        run_description = run.iamc.describe()
+        expected_values = test_data_add["value"].astype(float)
+        assert run_description.count == len(test_data_add)
+        assert run_description.min == pytest.approx(float(expected_values.min()))
+        assert run_description.p25 == pytest.approx(
+            float(expected_values.quantile(0.25))
+        )
+        assert run_description.median == pytest.approx(
+            float(expected_values.quantile(0.5))
+        )
+        assert run_description.p75 == pytest.approx(
+            float(expected_values.quantile(0.75))
+        )
+        assert run_description.max == pytest.approx(float(expected_values.max()))
+
+        expected_categories = (
+            sorted(test_data_add["subannual"].dropna().astype(str).drop_duplicates())
+            if "subannual" in test_data_add.columns
+            else []
+        )
+        assert run_description.categories == expected_categories
+        assert run_description.types
+        if "year" in test_data_add.columns:
+            assert run_description.first_year == test_data_add["year"].min()
+            assert run_description.last_year == test_data_add["year"].max()
+
+        if "datetime" in test_data_add.columns:
+            assert run_description.first_datetime == test_data_add["datetime"].min()
+            assert run_description.last_datetime == test_data_add["datetime"].max()
+        elif "time" in test_data_add.columns:
+            ts = test_data_add["time"].loc[
+                test_data_add["time"].map(lambda v: isinstance(v, pd.Timestamp))
+            ]
+            if not ts.empty:
+                assert run_description.first_datetime == ts.min()
+                assert run_description.last_datetime == ts.max()
+            else:
+                assert run_description.first_datetime is None
+                assert run_description.last_datetime is None
+        else:
+            assert run_description.first_datetime is None
+            assert run_description.last_datetime is None
+
+        run_filtered_tabulate = run.iamc.tabulate(region="R 1")
+        run_filtered_description = run.iamc.describe(region="R 1")
+        assert run_filtered_description.count == len(run_filtered_tabulate)
+
+        platform_description = platform.iamc.describe(
+            run={"id": run.id, "default_only": False}
+        )
+        platform_tabulate = platform.iamc.tabulate(
+            run={"id": run.id, "default_only": False}
+        )
+        assert platform_description.count == len(platform_tabulate)
+
     def test_iamc_data_facade_name_filter_shorthands(
         self,
         run: ixmp4.Run,
     ) -> None:
-        ret_region = run.iamc.tabulate(region="Region 1")
-        ret_region_explicit = run.iamc.tabulate(region={"name__like": "Region 1"})
+        ret_region = run.iamc.tabulate(region="R 1")
+        ret_region_explicit = run.iamc.tabulate(region={"name__like": "R 1"})
         pdt.assert_frame_equal(
             self.canonical_sort(ret_region),
             self.canonical_sort(ret_region_explicit),
             check_like=True,
         )
 
-        ret_unit = run.iamc.tabulate(unit=["Unit 1", "Unit 2"])
-        ret_unit_explicit = run.iamc.tabulate(unit={"name__in": ["Unit 1", "Unit 2"]})
+        ret_unit = run.iamc.tabulate(unit=["U 1", "U 2"])
+        ret_unit_explicit = run.iamc.tabulate(unit={"name__in": ["U 1", "U 2"]})
         pdt.assert_frame_equal(
             self.canonical_sort(ret_unit),
             self.canonical_sort(ret_unit_explicit),
             check_like=True,
         )
 
-        ret_variable = run.iamc.tabulate(variable="Variable 1")
-        ret_variable_explicit = run.iamc.tabulate(variable={"name__like": "Variable 1"})
+        ret_variable = run.iamc.tabulate(variable="V 1")
+        ret_variable_explicit = run.iamc.tabulate(variable={"name__like": "V 1"})
         pdt.assert_frame_equal(
             self.canonical_sort(ret_variable),
             self.canonical_sort(ret_variable_explicit),
             check_like=True,
         )
 
-        ret_variable_in = run.iamc.tabulate(variable=["Variable 1", "Variable 2"])
+        ret_variable_in = run.iamc.tabulate(variable=["V 1", "V 2"])
         ret_variable_in_explicit = run.iamc.tabulate(
-            variable={"name__in": ["Variable 1", "Variable 2"]}
+            variable={"name__in": ["V 1", "V 2"]}
         )
         pdt.assert_frame_equal(
             self.canonical_sort(ret_variable_in),
@@ -129,7 +209,7 @@ class IamcDataTest(IamcTest):
         test_data_type: Type | None,
     ) -> None:
         with run.transact("Partial Removal"):
-            run.iamc.remove(test_data_remove, type=test_data_type)
+            run.iamc.remove(test_data_remove.copy(), type=test_data_type)
 
     def test_iamc_data_remaining_after_remove_partial(
         self,
@@ -138,7 +218,9 @@ class IamcDataTest(IamcTest):
         test_data_type: Type | None,
     ) -> None:
         ret = run.iamc.tabulate()
-        pdt.assert_frame_equal(test_data_remaining, ret, check_like=True)
+        pdt.assert_frame_equal(
+            self.drop_empty_columns(test_data_remaining), ret, check_like=True
+        )
 
     def test_iamc_data_upsert(
         self,
@@ -147,7 +229,7 @@ class IamcDataTest(IamcTest):
         test_data_type: Type | None,
     ) -> None:
         with run.transact("Upsert"):
-            run.iamc.add(test_data_upsert, type=test_data_type)
+            run.iamc.add(test_data_upsert.copy(), type=test_data_type)
 
     def test_iamc_data_tabulate_after_upsert(
         self,
@@ -189,9 +271,6 @@ class IamcDataTest(IamcTest):
     ) -> None:
         ret = run.iamc.tabulate()
         assert ret.empty
-
-    def test_iamc_data_versioning(self, versioning_platform: ixmp4.Platform) -> None:
-        pass  # TODO: Test core versioning api once its implemented
 
 
 class IamcDataRollbackTest(IamcTest):
@@ -429,14 +508,12 @@ class IamcDataRollbackTest(IamcTest):
     ) -> None:
         tx_id = self.latest_transaction_id(run)
         self.clear_iamc_data(run, test_data_add)
-        self.delete_measurands_for_variable(run, "Variable 1")
-        versioning_platform.iamc.variables.delete("Variable 1")
+        self.delete_measurands_for_variable(run, "V 1")
+        versioning_platform.iamc.variables.delete("V 1")
 
         run._service.revert(run.id, tx_id)
 
-        assert versioning_platform.iamc.variables.get_by_name("Variable 1").name == (
-            "Variable 1"
-        )
+        assert versioning_platform.iamc.variables.get_by_name("V 1").name == ("V 1")
         ret = run.iamc.tabulate()
         pdt.assert_frame_equal(
             self.canonical_sort(test_data_add),
@@ -452,7 +529,7 @@ class IamcDataRollbackTest(IamcTest):
     ) -> None:
         tx_id = self.latest_transaction_id(run)
         self.clear_iamc_data(run, test_data_add)
-        versioning_platform.regions.delete("Region 1")
+        versioning_platform.regions.delete("R 1")
 
         with pytest.raises(ixmp4.NotFound):
             run._service.revert(run.id, tx_id)
@@ -465,8 +542,8 @@ class IamcDataRollbackTest(IamcTest):
     ) -> None:
         tx_id = self.latest_transaction_id(run)
         self.clear_iamc_data(run, test_data_add)
-        self.delete_measurands_for_unit(run, "Unit 1")
-        versioning_platform.units.delete("Unit 1")
+        self.delete_measurands_for_unit(run, "U 1")
+        versioning_platform.units.delete("U 1")
 
         with pytest.raises(ixmp4.NotFound):
             run._service.revert(run.id, tx_id)
@@ -481,14 +558,14 @@ class IamcDataAnnual:
     ) -> pd.DataFrame:
         df = pd.DataFrame(
             [
-                ["Region 1", "Unit 1", "Variable 1", 2000, 1.1],
-                ["Region 1", "Unit 1", "Variable 1", 2010, 1.3],
-                ["Region 1", "Unit 2", "Variable 2", 2020, 1.5],
-                ["Region 1", "Unit 2", "Variable 2", 2030, 1.7],
-                ["Region 2", "Unit 1", "Variable 1", 2000, 2.1],
-                ["Region 2", "Unit 1", "Variable 1", 2010, 2.3],
-                ["Region 2", "Unit 2", "Variable 2", 2020, 2.5],
-                ["Region 2", "Unit 2", "Variable 2", 2030, 2.7],
+                ["R 1", "U 1", "V 1", 2000, 1.1],
+                ["R 1", "U 1", "V 1", 2010, 1.3],
+                ["R 1", "U 2", "V 2", 2020, 1.5],
+                ["R 1", "U 2", "V 2", 2030, 1.7],
+                ["R 2", "U 1", "V 1", 2000, 2.1],
+                ["R 2", "U 1", "V 1", 2010, 2.3],
+                ["R 2", "U 2", "V 2", 2020, 2.5],
+                ["R 2", "U 2", "V 2", 2030, 2.7],
             ],
             columns=["region", "unit", "variable", "year", "value"],
         )
@@ -503,10 +580,10 @@ class IamcDataAnnual:
     ) -> pd.DataFrame:
         df = pd.DataFrame(
             [
-                ["Region 1", "Unit 1", "Variable 1", 2000, 1.1],
-                ["Region 1", "Unit 1", "Variable 1", 2010, 1.3],
-                ["Region 1", "Unit 2", "Variable 2", 2020, 1.5],
-                ["Region 1", "Unit 2", "Variable 2", 2030, 1.7],
+                ["R 1", "U 1", "V 1", 2000, 1.1],
+                ["R 1", "U 1", "V 1", 2010, 1.3],
+                ["R 1", "U 2", "V 2", 2020, 1.5],
+                ["R 1", "U 2", "V 2", 2030, 1.7],
             ],
             columns=["region", "unit", "variable", "year", "value"],
         )
@@ -521,10 +598,10 @@ class IamcDataAnnual:
     ) -> pd.DataFrame:
         df = pd.DataFrame(
             [
-                ["Region 2", "Unit 1", "Variable 1", 2000, 2.1],
-                ["Region 2", "Unit 1", "Variable 1", 2010, 2.3],
-                ["Region 2", "Unit 2", "Variable 2", 2020, 2.5],
-                ["Region 2", "Unit 2", "Variable 2", 2030, 2.7],
+                ["R 2", "U 1", "V 1", 2000, 2.1],
+                ["R 2", "U 1", "V 1", 2010, 2.3],
+                ["R 2", "U 2", "V 2", 2020, 2.5],
+                ["R 2", "U 2", "V 2", 2030, 2.7],
             ],
             columns=["region", "unit", "variable", "year", "value"],
         )
@@ -543,7 +620,7 @@ class IamcDataAnnual:
     @pytest.fixture(scope="class")
     def test_data_new_timeseries(self) -> pd.DataFrame:
         df = pd.DataFrame(
-            [["Region 1", "Unit 2", "Variable 1", 2040, 9.9]],
+            [["R 1", "U 2", "V 1", 2040, 9.9]],
             columns=["region", "unit", "variable", "year", "value"],
         )
         df["year"] = df["year"].astype("Int64")
@@ -553,8 +630,8 @@ class IamcDataAnnual:
     def test_data_remove_full_timeseries(self) -> pd.DataFrame:
         df = pd.DataFrame(
             [
-                ["Region 1", "Unit 1", "Variable 1", 2000],
-                ["Region 1", "Unit 1", "Variable 1", 2010],
+                ["R 1", "U 1", "V 1", 2000],
+                ["R 1", "U 1", "V 1", 2010],
             ],
             columns=["region", "unit", "variable", "year"],
         )
@@ -572,9 +649,319 @@ class IamcDataAnnual:
         )
         return expected[
             ~(
-                (expected["region"] == "Region 1")
-                & (expected["unit"] == "Unit 1")
-                & (expected["variable"] == "Variable 1")
+                (expected["region"] == "R 1")
+                & (expected["unit"] == "U 1")
+                & (expected["variable"] == "V 1")
+            )
+        ].reset_index(drop=True)
+
+
+class IamcDataCategorical:
+    @pytest.fixture(scope="class")
+    def test_data_add(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        df = pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", 2000, "Summer", 1.1],
+                ["R 1", "U 1", "V 1", 2010, "Summer", 1.3],
+                ["R 1", "U 2", "V 2", 2020, "Winter", 1.5],
+                ["R 1", "U 2", "V 2", 2030, "Winter", 1.7],
+                ["R 2", "U 1", "V 1", 2000, "Summer", 2.1],
+                ["R 2", "U 1", "V 1", 2010, "Summer", 2.3],
+                ["R 2", "U 2", "V 2", 2020, "Winter", 2.5],
+                ["R 2", "U 2", "V 2", 2030, "Winter", 2.7],
+            ],
+            columns=["region", "unit", "variable", "year", "subannual", "value"],
+        )
+        df["year"] = df["year"].astype("Int64")
+        return df
+
+    @pytest.fixture(scope="class")
+    def test_data_remove(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        df = pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", 2000, "Summer", 1.1],
+                ["R 1", "U 1", "V 1", 2010, "Summer", 1.3],
+                ["R 1", "U 2", "V 2", 2020, "Winter", 1.5],
+                ["R 1", "U 2", "V 2", 2030, "Winter", 1.7],
+            ],
+            columns=["region", "unit", "variable", "year", "subannual", "value"],
+        )
+        df["year"] = df["year"].astype("Int64")
+        return df
+
+    @pytest.fixture(scope="class")
+    def test_data_remaining(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        df = pd.DataFrame(
+            [
+                ["R 2", "U 1", "V 1", 2000, "Summer", 2.1],
+                ["R 2", "U 1", "V 1", 2010, "Summer", 2.3],
+                ["R 2", "U 2", "V 2", 2020, "Winter", 2.5],
+                ["R 2", "U 2", "V 2", 2030, "Winter", 2.7],
+            ],
+            columns=["region", "unit", "variable", "year", "subannual", "value"],
+        )
+        df["year"] = df["year"].astype("Int64")
+        return df
+
+    @pytest.fixture(scope="class")
+    def test_data_upsert(
+        self,
+        test_data_add: pd.DataFrame,
+    ) -> pd.DataFrame:
+        test_data_upsert = test_data_add.copy()
+        test_data_upsert["value"] = np.sin(test_data_upsert["value"])
+        return test_data_upsert
+
+    @pytest.fixture(scope="class")
+    def test_data_new_timeseries(self) -> pd.DataFrame:
+        df = pd.DataFrame(
+            [["R 1", "U 2", "V 1", 2040, "Spring", 9.9]],
+            columns=["region", "unit", "variable", "year", "subannual", "value"],
+        )
+        df["year"] = df["year"].astype("Int64")
+        return df
+
+    @pytest.fixture(scope="class")
+    def test_data_remove_full_timeseries(self) -> pd.DataFrame:
+        df = pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", 2000, "Summer"],
+                ["R 1", "U 1", "V 1", 2010, "Summer"],
+            ],
+            columns=["region", "unit", "variable", "year", "subannual"],
+        )
+        df["year"] = df["year"].astype("Int64")
+        return df
+
+    @pytest.fixture(scope="class")
+    def test_data_upsert_after_full_timeseries_removal(
+        self,
+        test_data_new_timeseries: pd.DataFrame,
+        test_data_upsert: pd.DataFrame,
+    ) -> pd.DataFrame:
+        expected = pd.concat(
+            [test_data_upsert, test_data_new_timeseries], ignore_index=True
+        )
+        return expected[
+            ~(
+                (expected["region"] == "R 1")
+                & (expected["unit"] == "U 1")
+                & (expected["variable"] == "V 1")
+            )
+        ].reset_index(drop=True)
+
+
+class IamcDataDatetime:
+    @pytest.fixture(scope="class")
+    def test_data_add(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", pd.Timestamp("2000-01-01"), 1.1],
+                ["R 1", "U 1", "V 1", pd.Timestamp("2000-02-01"), 1.3],
+                ["R 1", "U 2", "V 2", pd.Timestamp("2000-03-01"), 1.5],
+                ["R 1", "U 2", "V 2", pd.Timestamp("2000-04-01"), 1.7],
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-01-01"), 2.1],
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-02-01"), 2.3],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-03-01"), 2.5],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-04-01"), 2.7],
+            ],
+            columns=["region", "unit", "variable", "time", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_remove(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", pd.Timestamp("2000-01-01"), 1.1],
+                ["R 1", "U 1", "V 1", pd.Timestamp("2000-02-01"), 1.3],
+                ["R 1", "U 2", "V 2", pd.Timestamp("2000-03-01"), 1.5],
+                ["R 1", "U 2", "V 2", pd.Timestamp("2000-04-01"), 1.7],
+            ],
+            columns=["region", "unit", "variable", "time", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_remaining(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-01-01"), 2.1],
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-02-01"), 2.3],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-03-01"), 2.5],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-04-01"), 2.7],
+            ],
+            columns=["region", "unit", "variable", "time", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_upsert(
+        self,
+        test_data_add: pd.DataFrame,
+    ) -> pd.DataFrame:
+        test_data_upsert = test_data_add.copy()
+        test_data_upsert["value"] = np.sin(test_data_upsert["value"])
+        return test_data_upsert
+
+    @pytest.fixture(scope="class")
+    def test_data_new_timeseries(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [["R 1", "U 2", "V 1", pd.Timestamp("2020-01-01"), 9.9]],
+            columns=["region", "unit", "variable", "time", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_remove_full_timeseries(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", pd.Timestamp("2000-01-01")],
+                ["R 1", "U 1", "V 1", pd.Timestamp("2000-02-01")],
+            ],
+            columns=["region", "unit", "variable", "time"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_upsert_after_full_timeseries_removal(
+        self,
+        test_data_new_timeseries: pd.DataFrame,
+        test_data_upsert: pd.DataFrame,
+    ) -> pd.DataFrame:
+        expected = pd.concat(
+            [test_data_upsert, test_data_new_timeseries], ignore_index=True
+        )
+        return expected[
+            ~(
+                (expected["region"] == "R 1")
+                & (expected["unit"] == "U 1")
+                & (expected["variable"] == "V 1")
+            )
+        ].reset_index(drop=True)
+
+
+class IamcDataMixed:
+    @pytest.fixture(scope="class")
+    def test_data_add(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", 2000, None, 0.1],
+                ["R 1", "U 1", "V 1", 2010, None, 0.2],
+                ["R 1", "U 2", "V 2", 2020, "Summer", 1.5],
+                ["R 1", "U 2", "V 2", 2030, "Winter", 1.7],
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-01-01"), None, 2.1],
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-02-01"), None, 2.3],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-03-01"), None, 2.5],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-04-01"), None, 2.7],
+            ],
+            columns=["region", "unit", "variable", "time", "subannual", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_remove(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", 2000, None, 0.1],
+                ["R 1", "U 1", "V 1", 2010, None, 0.2],
+                ["R 1", "U 2", "V 2", 2020, "Summer", 1.5],
+                ["R 1", "U 2", "V 2", 2030, "Winter", 1.7],
+            ],
+            columns=["region", "unit", "variable", "time", "subannual", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_remaining(
+        self,
+        regions: list[ixmp4.Region],
+        units: list[ixmp4.Unit],
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-01-01"), None, 2.1],
+                ["R 2", "U 1", "V 1", pd.Timestamp("2010-02-01"), None, 2.3],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-03-01"), None, 2.5],
+                ["R 2", "U 2", "V 2", pd.Timestamp("2010-04-01"), None, 2.7],
+            ],
+            columns=["region", "unit", "variable", "time", "subannual", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_upsert(
+        self,
+        test_data_add: pd.DataFrame,
+    ) -> pd.DataFrame:
+        test_data_upsert = test_data_add.copy()
+        test_data_upsert["value"] = np.sin(test_data_upsert["value"])
+        return test_data_upsert
+
+    @pytest.fixture(scope="class")
+    def test_data_new_timeseries(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                [
+                    "R 1",
+                    "U 2",
+                    "V 1",
+                    pd.Timestamp("2020-01-01"),
+                    None,
+                    9.9,
+                ]
+            ],
+            columns=["region", "unit", "variable", "time", "subannual", "value"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_remove_full_timeseries(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                ["R 1", "U 1", "V 1", 2000, None],
+                ["R 1", "U 1", "V 1", 2010, None],
+            ],
+            columns=["region", "unit", "variable", "time", "subannual"],
+        )
+
+    @pytest.fixture(scope="class")
+    def test_data_upsert_after_full_timeseries_removal(
+        self,
+        test_data_new_timeseries: pd.DataFrame,
+        test_data_upsert: pd.DataFrame,
+    ) -> pd.DataFrame:
+        expected = pd.concat(
+            [test_data_upsert, test_data_new_timeseries], ignore_index=True
+        )
+        return expected[
+            ~(
+                (expected["region"] == "R 1")
+                & (expected["unit"] == "U 1")
+                & (expected["variable"] == "V 1")
             )
         ].reset_index(drop=True)
 
@@ -589,6 +976,36 @@ class TestIamcDataAnnualWithType(IamcDataAnnual, IamcDataTest):
     @pytest.fixture(scope="class")
     def test_data_type(self) -> Type | None:
         return Type.ANNUAL
+
+
+class TestIamcDataCategoricalInferType(IamcDataCategorical, IamcDataTest):
+    @pytest.fixture(scope="class")
+    def test_data_type(self) -> Type | None:
+        return None
+
+
+class TestIamcDataCategoricalWithType(IamcDataCategorical, IamcDataTest):
+    @pytest.fixture(scope="class")
+    def test_data_type(self) -> Type | None:
+        return Type.CATEGORICAL
+
+
+class TestIamcDataDatetimeInferType(IamcDataDatetime, IamcDataTest):
+    @pytest.fixture(scope="class")
+    def test_data_type(self) -> Type | None:
+        return None
+
+
+class TestIamcDataDatetimeWithType(IamcDataDatetime, IamcDataTest):
+    @pytest.fixture(scope="class")
+    def test_data_type(self) -> Type | None:
+        return Type.DATETIME
+
+
+class TestIamcDataMixedInferType(IamcDataMixed, IamcDataTest):
+    @pytest.fixture(scope="class")
+    def test_data_type(self) -> Type | None:
+        return None
 
 
 class TestIamcDataAnnualRollback(IamcDataAnnual, IamcDataRollbackTest):
@@ -708,6 +1125,7 @@ class IamcDataInputTest(IamcTest):
 
     def test_iamc_data_input(
         self,
+        platform: ixmp4.Platform,
         run: ixmp4.Run,
         input_data: pd.DataFrame,
         expected_data: pd.DataFrame,
@@ -737,14 +1155,14 @@ class TestAnnualIamcInputData(IamcDataInputTest):
     ) -> pd.DataFrame:
         return pd.DataFrame(
             [
-                ["Region 1", "Unit 1", "Variable 1", 2000, 1.1],
-                ["Region 1", "Unit 1", "Variable 1", 2010, 1.3],
-                ["Region 1", "Unit 2", "Variable 2", 2020, 1.5],
-                ["Region 1", "Unit 2", "Variable 2", 2030, 1.7],
-                ["Region 2", "Unit 1", "Variable 1", 2000, 2.1],
-                ["Region 2", "Unit 1", "Variable 1", 2010, 2.3],
-                ["Region 2", "Unit 2", "Variable 2", 2020, 2.5],
-                ["Region 2", "Unit 2", "Variable 2", 2030, 2.7],
+                ["R 1", "U 1", "V 1", 2000, 1.1],
+                ["R 1", "U 1", "V 1", 2010, 1.3],
+                ["R 1", "U 2", "V 2", 2020, 1.5],
+                ["R 1", "U 2", "V 2", 2030, 1.7],
+                ["R 2", "U 1", "V 1", 2000, 2.1],
+                ["R 2", "U 1", "V 1", 2010, 2.3],
+                ["R 2", "U 2", "V 2", 2020, 2.5],
+                ["R 2", "U 2", "V 2", 2030, 2.7],
             ],
             columns=["region", "unit", "variable", "year", "value"],
         ).astype({"year": "Int64"})
@@ -765,8 +1183,8 @@ class TestCategoricalIamcInputData(IamcDataInputTest):
     def expected_data(self) -> pd.DataFrame:
         return pd.DataFrame(
             [
-                ["Region 1", "Variable 1", "Unit 1", 2000, "Summer", 1.1],
-                ["Region 2", "Variable 2", "Unit 2", 2010, "Winter", 2.3],
+                ["R 1", "V 1", "U 1", 2000, "Summer", 1.1],
+                ["R 2", "V 2", "U 2", 2010, "Winter", 2.3],
             ],
             columns=["region", "variable", "unit", "year", "subannual", "value"],
         ).astype({"year": "Int64"})
@@ -788,20 +1206,8 @@ class TestDatetimeIamcInputData(IamcDataInputTest):
     def expected_data(self) -> pd.DataFrame:
         return pd.DataFrame(
             [
-                [
-                    "Region 1",
-                    "Variable 1",
-                    "Unit 1",
-                    pd.Timestamp("2000-01-01 00:00:00"),
-                    1.1,
-                ],
-                [
-                    "Region 2",
-                    "Variable 2",
-                    "Unit 2",
-                    pd.Timestamp("2010-06-01 12:34:56"),
-                    2.3,
-                ],
+                ["R 1", "V 1", "U 1", pd.Timestamp("2000-01-01 00:00:00"), 1.1],
+                ["R 2", "V 2", "U 2", pd.Timestamp("2010-06-01 12:34:56"), 2.3],
             ],
             columns=["region", "variable", "unit", "time", "value"],
         )
@@ -823,9 +1229,9 @@ class TestSingleRowDatetimeIamcInputData(IamcDataInputTest):
         return pd.DataFrame(
             [
                 [
-                    "Region 1",
-                    "Variable 1",
-                    "Unit 1",
+                    "R 1",
+                    "V 1",
+                    "U 1",
                     pd.Timestamp("2000-01-01 00:00:00"),
                     1.1,
                 ],
@@ -848,28 +1254,14 @@ class TestMixedIamcInputData(IamcDataInputTest):
         return pd.DataFrame(
             [
                 # ANNUAL
-                ["Region 1", "Variable 1", "Unit 1", 2000, None, 0.1],
-                ["Region 2", "Variable 2", "Unit 2", 2010, None, 0.23],
+                ["R 1", "V 1", "U 1", 2000, None, 0.1],
+                ["R 2", "V 2", "U 2", 2010, None, 0.23],
                 # CATEGORICAL
-                ["Region 1", "Variable 1", "Unit 1", 2000, "Summer", 1.1],
-                ["Region 2", "Variable 2", "Unit 2", 2010, "Winter", 2.3],
+                ["R 1", "V 1", "U 1", 2000, "Summer", 1.1],
+                ["R 2", "V 2", "U 2", 2010, "Winter", 2.3],
                 # DATETIME
-                [
-                    "Region 1",
-                    "Variable 1",
-                    "Unit 1",
-                    pd.Timestamp("2000-01-01 00:00:00"),
-                    None,
-                    101.0,
-                ],
-                [
-                    "Region 2",
-                    "Variable 2",
-                    "Unit 2",
-                    pd.Timestamp("2010-06-01 12:34:56"),
-                    None,
-                    3.14,
-                ],
+                ["R 1", "V 1", "U 1", pd.Timestamp("2000-01-01 00:00:00"), None, 101.0],
+                ["R 2", "V 2", "U 2", pd.Timestamp("2010-06-01 12:34:56"), None, 3.14],
             ],
             columns=["region", "variable", "unit", "time", "subannual", "value"],
         )

--- a/tests/data/test_iamc_datapoint_service.py
+++ b/tests/data/test_iamc_datapoint_service.py
@@ -248,6 +248,73 @@ class DataPointBulkOperationsTest(DataPointServiceTest):
         ret_df = service.tabulate(join_run_id=True)
         assert "run__id" in ret_df.columns
 
+    def test_datapoint_describe(
+        self,
+        service: DataPointService,
+        expected_df: pd.DataFrame,
+    ) -> None:
+        description = service.describe()
+
+        values = expected_df["value"].astype(float)
+        assert description.count == len(expected_df)
+        assert description.min == pytest.approx(float(values.min()))
+        assert description.p25 == pytest.approx(float(values.quantile(0.25)))
+        assert description.median == pytest.approx(float(values.quantile(0.5)))
+        assert description.p75 == pytest.approx(float(values.quantile(0.75)))
+        assert description.max == pytest.approx(float(values.max()))
+
+        if "step_year" in expected_df.columns:
+            expected_years = pd.to_numeric(
+                expected_df["step_year"], errors="coerce"
+            ).dropna()
+            if expected_years.empty:
+                assert description.first_year is None
+                assert description.last_year is None
+            else:
+                assert description.first_year == int(expected_years.min())
+                assert description.last_year == int(expected_years.max())
+        else:
+            assert description.first_year is None
+            assert description.last_year is None
+
+        if "step_datetime" in expected_df.columns:
+            expected_datetimes = pd.to_datetime(
+                expected_df["step_datetime"], errors="coerce"
+            ).dropna()
+            if expected_datetimes.empty:
+                assert description.first_datetime is None
+                assert description.last_datetime is None
+            else:
+                assert description.first_datetime == expected_datetimes.min()
+                assert description.last_datetime == expected_datetimes.max()
+        else:
+            assert description.first_datetime is None
+            assert description.last_datetime is None
+
+        expected_categories: list[str] = []
+        if "step_category" in expected_df.columns:
+            expected_categories = sorted(
+                expected_df["step_category"]
+                .dropna()
+                .astype(str)
+                .drop_duplicates()
+                .tolist()
+            )
+        assert description.categories == expected_categories
+
+        expected_types = [
+            type_.value
+            for type_ in Type
+            if type_.value in expected_df["type"].astype(str).unique()
+        ]
+        assert description.types == expected_types
+
+        first_type = str(expected_df["type"].iloc[0])
+        filtered_description = service.describe(type=first_type)
+        assert filtered_description.count == len(
+            expected_df[expected_df["type"].astype(str) == first_type]
+        )
+
     def test_datapoint_bulk_update(
         self,
         service: DataPointService,

--- a/tests/data/test_iamc_datapoint_service.py
+++ b/tests/data/test_iamc_datapoint_service.py
@@ -779,6 +779,10 @@ class TestDataPointAuthSarahPrivate(
         ret_df = service.tabulate()
         assert len(ret_df) == 4
 
+    def test_datapoint_describe(self, service: DataPointService) -> None:
+        aggs = service.describe()
+        assert aggs.count == 4
+
     def test_datapoint_bulk_delete(
         self, service: DataPointService, test_df: pd.DataFrame
     ) -> None:
@@ -802,6 +806,10 @@ class TestDataPointAuthAlicePrivate(
     def test_datapoint_tabulate(self, service: DataPointService) -> None:
         with pytest.raises(Forbidden):
             service.tabulate()
+
+    def test_datapoint_describe(self, service: DataPointService) -> None:
+        with pytest.raises(Forbidden):
+            service.describe()
 
     def test_datapoint_bulk_delete(
         self,
@@ -828,6 +836,10 @@ class TestDataPointAuthBobPrivate(
     def test_datapoint_tabulate(self, service: DataPointService) -> None:
         ret_df = service.tabulate()
         assert len(ret_df) == 4
+
+    def test_datapoint_describe(self, service: DataPointService) -> None:
+        aggs = service.describe()
+        assert aggs.count == 4
 
     def test_datapoint_bulk_delete(
         self, service: DataPointService, test_df: pd.DataFrame
@@ -929,6 +941,10 @@ class TestDataPointAuthCarinaPrivate(
     def test_datapoint_tabulate(self, service: DataPointService) -> None:
         ret_df = service.tabulate(run={"default_only": False})
         assert len(ret_df) == 8
+
+    def test_datapoint_describe(self, service: DataPointService) -> None:
+        aggs = service.describe(run={"default_only": False})
+        assert aggs.count == 8
 
     def test_datapoint_bulk_delete(
         self,


### PR DESCRIPTION
Adds aggregations/statistics via `describe()` methods to [run](https://iiasa-energy-program-ece-docs--253.com.readthedocs.build/projects/ixmp4/en/253/core/iamc.html#ixmp4.core.iamc.data.RunIamcData.describe) and [platform](https://iiasa-energy-program-ece-docs--253.com.readthedocs.build/projects/ixmp4/en/253/core/iamc.html#ixmp4.core.iamc.data.PlatformIamcData.describe) IAMC data objects. 
These methods return a [`DataPointAggregations`](https://iiasa-energy-program-ece-docs--253.com.readthedocs.build/projects/ixmp4/en/253/data/iamc.html#ixmp4.data.iamc.datapoint.dto.DataPointAggregations) object, which contains:

```py
count: int
min: float | None
p25: float | None
median: float | None
p75: float | None
max: float | None
first_year: int | None
last_year: int | None
first_datetime: datetime | None
last_datetime: datetime | None
categories: list[str]
types: list[str]
```

```py
platform.iamc.describe().types
# > ["ANNUAL", "CATEGORICAL"]

run.iamc.describe(variable="Emissions|CO2").median
# > 3.2
```

TODO: Add describe to meta indicators. 