### PR TITLE
Quickfix for meta in datetime format

### DIFF
--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -14,8 +14,8 @@ from ixmp4.data.meta.filter import (
 )
 from ixmp4.data.meta.service import RunMetaEntryService
 
-from .base import BaseServiceFacade
 from ..data.meta.type import convert_value
+from .base import BaseServiceFacade
 
 if TYPE_CHECKING:
     from ixmp4.data.backend import Backend

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -116,8 +116,7 @@ class RunMetaDictFacade(
 
         py_value = numpy_to_pytype(value)
         if py_value is not None:
-            _, py_value = convert_value(py_value)
-            self._service.create(self.run.id, key, py_value)
+            self._service.create(self.run.id, key, convert_value(py_value))
         self.df, self.data = self._get()
 
     def __delitem__(self, key: str) -> None:
@@ -200,7 +199,7 @@ class RunMetaDescriptor(object):
             {"key": value.keys(), "value": [numpy_to_pytype(v) for v in value.values()]}
         )
         df.dropna(axis=0, inplace=True)
-        df["value"] = df["value"].map(lambda v: convert_value(v)[1])
+        df["value"] = df["value"].map(lambda v: convert_value(v))
         df["run__id"] = obj._dto.id
         obj._backend.meta.bulk_upsert(df)
 

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -15,6 +15,7 @@ from ixmp4.data.meta.filter import (
 from ixmp4.data.meta.service import RunMetaEntryService
 
 from .base import BaseServiceFacade
+from ..data.meta.type import convert_value
 
 if TYPE_CHECKING:
     from ixmp4.data.backend import Backend
@@ -115,6 +116,7 @@ class RunMetaDictFacade(
 
         py_value = numpy_to_pytype(value)
         if py_value is not None:
+            _, py_value = convert_value(py_value)
             self._service.create(self.run.id, key, py_value)
         self.df, self.data = self._get()
 
@@ -198,6 +200,7 @@ class RunMetaDescriptor(object):
             {"key": value.keys(), "value": [numpy_to_pytype(v) for v in value.values()]}
         )
         df.dropna(axis=0, inplace=True)
+        df["value"] = df["value"].map(lambda v: convert_value(v)[1])
         df["run__id"] = obj._dto.id
         obj._backend.meta.bulk_upsert(df)
 

--- a/ixmp4/data/meta/repositories.py
+++ b/ixmp4/data/meta/repositories.py
@@ -125,6 +125,8 @@ class PandasRepository(RunMetaAuthRepository, BasePandasRepository):
         for type_, type_df in df.groupby("dtype"):
             col = Type.column_for_type(cast(Type, type_))
             type_df["dtype"] = type_df["dtype"].map(lambda x: str(x))
+            if type_ == "STR":
+                type_df["value"] = type_df["value"].map(lambda x: str(x))
             type_df = type_df.rename(columns={"value": col})
 
             null_cols = set(Type.columns()) - set([col])

--- a/ixmp4/data/meta/repositories.py
+++ b/ixmp4/data/meta/repositories.py
@@ -125,8 +125,6 @@ class PandasRepository(RunMetaAuthRepository, BasePandasRepository):
         for type_, type_df in df.groupby("dtype"):
             col = Type.column_for_type(cast(Type, type_))
             type_df["dtype"] = type_df["dtype"].map(lambda x: str(x))
-            if type_ == "STR":
-                type_df["value"] = type_df["value"].map(lambda x: str(x))
             type_df = type_df.rename(columns={"value": col})
 
             null_cols = set(Type.columns()) - set([col])

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -1,6 +1,6 @@
-from enum import Enum
-from typing import Literal, Any
 import logging
+from enum import Enum
+from typing import Any, Literal
 
 from ixmp4.data.meta.exceptions import InvalidRunMeta
 

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -38,12 +38,12 @@ class Type(str, Enum):
 def convert_value(value: Any) -> tuple[Type, Any]:
     value_type = type(value)
 
-    if value_type in _type_map:
-        return _type_map[value_type], value
+    if type(value) in _type_map:
+        return value
 
     logger.warning("Converting value of type '%s' to string.", value_type.__name__)
     try:
-        return Type.STR, str(value)
+        return str(value)
     except Exception as e:
         raise InvalidRunMeta(
             f"Failed to convert value of type '{value_type.__name__}' to string: {e}"

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -12,11 +12,11 @@ class Type(str, Enum):
 
     @classmethod
     def from_pytype(cls, type_: type) -> "Type":
-        return _type_map[type_]
+        return _type_map.get(type_, Type.STR)
 
     @classmethod
     def column_for_type(cls, type_: "Type") -> str:
-        return _column_map[type_]
+        return _column_map.get(type_, "value_str")
 
     @classmethod
     def pd_dtype_for_type(cls, type_: "Type") -> PdDtype:

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -17,11 +17,11 @@ class Type(str, Enum):
 
     @classmethod
     def from_pytype(cls, type_: type) -> "Type":
-        return _type_map.get(type_, Type.STR)
+        return _type_map[type_]
 
     @classmethod
     def column_for_type(cls, type_: "Type") -> str:
-        return _column_map.get(type_, "value_str")
+        return _column_map[type_]
 
     @classmethod
     def pd_dtype_for_type(cls, type_: "Type") -> PdDtype:
@@ -35,7 +35,7 @@ class Type(str, Enum):
         return self.value
 
 
-def convert_value(value: Any) -> tuple[Type, Any]:
+def convert_value(value: Any) -> Any:
     value_type = type(value)
 
     if type(value) in _type_map:

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -1,5 +1,10 @@
 from enum import Enum
-from typing import Literal
+from typing import Literal, Any
+import logging
+
+from ixmp4.data.meta.exceptions import InvalidRunMeta
+
+logger = logging.getLogger(__name__)
 
 PdDtype = Literal["Int64", "str", "float64", "boolean"]
 
@@ -28,6 +33,21 @@ class Type(str, Enum):
 
     def __str__(self) -> str:
         return self.value
+
+
+def convert_value(value: Any) -> tuple[Type, Any]:
+    value_type = type(value)
+
+    if value_type in _type_map:
+        return _type_map[value_type], value
+
+    logger.warning("Converting value of type '%s' to string.", value_type.__name__)
+    try:
+        return Type.STR, str(value)
+    except Exception as e:
+        raise InvalidRunMeta(
+            f"Failed to convert value of type '{value_type.__name__}' to string: {e}"
+        ) from e
 
 
 _type_map: dict[type, Type] = {

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -46,10 +46,9 @@ class TestMetaData(MetaTest):
         run2 = platform.runs.get("Model", "Scenario")
         assert dict(run2.meta) == exp
 
-    def _test_add_meta_invalid_type(
-        self, platform: ixmp4.Platform, run: ixmp4.Run
-    ) -> None:
+    def test_add_meta_invalid_type(self, platform: ixmp4.Platform) -> None:
 
+        run = platform.runs.create("Model", "Scenario")
         class NoStringRepresentationClass:
             def __str__(self):
                 raise TypeError("String representation is not supported")

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -49,6 +49,7 @@ class TestMetaData(MetaTest):
     def test_add_meta_invalid_type(self, platform: ixmp4.Platform) -> None:
 
         run = platform.runs.create("Model", "Scenario")
+
         class NoStringRepresentationClass:
             def __str__(self):
                 raise TypeError("String representation is not supported")

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -36,7 +36,7 @@ class TestMetaData(MetaTest):
         exp = {
             "mint": 13,
             "mfloat": -1.9,
-            "mdatetime": "2026-06-25T00:00:00",
+            "mdatetime": "2026-06-25 00:00:00",
             "mstr": "foo",
         }
 

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -29,13 +29,21 @@ class TestMetaData(MetaTest):
                 "mstr": "foo",
                 "mnone": None,  # <- should be ignored
                 "mnan": np.nan,  # <-'
+                "mdatetime": pd.to_datetime("2026-6-25"),
             }
             run.meta["mfloat"] = -1.9
 
-        assert dict(run.meta) == {"mint": 13, "mfloat": -1.9, "mstr": "foo"}
+        exp = {
+            "mint": 13,
+            "mfloat": -1.9,
+            "mdatetime": "2026-06-25T00:00:00",
+            "mstr": "foo",
+        }
+
+        assert dict(run.meta) == exp
 
         run2 = platform.runs.get("Model", "Scenario")
-        assert dict(run2.meta) == {"mint": 13, "mfloat": -1.9, "mstr": "foo"}
+        assert dict(run2.meta) == exp
 
     def test_tabulate_platform_meta_after_add(self, platform: ixmp4.Platform) -> None:
         exp = pd.DataFrame(

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -30,7 +30,7 @@ class TestMetaData(MetaTest):
                 "mstr": "foo",
                 "mnone": None,  # <- should be ignored
                 "mnan": np.nan,  # <-'
-                "mdatetime": pd.to_datetime("2026-6-25 01:00"),
+                "mdatetime": pd.to_datetime("2026-6-25 01:00"),  # type: ignore
             }
             run.meta["mfloat"] = -1.9
 
@@ -51,7 +51,7 @@ class TestMetaData(MetaTest):
         run = platform.runs.create("Model", "Scenario")
 
         class NoStringRepresentationClass:
-            def __str__(self):
+            def __str__(self) -> str:
                 raise TypeError("String representation is not supported")
 
         match = (
@@ -61,11 +61,11 @@ class TestMetaData(MetaTest):
 
         with run.transact("Add meta data"):
             with pytest.raises(InvalidRunMeta, match=match):
-                run.meta = {"mstr": "foo", "no-string": NoStringRepresentationClass()}
+                run.meta = {"mstr": "foo", "no-string": NoStringRepresentationClass()}  # type: ignore
 
         with run.transact("Add meta data"):
             with pytest.raises(InvalidRunMeta, match=match):
-                run.meta["no-string"] = NoStringRepresentationClass()
+                run.meta["no-string"] = NoStringRepresentationClass()  # type: ignore
 
     def test_tabulate_platform_meta_after_add(self, platform: ixmp4.Platform) -> None:
         exp = pd.DataFrame(

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -4,6 +4,7 @@ import pandas.testing as pdt
 import pytest
 
 import ixmp4
+from ixmp4.data.meta.exceptions import InvalidRunMeta
 from tests import backends
 from tests.custom_exception import CustomException
 
@@ -29,14 +30,14 @@ class TestMetaData(MetaTest):
                 "mstr": "foo",
                 "mnone": None,  # <- should be ignored
                 "mnan": np.nan,  # <-'
-                "mdatetime": pd.to_datetime("2026-6-25"),
+                "mdatetime": pd.to_datetime("2026-6-25 01:00"),
             }
             run.meta["mfloat"] = -1.9
 
         exp = {
             "mint": 13,
             "mfloat": -1.9,
-            "mdatetime": "2026-06-25 00:00:00",
+            "mdatetime": "2026-06-25 01:00:00",
             "mstr": "foo",
         }
 
@@ -44,6 +45,27 @@ class TestMetaData(MetaTest):
 
         run2 = platform.runs.get("Model", "Scenario")
         assert dict(run2.meta) == exp
+
+    def test_add_meta_invalid_type(
+        self, platform: ixmp4.Platform, run: ixmp4.Run
+    ) -> None:
+
+        class NoStringRepresentationClass:
+            def __str__(self):
+                raise TypeError("String representation is not supported")
+
+        match = (
+            "Failed to convert value of type 'NoStringRepresentationClass' to string: "
+            "String representation is not supported"
+        )
+
+        with run.transact("Add meta data"):
+            with pytest.raises(InvalidRunMeta, match=match):
+                run.meta = {"mstr": "foo", "no-string": NoStringRepresentationClass()}
+
+        with run.transact("Add meta data"):
+            with pytest.raises(InvalidRunMeta, match=match):
+                run.meta["no-string"] = NoStringRepresentationClass()
 
     def test_tabulate_platform_meta_after_add(self, platform: ixmp4.Platform) -> None:
         exp = pd.DataFrame(

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -46,7 +46,7 @@ class TestMetaData(MetaTest):
         run2 = platform.runs.get("Model", "Scenario")
         assert dict(run2.meta) == exp
 
-    def test_add_meta_invalid_type(
+    def _test_add_meta_invalid_type(
         self, platform: ixmp4.Platform, run: ixmp4.Run
     ) -> None:
 
@@ -72,6 +72,7 @@ class TestMetaData(MetaTest):
             [
                 ["Model", "Scenario", 1, "mfloat", -1.9],
                 ["Model", "Scenario", 1, "mint", 13],
+                ["Model", "Scenario", 1, "mdatetime", "2026-06-25 01:00:00"],
                 ["Model", "Scenario", 1, "mstr", "foo"],
             ],
             columns=["model", "scenario", "version", "key", "value"],
@@ -92,15 +93,19 @@ class TestMetaData(MetaTest):
         with run.transact("Delete meta data with `del`"):
             del run.meta["mint"]
 
-        assert dict(run.meta) == {"mstr": "foo", "mfloat": -1.9}
+        assert dict(run.meta) == {
+            "mdatetime": "2026-06-25 01:00:00",
+            "mstr": "foo",
+            "mfloat": -1.9,
+        }
 
         with run.transact("Delete meta data with `None`"):
             run.meta["mfloat"] = None
 
-        assert dict(run.meta) == {"mstr": "foo"}
+        assert dict(run.meta) == {"mdatetime": "2026-06-25 01:00:00", "mstr": "foo"}
 
         run2 = platform.runs.get("Model", "Scenario")
-        assert dict(run2.meta) == {"mstr": "foo"}
+        assert dict(run2.meta) == {"mdatetime": "2026-06-25 01:00:00", "mstr": "foo"}
 
     def test_update_meta(self, platform: ixmp4.Platform, run: ixmp4.Run) -> None:
         with run.transact("Update meta data"):


### PR DESCRIPTION
This PR fixes a database-error when trying to write a meta-indicator in a unsupported format such as datetime (currently supported int, float, str, bool).

The solution casts any non-supported type to string and saves it in this format - not reverting to the original state when reading from the database. We will treat that as a known limitation for the time being.

Tests currently fail because the RestAPI-route casts the pd.Timestamp to a string "2026-06-25T00:00" whereas the direct route casts to "2026-06-25 00:00" (whitespace instead of "T").

Closes #256 