### PR TITLE
Add simple check for meta-indicator value type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     entry: bash -c "poetry run mypy ."
     language: system
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.0
+  rev: v0.15.20
   hooks:
   - id: ruff
   - id: ruff-format

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -115,8 +115,9 @@ class RunMetaDictFacade(
             pass
 
         py_value = numpy_to_pytype(value)
+        check_meta_type(py_value)
         if py_value is not None:
-            self._service.create(self.run.id, key, check_meta_type(py_value))
+            self._service.create(self.run.id, key, py_value)
         self.df, self.data = self._get()
 
     def __delitem__(self, key: str) -> None:

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -14,6 +14,7 @@ from ixmp4.data.meta.filter import (
 )
 from ixmp4.data.meta.service import RunMetaEntryService
 
+from ..data.meta.type import check_meta_type
 from .base import BaseServiceFacade
 
 if TYPE_CHECKING:
@@ -115,7 +116,7 @@ class RunMetaDictFacade(
 
         py_value = numpy_to_pytype(value)
         if py_value is not None:
-            self._service.create(self.run.id, key, py_value)
+            self._service.create(self.run.id, key, check_meta_type(py_value))
         self.df, self.data = self._get()
 
     def __delitem__(self, key: str) -> None:
@@ -191,6 +192,8 @@ class RunMetaDescriptor(object):
         :class:`ixmp4.data.run.exceptions.RunLockRequired`
             If no run lock is held.
         """
+        check_meta_type(value.values())
+
         obj.require_lock()
         self._delete_existing(obj)
 

--- a/ixmp4/core/meta.py
+++ b/ixmp4/core/meta.py
@@ -193,14 +193,13 @@ class RunMetaDescriptor(object):
         :class:`ixmp4.data.run.exceptions.RunLockRequired`
             If no run lock is held.
         """
-        check_meta_type(value.values())
-
         obj.require_lock()
         self._delete_existing(obj)
 
         df = pd.DataFrame(
             {"key": value.keys(), "value": [numpy_to_pytype(v) for v in value.values()]}
         )
+        check_meta_type(df.value)
         df.dropna(axis=0, inplace=True)
         df["run__id"] = obj._dto.id
         obj._backend.meta.bulk_upsert(df)

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -1,5 +1,7 @@
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
+from ixmp4.data.meta.exceptions import InvalidRunMeta
+from pandas.core.dtypes.inference import is_list_like
 
 PdDtype = Literal["Int64", "str", "float64", "boolean"]
 
@@ -28,6 +30,18 @@ class Type(str, Enum):
 
     def __str__(self) -> str:
         return self.value
+
+
+def check_meta_type(value: Any) -> Any:
+    if is_list_like(value):
+        for v in value:
+            check_meta_type(v)
+
+    if type(value) not in _type_map:
+        raise InvalidRunMeta(
+            f"Invalid meta indicator '{value}', allowed types: {list(_type_map.keys())}"
+        )
+    return value
 
 
 _type_map: dict[type, Type] = {

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -36,8 +36,9 @@ def check_meta_type(value: Any) -> None:
     if is_list_like(value):
         for v in value:
             check_meta_type(v)
+        return
 
-    if type(value) not in _type_map:
+    if type(value) not in _type_map and value is not None:
         raise InvalidRunMeta(
             f"Invalid meta indicator '{value}', allowed types: {list(_type_map.keys())}"
         )

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -1,7 +1,9 @@
 from enum import Enum
 from typing import Any, Literal
-from ixmp4.data.meta.exceptions import InvalidRunMeta
+
 from pandas.core.dtypes.inference import is_list_like
+
+from ixmp4.data.meta.exceptions import InvalidRunMeta
 
 PdDtype = Literal["Int64", "str", "float64", "boolean"]
 

--- a/ixmp4/data/meta/type.py
+++ b/ixmp4/data/meta/type.py
@@ -32,7 +32,7 @@ class Type(str, Enum):
         return self.value
 
 
-def check_meta_type(value: Any) -> Any:
+def check_meta_type(value: Any) -> None:
     if is_list_like(value):
         for v in value:
             check_meta_type(v)
@@ -41,7 +41,6 @@ def check_meta_type(value: Any) -> Any:
         raise InvalidRunMeta(
             f"Invalid meta indicator '{value}', allowed types: {list(_type_map.keys())}"
         )
-    return value
 
 
 _type_map: dict[type, Type] = {

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -52,7 +52,7 @@ class TestMetaData(MetaTest):
 
         with run.transact("Add meta indicator"):
             with pytest.raises(InvalidRunMeta, match=match):
-                run.meta = {"mstr": "foo",  "mdatetime": datetime_value}
+                run.meta = {"mstr": "foo", "mdatetime": datetime_value}
 
         with run.transact("Add meta indicator"):
             with pytest.raises(InvalidRunMeta, match=match):

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -1,9 +1,12 @@
+import re
+
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
 
 import ixmp4
+from ixmp4.data.meta.exceptions import InvalidRunMeta
 from tests import backends
 from tests.custom_exception import CustomException
 
@@ -36,6 +39,24 @@ class TestMetaData(MetaTest):
 
         run2 = platform.runs.get("Model", "Scenario")
         assert dict(run2.meta) == {"mint": 13, "mfloat": -1.9, "mstr": "foo"}
+
+    def test_add_meta_invalid_type(self, platform: ixmp4.Platform) -> None:
+
+        run = platform.runs.create("Model", "Scenario")
+
+        match = re.escape(
+            "Invalid meta indicator '2026-06-25 01:00:00', allowed types: "
+            "[<class 'int'>, <class 'str'>, <class 'float'>, <class 'bool'>]"
+        )
+        datetime_value = pd.to_datetime("2026-6-25 01:00")
+
+        with run.transact("Add meta indicator"):
+            with pytest.raises(InvalidRunMeta, match=match):
+                run.meta = {"mstr": "foo",  "mdatetime": datetime_value}
+
+        with run.transact("Add meta indicator"):
+            with pytest.raises(InvalidRunMeta, match=match):
+                run.meta["mdatetime"] = datetime_value
 
     def test_tabulate_platform_meta_after_add(self, platform: ixmp4.Platform) -> None:
         exp = pd.DataFrame(

--- a/tests/core/test_meta.py
+++ b/tests/core/test_meta.py
@@ -50,13 +50,13 @@ class TestMetaData(MetaTest):
         )
         datetime_value = pd.to_datetime("2026-6-25 01:00")
 
-        with run.transact("Add meta indicator"):
-            with pytest.raises(InvalidRunMeta, match=match):
-                run.meta = {"mstr": "foo", "mdatetime": datetime_value}
+        with pytest.raises(InvalidRunMeta, match=match):
+            with run.transact("Add meta indicator"):
+                run.meta = {"mstr": "foo", "mdatetime": datetime_value}  # type: ignore
 
-        with run.transact("Add meta indicator"):
-            with pytest.raises(InvalidRunMeta, match=match):
-                run.meta["mdatetime"] = datetime_value
+        with pytest.raises(InvalidRunMeta, match=match):
+            with run.transact("Add meta indicator"):
+                run.meta["mdatetime"] = datetime_value  # type: ignore
 
     def test_tabulate_platform_meta_after_add(self, platform: ixmp4.Platform) -> None:
         exp = pd.DataFrame(


### PR DESCRIPTION
This is an alternative to #257, raising a clear error message when meta-indicator values of an unsupported type are added instead of (trying to) casting everything unexpected to string.

Closes #256 